### PR TITLE
Make initializers unavailable in SPEmitter and SPTracker

### DIFF
--- a/Snowplow/SPEmitter.h
+++ b/Snowplow/SPEmitter.h
@@ -61,11 +61,8 @@ enum SPRequestOptions {
  */
 + (instancetype) build:(void(^)(id<SPEmitterBuilder>builder))buildBlock;
 
-/**
- * Initializes a newly allocated SnowplowEmitter
- * @return A SnowplowEmitter.
- */
-- (id) init;
++ (instancetype) new NS_UNAVAILABLE;
+- (instancetype) init NS_UNAVAILABLE;
 
 /**
  * Inserts a SnowplowPayload object into the buffer to be sent in the next POST requests. Use this in favour over addToBuffer:

--- a/Snowplow/SPEmitter.m
+++ b/Snowplow/SPEmitter.m
@@ -52,7 +52,7 @@
 // SnowplowEmitter Builder
 
 + (instancetype) build:(void(^)(id<SPEmitterBuilder>builder))buildBlock {
-    SPEmitter* emitter = [SPEmitter new];
+    SPEmitter* emitter = [[SPEmitter alloc] initWithDefaultValues];
     if (buildBlock) {
         buildBlock(emitter);
     }
@@ -60,7 +60,7 @@
     return emitter;
 }
 
-- (id) init {
+- (instancetype) initWithDefaultValues {
     self = [super init];
     if (self) {
         _httpMethod = SPRequestPost;

--- a/Snowplow/SPTracker.h
+++ b/Snowplow/SPTracker.h
@@ -54,11 +54,8 @@
  */
 + (instancetype) build:(void(^)(id<SPTrackerBuilder>builder))buildBlock;
 
-/**
- *  Initializes a newly allocated SnowplowTracker.
- *  @return A SnowplowTracker instance.
- */
-- (id) init;
++ (instancetype) new NS_UNAVAILABLE;
+- (instancetype) init NS_UNAVAILABLE;
 
 /**
  * Pauses all event tracking, storage and session checking.

--- a/Snowplow/SPTracker.m
+++ b/Snowplow/SPTracker.m
@@ -53,7 +53,7 @@
 // SnowplowTracker Builder
 
 + (instancetype) build:(void(^)(id<SPTrackerBuilder>builder))buildBlock {
-    SPTracker* tracker = [SPTracker new];
+    SPTracker* tracker = [[SPTracker alloc] initWithDefaultValues];
     if (buildBlock) {
         buildBlock(tracker);
     }
@@ -61,7 +61,7 @@
     return tracker;
 }
 
-- (id) init {
+- (instancetype) initWithDefaultValues {
     self = [super init];
     if (self) {
         _trackerNamespace = nil;


### PR DESCRIPTION
This fixes #254 by marking `- init` and `+ new` as unavailable.