### PR TITLE
Update SnowplowTracker.podspec

### DIFF
--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -41,6 +41,6 @@ Pod::Spec.new do |s|
   s.ios.frameworks = 'CoreTelephony', 'UIKit', 'Foundation'
   s.osx.frameworks = 'AppKit', 'Foundation'
   s.tvos.frameworks = 'UIKit', 'Foundation'
-  s.dependency 'FMDB', '2.6.2'
+  s.dependency 'FMDB', '~> 2'
   s.ios.dependency 'ReachabilitySwift'
 end


### PR DESCRIPTION
#432 Allow the use of newer FMDB 2.x versions when using Cocoapods.
