### PR TITLE
Fix crash when logging emitter attempts

### DIFF
--- a/Snowplow/SPEmitter.m
+++ b/Snowplow/SPEmitter.m
@@ -290,8 +290,8 @@ const NSInteger POST_STM_BYTES = 22;
     
     [_dataOperationQueue waitUntilAllOperationsAreFinished];
     
-    SnowplowDLog(@"Success Count: %@", success);
-    SnowplowDLog(@"Failure Count: %@", failure);
+    SnowplowDLog(@"Success Count: %@", @(success).stringValue);
+    SnowplowDLog(@"Failure Count: %@", @(failure).stringValue);
     
     if (_callback != nil) {
         if (failure == 0) {


### PR DESCRIPTION
This fixes a crash I encountered when enabling debug logging by doing 
`#define SNOWPLOW_DEBUG 1`

doing an explicit cast to long int is probably more performant, but this code probably isn't running in release mode anyway.

![screen shot 2016-02-03 at 11 23 04 am](https://cloud.githubusercontent.com/assets/3002955/12788685/8e32421a-ca68-11e5-9c51-3355d7eb9a27.png)