### PR TITLE
Updated FMDB dependency in the podspecs

### DIFF
--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -35,6 +35,6 @@ Pod::Spec.new do |s|
   s.ios.frameworks = 'CoreTelephony', 'UIKit', 'Foundation'
   s.osx.frameworks = 'AppKit', 'Foundation'
   s.tvos.frameworks = 'UIKit', 'Foundation'
-  s.dependency 'FMDB', '2.5'
+  s.dependency 'FMDB', '2.6.2'
   s.ios.dependency 'Reachability', '3.2'
 end


### PR DESCRIPTION
Currently when I try to use the Snowplow tracker in my (swift) project, it will fail to build.

The error message is related to FMDB and importing #import <sqlite3.h>. The details of this problem can be found here: https://github.com/ccgus/fmdb/issues/309
![screen shot 2017-02-03 at 5 14 39 pm](https://cloud.githubusercontent.com/assets/480019/22610863/92669244-ea35-11e6-8e85-6230d025a80a.png)

In order to make Snowplow work for my own project, I adjusted the FMDB dependency to use 2.6.2 (latest) instead of 2.5.
