### PR TITLE
sets _standardData as a pubic property to be able to set custom values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ xcuserdata
 DerivedData
 *.xcuserstate
 
+.DS_Store

--- a/Snowplow/SnowplowTracker.h
+++ b/Snowplow/SnowplowTracker.h
@@ -26,10 +26,11 @@
 
 @interface SnowplowTracker : NSObject
 
-@property (retain)              SnowplowEmitter *   collector;
-@property (retain)              NSString *          appId;
-@property (retain)              NSString *          trackerNamespace;
-@property (nonatomic, retain)   NSString *          userId;
+@property (retain)                  SnowplowEmitter *       collector;
+@property (retain)                  NSString *              appId;
+@property (retain)                  NSString *              trackerNamespace;
+    @property (nonatomic, retain)   NSString *              userId;
+@property (nonatomic, retain)       NSMutableDictionary *   standardData;
 
 extern NSString * const kSnowplowVendor;
 extern NSString * const kIglu;

--- a/Snowplow/SnowplowTracker.m
+++ b/Snowplow/SnowplowTracker.m
@@ -26,7 +26,6 @@
 
 @implementation SnowplowTracker {
     Boolean                 _base64Encoded;
-    NSMutableDictionary *   _standardData;
     NSString *              _schemaTag;
     NSString *              _contextSchema;
     NSString *              _unstructedEventSchema;


### PR DESCRIPTION
Here in ChefsFeed we need to track other values that those set automatically by the tracker like domain_userid or domain_sessionidx.

After reading the code and to understand it, I'd suggest to expose _standardData as a property, that will open the possibility to add necessary values to the request sent to snowplow server.

Thoughts?