### PR TITLE
Only start a single timer, be sure to stop previous checker

### DIFF
--- a/Snowplow/SPSession.m
+++ b/Snowplow/SPSession.m
@@ -95,6 +95,7 @@ NSString * const kSessionSavePath = @"session.dict";
 
 - (void) startChecker {
     dispatch_async(dispatch_get_main_queue(), ^{
+        [self stopChecker];
         _sessionTimer = [NSTimer scheduledTimerWithTimeInterval:_checkInterval
                                                          target:[[SPWeakTimerTarget alloc] initWithTarget:self andSelector:@selector(checkSession:)]
                                                        selector:@selector(timerFired:)


### PR DESCRIPTION
If you end up calling either SPTracker `resumeEventTracking()` or SPSession `startChecker()` without stopping the previous one you can get two threads running at once. This can cause an issue if they both check roughly at the same time causes the dictionary to be deallocated at the same from two threads curing `SPSession updateSessionDict` The crashes we were getting were:

    [CFString release]: message sent to deallocated instance 0x7fcf8e290f30

and `EXC_BAD_ACCESS` during

    #0	0x0000000111676e1f in ___forwarding___ ()
    #1	0x0000000111676a98 in __forwarding_prep_0___ ()
    #2	0x0000000111620dad in -[__NSDictionaryM dealloc] ()
    #3	0x00000001111abafe in objc_object::sidetable_release(bool) ()
    #4	0x000000010d1b975b in -[SPSession updateSessionDict] at /github/PrayerCenter/Pods/SnowplowTracker/Snowplow/SPSession.m:235
    #5	0x000000010d1b9433 in __26-[SPSession checkSession:]_block_invoke at /github/PrayerCenter/Pods/SnowplowTracker/Snowplow/SPSession.m:212
    #6	0x000000011252be5d in _dispatch_call_block_and_release ()
    #7	0x000000011254c49b in _dispatch_client_callout ()
    #8	0x0000000112534bef in _dispatch_root_queue_drain ()
    #9	0x00000001125344c5 in _dispatch_worker_thread3 ()
    #10	0x000000011287d4f2 in _pthread_wqthread ()
    #11	0x000000011287b375 in start_wqthread ()
    Enqueued from com.apple.main-thread (Thread 1)Queue : com.apple.main-thread (serial)
    #0	0x000000011253535f in _dispatch_async_f_slow ()
    #1	0x000000010d1b9320 in -[SPSession checkSession:] at /github/PrayerCenter/Pods/SnowplowTracker/Snowplow/SPSession.m:198
    #2	0x000000010d1c00e5 in -[SPWeakTimerTarget timerFired:] at /github/PrayerCenter/Pods/SnowplowTracker/Snowplow/SPWeakTimerTarget.m:44
    #3	0x000000010e95a181 in __NSFireTimer ()


The fix is just to stop the checker anytime the checker is started.