### PR TITLE
Fix IDFA rejection when app submitted with v.1.1.4

### DIFF
--- a/Snowplow iOSTests/TestUtils.m
+++ b/Snowplow iOSTests/TestUtils.m
@@ -21,6 +21,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <AdSupport/AdSupport.h>
 #import "SPUtilities.h"
 #import "Snowplow.h"
 
@@ -88,12 +89,10 @@
                    @"UUID generated doesn't match the type 4 UUID RFC");
 }
 
-/**
-
- This is always NULL as we do not have the AdSupport imported
- 
 - (void)testGetAppleIdfa {
-    NSString *sample_uuid = [SPUtils getAppleIdfa];
+    // The simulator running the test must have "limit ad tracking" disabled.
+    // (You can find it in the Simulator: Settings > Privacy > Advertising > Limit Ad Tracking > Set to False)
+    NSString *sample_uuid = [SPUtilities getAppleIdfa];
     
     // For regex pattern matching to verify if it's of UUID type 4
     NSString *pattern = @"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
@@ -105,7 +104,6 @@
     XCTAssertEqual([matches count], (NSUInteger)1,
                    @"UUID generated doesn't match the type 4 UUID RFC");
 }
-*/
 
 - (void)testGetOpenIdfa {
     NSString *sample_uuid = [SPUtilities getOpenIdfa];

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		75F9C5F021FA35BC00A5B8FC /* SPWeakTimerTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 044CA88B1B94791E000EA3B1 /* SPWeakTimerTarget.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		75F9C5F121FA35BC00A5B8FC /* SPEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 0402EBEB1BA93CA5006C8818 /* SPEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		75F9C5F221FA35BC00A5B8FC /* SPRequestCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 049B2BDA1B7A203200BD82FC /* SPRequestCallback.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED26E6BA23842AB00096AF7C /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED26E6B923842AAF0096AF7C /* AdSupport.framework */; };
 		ED8A3EEC2371708C00E51827 /* SPInstallTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 75264A31224E5DD2000E0E9B /* SPInstallTracker.m */; };
 		ED8A3EED2371709100E51827 /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 75264A2F224E5DBC000E0E9B /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
@@ -314,6 +315,7 @@
 		ABB767AF194974D3006275D1 /* SPEventStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPEventStore.m; sourceTree = "<group>"; };
 		ABFCC3741922984A00FAE8FE /* SPUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUtilities.h; sourceTree = "<group>"; };
 		ABFCC3751922984A00FAE8FE /* SPUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUtilities.m; sourceTree = "<group>"; };
+		ED26E6B923842AAF0096AF7C /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/AdSupport.framework; sourceTree = DEVELOPER_DIR; };
 		ED6AC5152369D42800A8F8A3 /* ios.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = ios.modulemap; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -333,6 +335,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED26E6BA23842AB00096AF7C /* AdSupport.framework in Frameworks */,
 				23DFEC832362FAF800BD19C4 /* VVJSONSchemaValidation.framework in Frameworks */,
 				23DFEC822362FAED00BD19C4 /* SnowplowIgluClient.framework in Frameworks */,
 				23DFEC812362FAE200BD19C4 /* Reachability.framework in Frameworks */,
@@ -462,6 +465,7 @@
 		AB0C27BF191B408200018557 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				ED26E6B923842AAF0096AF7C /* AdSupport.framework */,
 				753DDA6C21F803B10007C3AE /* Cocoa.framework */,
 				75CAC3C021F2930100271FB3 /* VVJSONSchemaValidation.framework */,
 				75CAC3B921F28BD600271FB3 /* SnowplowIgluClient.framework */,

--- a/Snowplow/SPUtilities.h
+++ b/Snowplow/SPUtilities.h
@@ -74,7 +74,7 @@
 + (NSString *) getOpenIdfa;
 
 /*!
- @brief Returns a generated string unique to each device, used only for serving advertisements. This works only if you have the AdSupport library in your project. If you have it, but do not want to use IDFA, add the complier flag <code>SNOWPLOW_NO_IFA</code> to your build settings.
+ @brief Returns a generated string unique to each device, used only for serving advertisements. This works only if you have the AdSupport library in your project. If you have it, but do not want to use IDFA, add the compiler flag <code>SNOWPLOW_NO_IFA</code> to your build settings.
 
  @return A string containing a formatted UUID for example E621E1F8-C36C-495A-93FC-0C247A3E6E5F.
  */

--- a/Snowplow/SPUtilities.m
+++ b/Snowplow/SPUtilities.m
@@ -29,7 +29,6 @@
 
 #if SNOWPLOW_TARGET_IOS
 
-@import AdSupport;
 #import "OpenIDFA.h"
 #import <UIKit/UIScreen.h>
 #import <CoreTelephony/CTCarrier.h>
@@ -49,7 +48,6 @@
 
 #elif SNOWPLOW_TARGET_TV
 
-@import AdSupport;
 #import <UIKit/UIScreen.h>
 
 #endif
@@ -90,17 +88,33 @@
     return idfa;
 }
 
+/*
+ The IDFA can be retrieved using selectors rather than proper instance methods because
+ the compiler would complain about the missing AdSupport framework.
+ As stated in the header file, this only works if you have the AdSupport library in your project.
+ If you have it, but do not want to use IDFA, add the compiler flag <code>SNOWPLOW_NO_IFA</code> to your build settings.
+ If you haven't AdSupport framework in your project it just compiles returning a nil advertisingIdentifier.
+ */
 + (NSString *) getAppleIdfa {
-    NSString* idfa = nil;
 #if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_TV
 #ifndef SNOWPLOW_NO_IFA
-    if([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]) {
-        NSUUID *identifier = [[ASIdentifierManager sharedManager] advertisingIdentifier];
-        idfa = [identifier UUIDString];
-    }
+    Class ASIdentifierManagerClass = NSClassFromString(@"ASIdentifierManager");
+    if (!ASIdentifierManagerClass) return nil;
+
+    SEL sharedManagerSelector = NSSelectorFromString(@"sharedManager");
+    id sharedManager = ((id (*)(id, SEL))[ASIdentifierManagerClass methodForSelector:sharedManagerSelector])(ASIdentifierManagerClass, sharedManagerSelector);
+
+    SEL isAdvertisingTrackingEnabledSelector = NSSelectorFromString(@"isAdvertisingTrackingEnabled");
+    BOOL isAdvertisingTrackingEnabled = ((BOOL (*)(id, SEL))[sharedManager methodForSelector:isAdvertisingTrackingEnabledSelector])(sharedManager, isAdvertisingTrackingEnabledSelector);
+
+    if (!isAdvertisingTrackingEnabled) return nil;
+
+    SEL advertisingIdentifierSelector = NSSelectorFromString(@"advertisingIdentifier");
+    NSUUID *uuid = ((NSUUID* (*)(id, SEL))[sharedManager methodForSelector:advertisingIdentifierSelector])(sharedManager, advertisingIdentifierSelector);
+    return [uuid UUIDString];
 #endif
 #endif
-    return idfa;
+    return nil;
 }
 
 + (NSString *) getAppleIdfv {


### PR DESCRIPTION
The version 1.1.4 update the code about the Apple IDFA.
The #447 add AdSupport module in the framework causing issues during the submission of apps to the App Store.

The current implementation let superfluous AdSupport framework because the class loading of `ASIdentifierManager` is done at runtime and not checked at compile time.