### PR TITLE
Expose session property in SPTracker

### DIFF
--- a/Snowplow/SPTracker.h
+++ b/Snowplow/SPTracker.h
@@ -45,6 +45,7 @@
 
 @property (readonly, nonatomic, retain) SPEmitter * emitter;
 @property (readonly, nonatomic, retain) SPSubject * subject;
+@property (nonatomic, retain) SPSession * session;
 @property (readonly, nonatomic, retain) NSString *  appId;
 @property (readonly, nonatomic, retain) NSString *  trackerNamespace;
 @property (readonly, nonatomic)         BOOL        base64Encoded;


### PR DESCRIPTION
We pass the session id as a header value in a service call to our api. In turn, our service makes the call to snowplow with the appropriate data.

We do this because the amount of data our marketing team wants is too great to be returned to the client and we feel its a better solution to have the platform do it instead. It maintains all the state needed for the snowplow call.

Without this property exposed we can't implement this solution and we have to resort to modifying your library ourselves.. which we don't want to do!
