### PR TITLE
Don't attempt to serialize nil object in event store

### DIFF
--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -76,6 +76,9 @@ static NSString * const _queryDeleteId    = @"DELETE FROM 'events' WHERE id=?";
 
 - (long long int) insertDictionaryData:(NSDictionary *)dict {
     __block long long int res = -1;
+    if (!dict) {
+      return res;
+    }
     [_queue inDatabase:^(FMDatabase *db) {
         if ([db open]) {
             NSData *data = [NSJSONSerialization dataWithJSONObject:dict options:0 error:nil];


### PR DESCRIPTION
Fixes a crash being reported by Crashlytics on our app. The impact is low, only 0.1% of our users are facing it. Happens when you try to get NSData from a nil object. I'm unable to replicate the crash. 
