### PR TITLE
Update third-party headers to be compatible with Xcode Header Search Path

### DIFF
--- a/Snowplow/SPEmitter.m
+++ b/Snowplow/SPEmitter.m
@@ -27,7 +27,7 @@
 #import "SPPayload.h"
 #import "SPRequestResponse.h"
 #import "SPWeakTimerTarget.h"
-#import <FMDB.h>
+#import <FMDB/FMDB.h>
 
 @interface SPEmitter ()
 

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,7 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtils.h"
-#import <FMDB.h>
+#import <FMDB/FMDB.h>
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/SPUtils.m
+++ b/Snowplow/SPUtils.m
@@ -29,7 +29,7 @@
 #import <UIKit/UIDevice.h>
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
-#import "Reachability.h"
+#import <Reachability/Reachability.h>
 
 #else
 


### PR DESCRIPTION
While linking snowplow-tracker with our project via Cocoapods we get the following error:
```
error: 'FMDB.h' file not found with <angled> include; use "quotes" instead
```
This is what I assume is wrong. Cocoapods adds the third party header files to the `Pods/Headers/Private` directory and set the Xcode config to look for the Headers there.
If we add import statements like `#import <FMDB.h>` the Xcode is unable to find them, as this statement resolves to path `Pods/Headers/Private/FMDB.h` while the path Xcode actually wants is `Pods/Headers/Private/FMDB/FMDB.h`