### PR TITLE
Remove success logging

### DIFF
--- a/Snowplow/SnowplowEmitter.m
+++ b/Snowplow/SnowplowEmitter.m
@@ -128,10 +128,8 @@ static NSString *const kPayloadDataSchema    = @"iglu:com.snowplowanalytics.snow
 }
 
 - (void) flushBuffer {
-    DLog(@"Flushing buffer..");
     // Avoid calling flush to send an empty buffer
     if ([_buffer count] == 0 && [_db count] == 0) {
-        DLog(@"Database empty. Returning..");
         return;
     }
     
@@ -188,12 +186,9 @@ static NSString *const kPayloadDataSchema    = @"iglu:com.snowplowanalytics.snow
         }
         else
         {
-            DLog(@"JSON: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
-            
             [_dbQueue inDatabase:^(FMDatabase *db) {
                 NSMutableArray *removedIDs = [NSMutableArray arrayWithArray:dbIndexArray];
                 for (int i=0; i < dbIndexArray.count; i++) {
-                    DLog(@"Removing event at index: %@", dbIndexArray[i]);
                     [_db removeEventWithId:[[dbIndexArray objectAtIndex:i] longLongValue]];
                     [removedIDs addObject:dbIndexArray[i]];
                 }
@@ -226,11 +221,9 @@ static NSString *const kPayloadDataSchema    = @"iglu:com.snowplowanalytics.snow
             }
         }
         else {
-            DLog(@"JSON: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
             [_dbQueue inDatabase:^(FMDatabase *db) {
                 NSMutableArray *removedIDs = [NSMutableArray arrayWithArray:dbIndexArray];
                 for (int i=0; i < dbIndexArray.count; i++) {
-                    DLog(@"Removing event at index: %@", dbIndexArray[i]);
                     [_db removeEventWithId:[[dbIndexArray objectAtIndex:i] longLongValue]];
                     [removedIDs addObject:dbIndexArray[i]];
                 }

--- a/Snowplow/SnowplowEventStore.m
+++ b/Snowplow/SnowplowEventStore.m
@@ -52,7 +52,6 @@ static NSString * const _querySetNonPending     = @"UPDATE events SET pending=0 
     if(self){
         _db = [FMDatabase databaseWithPath:_dbPath];
         if([_db open]) {
-            DLog(@"db description: %@", [_db databasePath]);
             [self createTable];
         } else {
             DLog(@"Failed to open database. Events in memory will not persist!");
@@ -91,7 +90,6 @@ static NSString * const _querySetNonPending     = @"UPDATE events SET pending=0 
 
 - (BOOL) removeEventWithId:(long long int)id_ {
     if([_db open]) {
-        NSLog(@"Removing %lld from database now.", id_);
         return [_db executeUpdate:_queryDeleteId, [NSNumber numberWithLongLong:id_]];
     } else {
         return false;
@@ -139,11 +137,7 @@ static NSString * const _querySetNonPending     = @"UPDATE events SET pending=0 
     if([_db open]) {
         FMResultSet *s = [_db executeQuery:_querySelectId, [NSNumber numberWithLongLong:id_]];
         while ([s next]) {
-            int index = [s intForColumn:@"ID"];
             NSData * data = [s dataForColumn:@"eventData"];
-            NSDate * date = [s dateForColumn:@"dateCreated"];
-            NSString * actualData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            DLog(@"Item: %d %@ %@", index, date, actualData);
             return [NSJSONSerialization JSONObjectWithData:data options:0 error:0];
         }
     }
@@ -177,8 +171,6 @@ static NSString * const _querySetNonPending     = @"UPDATE events SET pending=0 
             long long int index = [s longLongIntForColumn:@"ID"];
             NSData * data =[s dataForColumn:@"eventData"];
             NSDate * date = [s dateForColumn:@"dateCreated"];
-            NSString * actualData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            DLog(@"Item: %lld %@ %@", index, [date description], actualData);
             NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:0];
             NSMutableDictionary * eventWithSqlMetadata = [[NSMutableDictionary alloc] init];
             [eventWithSqlMetadata setValue:dict forKey:@"eventData"];

--- a/Snowplow/SnowplowPayload.m
+++ b/Snowplow/SnowplowPayload.m
@@ -79,11 +79,9 @@
             // We want to use the iOS 7 encoder if it's 7+ so we check if it's available
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
                 encodedString = [json base64EncodedStringWithOptions:0];
-                DLog(@"Using iOS 7 encoding: %@", encodedString);
 #else
                 // Officially deprecated in iOS 7, but works in all versions including 7
                 encodedString = [json base64Encoding];
-                DLog(@"Using 3PD encoding: %@", encodedString);
 #endif
             [self addValueToPayload:encodedString forKey:typeEncoded];
         } else {


### PR DESCRIPTION
Removing logging of successful transmissions, leaving in logging of errors. If these log statements should be kept, we should put them behind some sort of config to keep them out of production logs.