### PR TITLE
Add OpenIdfa files to framework target

### DIFF
--- a/Frameworks/Frameworks.xcodeproj/project.pbxproj
+++ b/Frameworks/Frameworks.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		462FD4FF1B15CABE00296A38 /* SPPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 462FD4F91B15CABE00296A38 /* SPPayload.m */; };
 		462FD5001B15CABE00296A38 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 462FD4FA1B15CABE00296A38 /* SPTracker.m */; };
 		462FD5011B15CABE00296A38 /* SPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 462FD4FB1B15CABE00296A38 /* SPUtilities.m */; };
+		9786415921F9101100DF8A49 /* OpenIDFA.h in Headers */ = {isa = PBXBuildFile; fileRef = 9786415721F9101100DF8A49 /* OpenIDFA.h */; };
+		9786415A21F9101100DF8A49 /* OpenIDFA.m in Sources */ = {isa = PBXBuildFile; fileRef = 9786415821F9101100DF8A49 /* OpenIDFA.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +68,8 @@
 		462FD4F91B15CABE00296A38 /* SPPayload.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPPayload.m; path = ../../Snowplow/SPPayload.m; sourceTree = "<group>"; };
 		462FD4FA1B15CABE00296A38 /* SPTracker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPTracker.m; path = ../../Snowplow/SPTracker.m; sourceTree = "<group>"; };
 		462FD4FB1B15CABE00296A38 /* SPUtilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPUtilities.m; path = ../../Snowplow/SPUtilities.m; sourceTree = "<group>"; };
+		9786415721F9101100DF8A49 /* OpenIDFA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OpenIDFA.h; path = ../../Snowplow/OpenIDFA.h; sourceTree = "<group>"; };
+		9786415821F9101100DF8A49 /* OpenIDFA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OpenIDFA.m; path = ../../Snowplow/OpenIDFA.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +137,8 @@
 		462FD4D91B15C76500296A38 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				9786415721F9101100DF8A49 /* OpenIDFA.h */,
+				9786415821F9101100DF8A49 /* OpenIDFA.m */,
 				462FD4DA1B15C76500296A38 /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -159,6 +165,7 @@
 				462FD4F21B15CA8A00296A38 /* SPEventStore.h in Headers */,
 				044CA8911B948639000EA3B1 /* SPWeakTimerTarget.h in Headers */,
 				04DD9E271B7A307900FFF578 /* SPRequestResponse.h in Headers */,
+				9786415921F9101100DF8A49 /* OpenIDFA.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +261,7 @@
 				041B60A81B84C0D600A1EBCB /* SPSubject.m in Sources */,
 				043EC5E51B8F050900294081 /* SPSession.m in Sources */,
 				462FD4FF1B15CABE00296A38 /* SPPayload.m in Sources */,
+				9786415A21F9101100DF8A49 /* OpenIDFA.m in Sources */,
 				0402EBF31BA94BCE006C8818 /* SPEvent.m in Sources */,
 				462FD4FE1B15CABE00296A38 /* SPEventStore.m in Sources */,
 				04DD9E281B7A307900FFF578 /* SPRequestResponse.m in Sources */,


### PR DESCRIPTION
Hello,

We are using the universal framework generated by the target "SnowplowTracker-iOS-Static".
When building our app we encountered a linking error:
```
Undefined symbols for architecture arm64: "_OBJC_CLASS_$_OpenIDFA", referenced from: 
objc-class-ref in SnowplowTracker(SPUtilities.o)
ld: symbol(s) not found for architecture arm64
```

OpenIdfa files are not included in the SnowplowTracker-iOS-Static target, meaning we have to add them to our codebase manually to make linking succeed. Preprocessor macro **SNOWPLOW_NO_OPENIDFA** is useless in this case since we are using the compiled framework.

We have a workaround, but it would be great to not have to include this files in our codebase.

Thanks