### PR TITLE
Use buffer size to limit number of events per POST

### DIFF
--- a/Snowplow.xcodeproj/project.xcworkspace/xcshareddata/Snowplow.xccheckout
+++ b/Snowplow.xcodeproj/project.xcworkspace/xcshareddata/Snowplow.xccheckout
@@ -10,31 +10,31 @@
 	<string>Snowplow</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>6E34EC2B-E58D-4D8A-A9E4-FBC55BCAF1ED</key>
-		<string>ssh://github.com/snowplow/snowplow-ios-tracker.git</string>
+		<key>60622D2027FDE57C4CF364BB08B662BD8E0B9774</key>
+		<string>github.com:leonardors/snowplow-objc-tracker.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>Snowplow.xcodeproj/project.xcworkspace</string>
+	<string>Snowplow.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>6E34EC2B-E58D-4D8A-A9E4-FBC55BCAF1ED</key>
+		<key>60622D2027FDE57C4CF364BB08B662BD8E0B9774</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/snowplow/snowplow-ios-tracker.git</string>
+	<string>github.com:leonardors/snowplow-objc-tracker.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>6E34EC2B-E58D-4D8A-A9E4-FBC55BCAF1ED</string>
+	<string>60622D2027FDE57C4CF364BB08B662BD8E0B9774</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>6E34EC2B-E58D-4D8A-A9E4-FBC55BCAF1ED</string>
+			<string>60622D2027FDE57C4CF364BB08B662BD8E0B9774</string>
 			<key>IDESourceControlWCCName</key>
-			<string>Snowplow</string>
+			<string>snowplow-objc-tracker</string>
 		</dict>
 	</array>
 </dict>

--- a/Snowplow/SnowplowEventStore.h
+++ b/Snowplow/SnowplowEventStore.h
@@ -103,6 +103,12 @@
 - (NSArray *) getAllNonPendingEvents;
 
 /**
+ *  Returns limited number the events that are NOT pending in an array of dictionaries.
+ *  @return An array with each dictionary element containing key-value pairs of 'date', 'data', 'ID'.
+ */
+- (NSArray *) getAllNonPendingEventsLimited:(NSUInteger)limit;
+
+/**
  *  Returns all event data of pending data.
  *  @return An array of event data with pending set as 1.
  */

--- a/Snowplow/SnowplowEventStore.m
+++ b/Snowplow/SnowplowEventStore.m
@@ -31,7 +31,6 @@
     FMDatabase *    _db;
 }
 
-static NSString * const _queryDeleteId          = @"DELETE FROM 'events' WHERE id=?";
 static NSString * const _queryCreateTable               = @"CREATE TABLE IF NOT EXISTS 'events' (id INTEGER PRIMARY KEY, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP)";
 static NSString * const _querySelectAll                 = @"SELECT * FROM 'events'";
 static NSString * const _querySelectCount               = @"SELECT Count(*) FROM 'events'";
@@ -160,7 +159,7 @@ static NSString * const _querySetNonPending             = @"UPDATE events SET pe
 }
 
 - (NSArray *) getAllNonPendingEventsLimited:(NSUInteger)limit {
-    NSString *query = [NSString stringWithFormat:@"%@ LIMIT %i", _querySelectNonPending, limit];
+    NSString *query = [NSString stringWithFormat:@"%@ LIMIT %lu", _querySelectNonPending, (unsigned long)limit];
     return [self getAllEventsWithQuery:query];
 }
 

--- a/Snowplow/SnowplowEventStore.m
+++ b/Snowplow/SnowplowEventStore.m
@@ -31,16 +31,17 @@
     FMDatabase *    _db;
 }
 
-static NSString * const _queryCreateTable       = @"CREATE TABLE IF NOT EXISTS 'events' (id INTEGER PRIMARY KEY, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP)";
-static NSString * const _querySelectAll         = @"SELECT * FROM 'events'";
-static NSString * const _querySelectCount       = @"SELECT Count(*) FROM 'events'";
-static NSString * const _queryInsertEvent       = @"INSERT INTO 'events' (eventData, pending) VALUES (?, 0)";
-static NSString * const _querySelectId          = @"SELECT * FROM 'events' WHERE id=?";
 static NSString * const _queryDeleteId          = @"DELETE FROM 'events' WHERE id=?";
-static NSString * const _querySelectPending     = @"SELECT * FROM 'events' WHERE pending=1";
-static NSString * const _querySelectNonPending  = @"SELECT * FROM 'events' WHERE pending=0";
-static NSString * const _querySetPending        = @"UPDATE events SET pending=1 WHERE id=?";
-static NSString * const _querySetNonPending     = @"UPDATE events SET pending=0 WHERE id=?";
+static NSString * const _queryCreateTable               = @"CREATE TABLE IF NOT EXISTS 'events' (id INTEGER PRIMARY KEY, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP)";
+static NSString * const _querySelectAll                 = @"SELECT * FROM 'events'";
+static NSString * const _querySelectCount               = @"SELECT Count(*) FROM 'events'";
+static NSString * const _queryInsertEvent               = @"INSERT INTO 'events' (eventData, pending) VALUES (?, 0)";
+static NSString * const _querySelectId                  = @"SELECT * FROM 'events' WHERE id=?";
+static NSString * const _queryDeleteId                  = @"DELETE FROM 'events' WHERE id=?";
+static NSString * const _querySelectPending             = @"SELECT * FROM 'events' WHERE pending=1";
+static NSString * const _querySelectNonPending          = @"SELECT * FROM 'events' WHERE pending=0";
+static NSString * const _querySetPending                = @"UPDATE events SET pending=1 WHERE id=?";
+static NSString * const _querySetNonPending             = @"UPDATE events SET pending=0 WHERE id=?";
 
 
 @synthesize appId;
@@ -118,7 +119,7 @@ static NSString * const _querySetNonPending     = @"UPDATE events SET pending=0 
 
 - (BOOL) removePendingWithId:(long long int)id_ {
     if ([_db open]) {
-        return [_db executeUpdate:_querySetPending, id_];
+        return [_db executeUpdate:_querySetNonPending, id_];
     } else {
         return false;
     }
@@ -156,6 +157,11 @@ static NSString * const _querySetNonPending     = @"UPDATE events SET pending=0 
 
 - (NSArray *) getAllNonPendingEvents {
     return [self getAllEventsWithQuery:_querySelectNonPending];
+}
+
+- (NSArray *) getAllNonPendingEventsLimited:(NSUInteger)limit {
+    NSString *query = [NSString stringWithFormat:@"%@ LIMIT %i", _querySelectNonPending, limit];
+    return [self getAllEventsWithQuery:query];
 }
 
 - (NSArray *) getAllPendingEvents {


### PR DESCRIPTION
I have attempted to distill this PR into a single tag line:

> Use buffer size to limit number of events per POST

Please comment @leonardors / @jbeemster if you think I am misinterpreting this PR!

In summary:

* Currently the buffer size is used only as a "trigger" to determine when to attempt to POST a batch of records
* This ignores the situation where e.g. the phone is out of network coverage, and so count(events) in queue > buffer size
* In this scenario, when it does become possible to send events again, we should split the events into multiple batches, as determined by the buffer size
* This PR does exactly this using a LIMIT X on the queue query, and a recursive pattern to ensure all events in the queue are sent
* This PR also fixes a distinct bug, #176, which I have extracted into its own ticket so we can consider separately