### PR TITLE
Ensure addDictionaryToPayload enumeration over immutable dictionary (close #480)

### DIFF
--- a/Snowplow/SPPayload.m
+++ b/Snowplow/SPPayload.m
@@ -56,12 +56,11 @@
 
 - (void) addDictionaryToPayload:(NSDictionary *)dict {
     if (dict != nil) {
-        for (NSString * key in dict) {
-            id value = [dict objectForKey:key];
+        [dict.copy enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL* stop) {
             if ([value isKindOfClass:[NSString class]]) {
                 [self addValueToPayload:(NSString *)value forKey:key];
             }
-        }
+        }];
     }
 }
 


### PR DESCRIPTION
The param type for `dict` is `NSDictionary` but the caller can pass in an immutable variety, like here:

https://github.com/snowplow/snowplow-objc-tracker/blob/4c28d7e8a3690cd5fd708b97e56db6dc14a7ee1f/Snowplow/SPTracker.m#L501-L502

Stop crashes like below that can occur via mutations of the passed in dictionary by ensuring we are enumerating over an immutable dictionary.

**Crash report on non-main thread:**
```
NSGenericException
SPPayload.m:59
*** Collection <__NSDictionaryM: 0x280c4db80> was mutated while being enumerated.
Sep 28th, 2019, 15:33:39 UTC

STACKTRACE

CrashReporter Key:  3d130da70c9c56af1526e9e41b6b0a11d319ce86
Hardware Model:     iPhone9,3
Process:            REDACTED
Identifier:         REDACTED
Version:            REDACTED
OS Version:         iOS 13.1.1



NSGenericException: *** Collection <__NSDictionaryM: 0x280c4db80> was mutated while being enumerated.

0  CoreFoundation          ___exceptionPreprocess
1  libobjc.A.dylib         _objc_exception_throw
2  CoreFoundation          ___NSFastEnumerationMutationHandler
3  Strava                  -[SPPayload addDictionaryToPayload:] (SPPayload.m:59:9)
4  Strava                  -[SPTracker getFinalPayloadWithPayload:andContext:andEventId:] (SPTracker.m:313:9)
5  Strava                  -[SPTracker addEventWithPayload:andContext:andEventId:] (SPTracker.m:305:34)
6  Strava                  -[SPTracker trackUnstructuredEvent:] (SPTracker.m:218:5)
7  Strava                  REDACTED
8  Strava                  REDACTED
9  Strava                  REDACTED
10 Strava                  REDACTED
11 Strava                  REDACTED
12 Strava                  REDACTED
13 Strava                  REDACTED
14 Strava                  REDACTED
15 Strava                  REDACTED
16 libdispatch.dylib       __dispatch_call_block_and_release
17 libdispatch.dylib       __dispatch_client_callout
18 libdispatch.dylib       __dispatch_lane_serial_drain$VARIANT$mp
19 libdispatch.dylib       __dispatch_lane_invoke$VARIANT$mp
20 libdispatch.dylib       __dispatch_workloop_worker_thread
21 libsystem_pthread.dylib __pthread_wqthread
22 libsystem_pthread.dylib _start_wqthread

THREADS

Thread 4
Error reported from this thread
0  CoreFoundation          ___exceptionPreprocess
1  libobjc.A.dylib         _objc_exception_throw
2  CoreFoundation          ___NSFastEnumerationMutationHandler
3  Strava                  -[SPPayload addDictionaryToPayload:] (SPPayload.m:59:9)
4  Strava                  -[SPTracker getFinalPayloadWithPayload:andContext:andEventId:] (SPTracker.m:313:9)
5  Strava                  -[SPTracker addEventWithPayload:andContext:andEventId:] (SPTracker.m:305:34)
6  Strava                  -[SPTracker trackUnstructuredEvent:] (SPTracker.m:218:5)
7  Strava                  REDACTED
8  Strava                  REDACTED
9  Strava                  REDACTED
10 Strava                  REDACTED
11 Strava                  REDACTED
12 Strava                  REDACTED
13 Strava                  REDACTED
14 Strava                  REDACTED
15 Strava                  REDACTED
16 libdispatch.dylib       __dispatch_call_block_and_release
17 libdispatch.dylib       __dispatch_client_callout
18 libdispatch.dylib       __dispatch_lane_serial_drain$VARIANT$mp
19 libdispatch.dylib       __dispatch_lane_invoke$VARIANT$mp
20 libdispatch.dylib       __dispatch_workloop_worker_thread
21 libsystem_pthread.dylib __pthread_wqthread
22 libsystem_pthread.dylib _start_wqthread
```