### PR TITLE
Fix truncation of structured event value to 6 digits

### DIFF
--- a/Snowplow/SPEvent.m
+++ b/Snowplow/SPEvent.m
@@ -196,7 +196,7 @@
     [pb addValueToPayload:_action forKey:kSPStuctAction];
     [pb addValueToPayload:_label forKey:kSPStuctLabel];
     [pb addValueToPayload:_property forKey:kSPStuctProperty];
-    [pb addValueToPayload:[NSString stringWithFormat:@"%g", [_value doubleValue]] forKey:kSPStuctValue];
+    [pb addValueToPayload:[NSString stringWithFormat:@"%.17g", [_value doubleValue]] forKey:kSPStuctValue];
     return [self addDefaultParamsToPayload:pb];
 }
 


### PR DESCRIPTION
[getPayload](https://github.com/snowplow/snowplow-objc-tracker/blob/master/Snowplow/SPEvent.m#L199) uses %g to format a double as a string, but %g defaults to 6 digits of precision:

> The double argument is converted in style f or e (or F or E for G conversions).  The precision specifies the number of significant digits.  If the precision is missing, 6 digits are given; if the precision is zero, it is treated as 1.  Style e is used if the exponent from its conversion is less than -4 or greater than or equal to the precision.  Trailing zeros are removed from the fractional part of the result; a decimal point appears only if it is followed by at least one digit.

so we're losing 4 digits of precision in our millisecond timestamps, which is rounding them down to 10s.

This PR increases the precision width to 17 digits, which is hopefully enough.