### PR TITLE
Unset payload key when value is nil

### DIFF
--- a/Snowplow/SnowplowPayload.m
+++ b/Snowplow/SnowplowPayload.m
@@ -48,6 +48,9 @@
 
 - (void) addValueToPayload:(NSString *)value forKey:(NSString *)key {
     if (value == nil) {
+        if ([_payload valueForKey:key] != nil) {
+            [_payload removeObjectForKey:key];
+        }
         return;
     }
     [_payload setObject:value forKey:key];

--- a/SnowplowTests/TestPayload.m
+++ b/SnowplowTests/TestPayload.m
@@ -128,6 +128,20 @@
                           @"Payload should have the same data as sample_dict_final");
 }
 
+- (void)testAddNilValueToPayload
+{
+    SnowplowPayload *payload = [[SnowplowPayload alloc] init];
+    [payload addValueToPayload:nil forKey:@"foo"];
+    XCTAssertEqualObjects(payload.getPayloadAsDictionary, [[NSDictionary alloc] init]);
+}
+
+- (void)testAddNilValueToPayloadUnsetsKey
+{
+    SnowplowPayload *payload = [[SnowplowPayload alloc] initWithNSDictionary:@{@"foo":@"bar"}];
+    [payload addValueToPayload:nil forKey:@"foo"];
+    XCTAssertEqualObjects(payload.getPayloadAsDictionary, [[NSDictionary alloc] init]);
+}
+
 - (void)testAddDictToPayload
 {
     NSDictionary *sample_dic = [[NSDictionary alloc] initWithObjectsAndKeys:


### PR DESCRIPTION
While checking what setting nil values for payload keys would do, I found a case where if you set a key on a payload and then set it again with nil, the original value would be retained. This is probably unlikely in use, but not totally out of the question. Here's a quick fix.