### PR TITLE
Use a querystring, not an HTTP body for GET

### DIFF
--- a/Snowplow/SnowplowEmitter.m
+++ b/Snowplow/SnowplowEmitter.m
@@ -206,13 +206,10 @@ static NSString *const kPayloadDataSchema    = @"iglu:com.snowplowanalytics.snow
 }
 
 - (void) sendGetData:(NSDictionary *)getData withDbIndexArray:(NSMutableArray *)dbIndexArray {
-    NSData *requestData = [NSJSONSerialization dataWithJSONObject:getData options:0 error:nil];
-    
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[_urlEndpoint absoluteString]]];
+    NSString *url = [NSString stringWithFormat:@"%@?%@", [_urlEndpoint absoluteString], [SnowplowUtils urlEncodeDictionary:getData]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     request.HTTPMethod = @"GET";
-    [request setValue:[NSString stringWithFormat:@"%ld", (unsigned long)[requestData length]] forHTTPHeaderField:@"Content-Length"];
     [request setValue:[self acceptContentTypeHeader] forHTTPHeaderField:@"Accept"];
-    [request setHTTPBody:requestData];
     
     NSURLSessionDataTask *dataTask = [[[self class] snowplowURLSession]
                                       dataTaskWithRequest:request

--- a/Snowplow/SnowplowUtils.h
+++ b/Snowplow/SnowplowUtils.h
@@ -125,4 +125,18 @@
  */
 + (NSString *) getAppId;
 
+/**
+ *  URL encodes a string so that it is suitable to use in a query-string. A nil s returns @"".
+ *  @return The url encoded string
+ */
++ (NSString *)urlEncodeString:(NSString *)s;
+
+/**
+ *  URL encodes a dictionary as key=value pairs separated by &, so that it can be used in a query-string.
+ *  This method can encode string, numbers, and bool values, and not embedded arrays or dictionaries. It
+ *  encodes bool as 1 and 0.
+ *  @return The url encoded string of the dictionary
+ */
++ (NSString *)urlEncodeDictionary:(NSDictionary *)d;
+
 @end

--- a/Snowplow/SnowplowUtils.m
+++ b/Snowplow/SnowplowUtils.m
@@ -189,4 +189,22 @@
     return [[NSBundle mainBundle] bundleIdentifier];
 }
 
+
++ (NSString *)urlEncodeString:(NSString *)s {
+    if (!s) {
+        return @"";   
+    }
+    return (NSString *)CFBridgingRelease(
+      CFURLCreateStringByAddingPercentEscapes(NULL, (CFStringRef) s, NULL, (CFStringRef)@"!*'\"();:@&=+$,/?%#[]% ",
+      CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding)));
+}
+
++ (NSString *)urlEncodeDictionary:(NSDictionary *)d {
+    NSMutableArray *keyValuePairs = [NSMutableArray arrayWithCapacity:d.count];
+    [d enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+        [keyValuePairs addObject:[NSString stringWithFormat:@"%@=%@", [self urlEncodeString:key], [self urlEncodeString:[value description]]]];
+    }];
+    return [keyValuePairs componentsJoinedByString:@"&"];
+}
+
 @end

--- a/SnowplowTests/TestUtils.m
+++ b/SnowplowTests/TestUtils.m
@@ -177,4 +177,31 @@
     NSLog(@"appId: %@", [SnowplowUtils getAppId]);
 }
 
+- (void)testUrlEncodingString
+{
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeString:@""], @"");
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeString:nil], @"");
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeString:@"a"], @"a");
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeString:@"a b"], @"a%20b");
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeString:@"a=&"], @"a%3D%26");
+}
+
+- (void)testUrlEncodingDictionary
+{
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeDictionary:nil], @"");
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeDictionary:@{@"a": @"b"}], @"a=b");
+    
+    id twoKeys = @{@"a" : @"b", @"c" : @"d" };
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeDictionary:twoKeys], @"a=b&c=d");
+    
+    id intValues = @{@"a" : @(-5), @"c" : @(3) };
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeDictionary:intValues], @"a=-5&c=3");
+    
+    id boolValues = @{@"a" : @(NO), @"c" : @(YES) };
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeDictionary:boolValues], @"a=0&c=1");
+
+    id encodedValues = @{@"a" : @" ", @"c" : @"=" };
+    XCTAssertEqualObjects([SnowplowUtils urlEncodeDictionary:encodedValues], @"a=%20&c=%3D");
+}
+
 @end


### PR DESCRIPTION
This PR fixes GET so that it uses the query-string to pass parameters, not the HTTP body, which iOS ignores for GET.

* There is a simple URLEncoding for dictionary which works for string, number, and bool values.
* I included unit tests so you can see what is supported.

I tested this in Trello and it works great.