### PR TITLE
Use URL-safe Base64 without padding

### DIFF
--- a/Snowplow/SnowplowPayload.m
+++ b/Snowplow/SnowplowPayload.m
@@ -85,6 +85,16 @@
                 encodedString = [json base64Encoding];
                 DLog(@"Using 3PD encoding: %@", encodedString);
 #endif
+            // We need URL safe with no padding. Since there is no built-in way to do this, we transform
+            // the encoded payload to make it URL safe by replacing chars that are different in the URL-safe
+            // alphabet. Namely, 62 is - instead of +, and 63 _ instead of /.
+            // See: https://tools.ietf.org/html/rfc4648#section-5
+            encodedString = [[encodedString stringByReplacingOccurrencesOfString:@"/" withString:@"_"]
+                             stringByReplacingOccurrencesOfString:@"+" withString:@"-"];
+
+            // There is also no padding since the length is implicitly known.
+            encodedString = [encodedString stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
+            
             [self addValueToPayload:encodedString forKey:typeEncoded];
         } else {
             [self addValueToPayload:[[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding] forKey:typeNotEncoded];

--- a/SnowplowTests/TestPayload.m
+++ b/SnowplowTests/TestPayload.m
@@ -164,7 +164,7 @@
     NSDictionary *sample_dic = [[NSDictionary alloc] initWithObjectsAndKeys:
                                 @"Value1", @"Key1", nil];
     NSDictionary *sample_enc = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                @"eyJLZXkxIjoiVmFsdWUxIn0=", @"type_enc", nil];
+                                @"eyJLZXkxIjoiVmFsdWUxIn0", @"type_enc", nil];
     // NSDictionary conversion to JSON string
     NSData *somedata = [NSJSONSerialization dataWithJSONObject:sample_dic options:0 error:0];
     
@@ -220,7 +220,7 @@
     // {"Key1":"Value1"} -> eyJLZXkxIjoiVmFsdWUxIn0=
 
     NSDictionary *sample_enc = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                @"eyJLZXkxIjoiVmFsdWUxIn0=", @"type_enc", nil];
+                                @"eyJLZXkxIjoiVmFsdWUxIn0", @"type_enc", nil];
     NSString *json_str = @"{\"Key1\":\"Value1\"}";
     
     SnowplowPayload *sample_payload = [[SnowplowPayload alloc] init];


### PR DESCRIPTION
There's no support for URL Safe or non-padding Base64 in the iOS SDK, so post-process the result to fix it. Closes #149 