### PR TITLE
Don't log entire connection error

### DIFF
--- a/Snowplow/SPEmitter.m
+++ b/Snowplow/SPEmitter.m
@@ -325,7 +325,7 @@ const NSInteger POST_STM_BYTES = 22;
             } else if ([response statusCode] >= 200 && [response statusCode] < 300) {
                 [results addObject:[[SPRequestResponse alloc] initWithBool:true withIndex:indexArray]];
             } else {
-                NSLog(@"Error: %@", connectionError);
+                NSLog(@"Snowplow connection error %@ %@ %@", connectionError.domain, @(connectionError.code), connectionError.localizedDescription);
                 [results addObject:[[SPRequestResponse alloc] initWithBool:false withIndex:indexArray]];
             }
         }


### PR DESCRIPTION
Logging `connectionError` directly logs the NSErrorFailingURLStringKey which is a ton of output!

Also, add a prefix so that these logs are easy to distinguish from app logs.
