### PR TITLE
Resolve potential memory leaks from implicit retain of self

### DIFF
--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -922,6 +922,7 @@
 			baseConfigurationReference = 12A60D7497F52746347837AE /* Pods-Snowplow.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				DSTROOT = /tmp/Snowplow.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Snowplow/Snowplow-Prefix.pch";
@@ -952,6 +953,7 @@
 			baseConfigurationReference = 37A423DE6135420B7C94F1C5 /* Pods-Snowplow.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				DSTROOT = /tmp/Snowplow.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Snowplow/Snowplow-Prefix.pch";

--- a/Snowplow/SPEmitter.m
+++ b/Snowplow/SPEmitter.m
@@ -152,9 +152,14 @@ const NSInteger POST_STM_BYTES = 22;
 // Builder Finished
 
 - (void) addPayloadToBuffer:(SPPayload *)spPayload {
+    __weak __typeof__(self) weakSelf = self;
+    
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [_db insertEvent:spPayload];
-        [self flushBuffer];
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) return;
+        
+        [strongSelf->_db insertEvent:spPayload];
+        [strongSelf flushBuffer];
     });
 }
 
@@ -333,10 +338,15 @@ const NSInteger POST_STM_BYTES = 22;
 }
 
 - (void) processSuccessesWithResults:(NSArray *)indexArray {
+    __weak __typeof__(self) weakSelf = self;
+    
     [_dataOperationQueue addOperationWithBlock:^{
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) return;
+        
         for (int i = 0; i < indexArray.count;  i++) {
             SnowplowDLog(@"SPLog: Removing event at index: %@", [@(i) stringValue]);
-            [_db removeEventWithId:[[indexArray objectAtIndex:i] longLongValue]];
+            [strongSelf->_db removeEventWithId:[[indexArray objectAtIndex:i] longLongValue]];
         }
     }];
 }
@@ -369,13 +379,18 @@ const NSInteger POST_STM_BYTES = 22;
 // Extra functions
 
 - (void) startTimerFlush {
+    __weak __typeof__(self) weakSelf = self;
+    
     if (_timer != nil) {
         [self stopTimerFlush];
     }
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        _timer = [NSTimer scheduledTimerWithTimeInterval:kSPDefaultBufferTimeout
-                                                  target:[[SPWeakTimerTarget alloc] initWithTarget:self andSelector:@selector(flushBuffer)]
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) return;
+        
+        strongSelf->_timer = [NSTimer scheduledTimerWithTimeInterval:kSPDefaultBufferTimeout
+                                                  target:[[SPWeakTimerTarget alloc] initWithTarget:strongSelf andSelector:@selector(flushBuffer)]
                                                 selector:@selector(timerFired:)
                                                 userInfo:nil
                                                  repeats:YES];

--- a/Snowplow/SPEvent.m
+++ b/Snowplow/SPEvent.m
@@ -370,20 +370,25 @@
 }
 
 - (NSArray *) getDocuments {
+    __weak __typeof__(self) weakSelf = self;
+    
     // returns the result of appending document passed through {docId, version, name, description} builder arguments to _documents
     NSMutableArray * documents = [[NSMutableArray alloc] init];
     SPConsentDocument * document = [SPConsentDocument build:^(id<SPConsentDocumentBuilder> builder) {
-        if (_documentId != nil) {
-            [builder setDocumentId:_documentId];
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) return;
+        
+        if (strongSelf->_documentId != nil) {
+            [builder setDocumentId:strongSelf->_documentId];
         }
-        if (_version != nil) {
-            [builder setVersion:_version];
+        if (strongSelf->_version != nil) {
+            [builder setVersion:strongSelf->_version];
         }
-        if ([_name length] != 0) {
-            [builder setName:_name];
+        if ([strongSelf->_name length] != 0) {
+            [builder setName:strongSelf->_name];
         }
-        if ([_description length] != 0) {
-            [builder setDescription:_description];
+        if ([strongSelf->_description length] != 0) {
+            [builder setDescription:strongSelf->_description];
         }
     }];
     [documents addObject:[document getPayload]];
@@ -528,16 +533,21 @@
 }
 
 - (NSArray *) getDocuments {
+    __weak __typeof__(self) weakSelf = self;
+    
     // returns the result of appending document passed through {docId, version, name, description} to the documents data member
     NSMutableArray * documents = [[NSMutableArray alloc] init];
     SPConsentDocument * document = [SPConsentDocument build:^(id<SPConsentDocumentBuilder> builder) {
-        [builder setDocumentId:_documentId];
-        [builder setVersion:_version];
-        if ([_name length] != 0) {
-            [builder setName:_name];
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) return;
+        
+        [builder setDocumentId:strongSelf->_documentId];
+        [builder setVersion:strongSelf->_version];
+        if ([strongSelf->_name length] != 0) {
+            [builder setName:strongSelf->_name];
         }
-        if ([_description length] != 0) {
-            [builder setDescription:_description];
+        if ([strongSelf->_description length] != 0) {
+            [builder setDescription:strongSelf->_description];
         }
     }];
     [documents addObject:[document getPayload]];

--- a/Snowplow/SPSession.m
+++ b/Snowplow/SPSession.m
@@ -96,13 +96,18 @@ NSString * const kSessionSavePath = @"session.dict";
 // --- Public
 
 - (void) startChecker {
+    __weak __typeof__(self) weakSelf = self;
+    
     if (_sessionTimer != nil) {
         [self stopChecker];
     }
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        _sessionTimer = [NSTimer scheduledTimerWithTimeInterval:_checkInterval
-                                                         target:[[SPWeakTimerTarget alloc] initWithTarget:self andSelector:@selector(checkSession:)]
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) return;
+        
+        strongSelf->_sessionTimer = [NSTimer scheduledTimerWithTimeInterval:strongSelf->_checkInterval
+                                                         target:[[SPWeakTimerTarget alloc] initWithTarget:strongSelf andSelector:@selector(checkSession:)]
                                                        selector:@selector(timerFired:)
                                                        userInfo:nil
                                                         repeats:YES];
@@ -187,21 +192,26 @@ NSString * const kSessionSavePath = @"session.dict";
 }
 
 - (void) checkSession:(NSTimer *)timer {
+    __weak __typeof__(self) weakSelf = self;
+    
     dispatch_async(_sessionQueue, ^{
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf == nil) return;
+        
         NSNumber *checkTime = [SPUtilities getTimestamp];
         NSInteger range = 0;
         
-        if (_inBackground) {
-            range = _backgroundTimeout;
+        if (strongSelf->_inBackground) {
+            range = strongSelf->_backgroundTimeout;
         } else {
-            range = _foregroundTimeout;
+            range = strongSelf->_foregroundTimeout;
         }
         
-        if (![self isTimeInRangeWithStartTime:_accessedLast.longLongValue andCheckTime:checkTime.longLongValue andRange:range]) {
-            [self updateSession];
-            [self updateAccessedLast];
-            [self updateSessionDict];
-            [self writeSessionToFile];
+        if (![strongSelf isTimeInRangeWithStartTime:strongSelf->_accessedLast.longLongValue andCheckTime:checkTime.longLongValue andRange:range]) {
+            [strongSelf updateSession];
+            [strongSelf updateAccessedLast];
+            [strongSelf updateSessionDict];
+            [strongSelf writeSessionToFile];
         }
     });
 }


### PR DESCRIPTION
I noticed issue #348 noted potential memory leaks from implicit retain of self, mostly in GCD blocks. I turned on the warning in the Xcode build settings to highlight the problem:

```
CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
```

I tried to resolve this with minimal code change, which involved introducing `weakSelf` and `strongSelf` references similar to the approach outlined in this post: https://dhoerl.wordpress.com/2013/04/23/i-finally-figured-out-weakself-and-strongself/ which looks something like:

```
// capture a weak reference to self
__weak __typeof__(self) weakSelf = self;

somethingTakingABlock(^{
    // capture a strong reference to whatever we have in weak self
    __typeof__(self) strongSelf = weakSelf;

    // if the weak reference was already nil, we don't want to continue (for reasons below)
    if (strongSelf == nil) return;

    // do things with self
});
```

Because use of ivars automatically uses `self`, I had to use the pointer dereferencing syntax `strongSelf->_ivar` instead of just `_ivar`. Since this will crash if the reference to `self` ends up being `nil` (I think), I return early from these blocks in that case.

I think a better solution is to use synthesized property access instead of ivars, in which case, sending those messages to `nil` will just be a no-op, but that's a larger code change. I'd be interested in your feedback on whether you'd be open to a larger change like this, which possibly results in cleaner code for dealing with retain cycles.

I haven't been able to run the unit tests because of a code signing issue in the `SnowplowIgluClient-iOS-SnowplowIgluResources` target. It looks like it's trying to code sign the Debug version in the source of that pod, but I haven't been able to get it working.

I'd like to see the tests run, just to make sure that by resolving the memory warnings, we haven't introduced any unwanted behaviour.