### PR TITLE
Add method to SPTracker to get session's userId

### DIFF
--- a/Snowplow/SPSession.h
+++ b/Snowplow/SPSession.h
@@ -98,4 +98,10 @@
  */
 - (BOOL) getInBackground;
 
+/**
+ * Returns the session's userId
+ * @return the session's userId
+ */
+- (NSString*) getUserId;
+
 @end

--- a/Snowplow/SPSession.m
+++ b/Snowplow/SPSession.m
@@ -157,6 +157,10 @@ NSString * const kSessionSavePath = @"session.dict";
     return _inBackground;
 }
 
+- (NSString *)getUserId {
+    return _userId;
+}
+
 // --- Private
 
 - (BOOL) writeSessionToFile {

--- a/Snowplow/SPTracker.h
+++ b/Snowplow/SPTracker.h
@@ -95,6 +95,12 @@
 - (BOOL) getIsTracking;
 
 /**
+ * Returns the session's userId.
+ * @return the session's userId.
+ */
+- (NSString*) getSessionUserId;
+
+/**
  * Constructs the final event payload that is sent to the emitter.
  * NOTE: This function is only used for testing purposes; should never be called in production.
  *

--- a/Snowplow/SPTracker.m
+++ b/Snowplow/SPTracker.m
@@ -191,6 +191,10 @@
     return _dataCollection;
 }
 
+- (NSString*) getSessionUserId {
+    return [_session getUserId];
+}
+
 // Event Tracking Functions
 
 - (void) trackPageViewEvent:(SPPageView *)event {


### PR DESCRIPTION
This pull request adds a getter to `SPTracker` to access the `[SPSession _userId]` field. The [Snowplow Android](https://github.com/snowplow/snowplow-android-tracker) library already has [this functionality](https://github.com/snowplow/snowplow-android-tracker/blob/master/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Session.java#L248), thus this brings the iOS library more in sync with Android.