### PR TITLE
ensure that sendEvents will run in background only

### DIFF
--- a/Snowplow/SnowplowEmitter.m
+++ b/Snowplow/SnowplowEmitter.m
@@ -124,7 +124,9 @@ static NSString *const kPayloadDataSchema    = @"iglu:com.snowplowanalytics.snow
 - (void) flushBuffer {
     if (_isSending == false) {
         _isSending = true;
-        [self sendEvents];
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [self sendEvents];
+        });
     }
 }
 


### PR DESCRIPTION
Hi,

My app sometimes freeze after I added Snowplow. 

![screen shot 2015-08-21 at 6 13 17 pm](https://cloud.githubusercontent.com/assets/1230665/9407270/d5e585d6-4831-11e5-9031-eae3fe269a9c.png)

It turns out that `sendEvents` is called in main thread from NSTimer which should not be.

I am not sure this is the best solution.