### PR TITLE
Allow overwriting of the 'platform' parameter (close #476)

### DIFF
--- a/Snowplow iOSTests/TestUtils.m
+++ b/Snowplow iOSTests/TestUtils.m
@@ -60,13 +60,9 @@
 
 - (void)testGetPlatform {
 #if TARGET_OS_IPHONE
-    XCTAssertEqualObjects([SPUtilities getPlatform],
-                          @"mob",
-                          @"How could this fail?");
+    XCTAssertEqual([SPUtilities getPlatform], SPDevicePlatformMobile);
 #else
-    XCTAssertEqualObjects([SPUtilities getPlatform],
-                          @"pc",
-                          @"How could this fail?");
+    XCTAssertEqual([SPUtilities getPlatform], SPDevicePlatformDesktop);
 #endif
 }
 

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -183,6 +183,14 @@
 		ED852B3523A0EEC600F2DF6B /* SNOWReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = ED852B3223A0EEC600F2DF6B /* SNOWReachability.h */; };
 		ED8A3EEC2371708C00E51827 /* SPInstallTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 75264A31224E5DD2000E0E9B /* SPInstallTracker.m */; };
 		ED8A3EED2371709100E51827 /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 75264A2F224E5DBC000E0E9B /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ED91CB6C23AA715B0078E75F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED91CB6D23AA715B0078E75F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED91CB6E23AA715B0078E75F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED91CB6F23AA715B0078E75F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED91CB7123AA8AD50078E75F /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */; };
+		ED91CB7223AA8AD50078E75F /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */; };
+		ED91CB7323AA8AD50078E75F /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */; };
+		ED91CB7423AA8AD50078E75F /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -316,6 +324,8 @@
 		ED6AC5152369D42800A8F8A3 /* ios.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = ios.modulemap; sourceTree = "<group>"; };
 		ED852B2E23A0E90E00F2DF6B /* SNOWReachabilty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SNOWReachabilty.m; sourceTree = "<group>"; };
 		ED852B3223A0EEC600F2DF6B /* SNOWReachability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SNOWReachability.h; sourceTree = "<group>"; };
+		ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDevicePlatform.h; sourceTree = "<group>"; };
+		ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPDevicePlatform.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -485,6 +495,8 @@
 				AB0C27C3191B408200018557 /* Supporting Files */,
 				AB0C27C5191B408200018557 /* Snowplow.h */,
 				043EC5E61B8F224900294081 /* Snowplow.m */,
+				ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */,
+				ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */,
 				AB9E8210192DD336006744C9 /* SPTracker.h */,
 				AB9E8211192DD336006744C9 /* SPTracker.m */,
 				AB0C27E9191B43D600018557 /* SPEmitter.h */,
@@ -539,6 +551,7 @@
 			files = (
 				752DAC3221CC43C60065F874 /* Snowplow.h in Headers */,
 				752DAC3321CC43C70065F874 /* SPTracker.h in Headers */,
+				ED91CB6C23AA715B0078E75F /* SPDevicePlatform.h in Headers */,
 				ED852B3323A0EEC600F2DF6B /* SNOWReachability.h in Headers */,
 				752DAC3421CC43C70065F874 /* SPEmitter.h in Headers */,
 				752DAC3521CC43C70065F874 /* SPSubject.h in Headers */,
@@ -566,6 +579,7 @@
 				75CAC45821F2A21B00271FB3 /* Snowplow-Bridging-Header.h in Headers */,
 				75CAC45921F2A21B00271FB3 /* Snowplow.h in Headers */,
 				75CAC45A21F2A21B00271FB3 /* SPTracker.h in Headers */,
+				ED91CB6D23AA715B0078E75F /* SPDevicePlatform.h in Headers */,
 				75CAC45B21F2A21B00271FB3 /* SPEmitter.h in Headers */,
 				75CAC45C21F2A21B00271FB3 /* SPSubject.h in Headers */,
 				75CAC45E21F2A21B00271FB3 /* SPPayload.h in Headers */,
@@ -596,6 +610,7 @@
 				75CAC43621F2A0CC00271FB3 /* SPEvent.h in Headers */,
 				75CAC43721F2A0CC00271FB3 /* SPRequestCallback.h in Headers */,
 				754774C22225FBB90043B814 /* SPScreenState.h in Headers */,
+				ED91CB6E23AA715B0078E75F /* SPDevicePlatform.h in Headers */,
 				75CAC43821F2A0CC00271FB3 /* Snowplow-Bridging-Header.h in Headers */,
 				75CAC42F21F2A0CC00271FB3 /* SPSession.h in Headers */,
 				ED852B3423A0EEC600F2DF6B /* SNOWReachability.h in Headers */,
@@ -612,6 +627,7 @@
 			files = (
 				75F9C5E521FA35BC00A5B8FC /* Snowplow-Bridging-Header.h in Headers */,
 				75F9C5E621FA35BC00A5B8FC /* Snowplow.h in Headers */,
+				ED91CB6F23AA715B0078E75F /* SPDevicePlatform.h in Headers */,
 				ED852B3523A0EEC600F2DF6B /* SNOWReachability.h in Headers */,
 				75F9C5E721FA35BC00A5B8FC /* SPTracker.h in Headers */,
 				75F9C5E821FA35BC00A5B8FC /* SPEmitter.h in Headers */,
@@ -836,6 +852,7 @@
 				754774D0222756470043B814 /* UIViewController+SPScreenView_SWIZZLE.m in Sources */,
 				752DAC3021CC431C0065F874 /* OpenIDFA.m in Sources */,
 				752DAC1721CC42BC0065F874 /* Snowplow.m in Sources */,
+				ED91CB7123AA8AD50078E75F /* SPDevicePlatform.m in Sources */,
 				752DAC1921CC42BC0065F874 /* SPTracker.m in Sources */,
 				752DAC1B21CC42BC0065F874 /* SPEmitter.m in Sources */,
 				75264A32224E5DD2000E0E9B /* SPInstallTracker.m in Sources */,
@@ -890,6 +907,7 @@
 				75CAC44221F2A17500271FB3 /* SPUtilities.m in Sources */,
 				75CAC44321F2A17500271FB3 /* SPRequestResponse.m in Sources */,
 				75CAC44421F2A17500271FB3 /* SPWeakTimerTarget.m in Sources */,
+				ED91CB7223AA8AD50078E75F /* SPDevicePlatform.m in Sources */,
 				75CAC44521F2A17500271FB3 /* SPEvent.m in Sources */,
 				75CAC44721F2A17500271FB3 /* Snowplow-Bridging-Header.h in Sources */,
 			);
@@ -904,6 +922,7 @@
 				75CAC44921F2A19500271FB3 /* SPTracker.m in Sources */,
 				ED8A3EEC2371708C00E51827 /* SPInstallTracker.m in Sources */,
 				75CAC44A21F2A19500271FB3 /* SPEmitter.m in Sources */,
+				ED91CB7323AA8AD50078E75F /* SPDevicePlatform.m in Sources */,
 				75CAC44B21F2A19500271FB3 /* SPSubject.m in Sources */,
 				75CAC44C21F2A19500271FB3 /* SPSession.m in Sources */,
 				75CAC44D21F2A19500271FB3 /* SPPayload.m in Sources */,
@@ -932,6 +951,7 @@
 				7534D20122569BED00904EE5 /* SPScreenState.m in Sources */,
 				7534D20222569BED00904EE5 /* UIViewController+SPScreenView_SWIZZLE.m in Sources */,
 				7534D20322569BED00904EE5 /* SPInstallTracker.m in Sources */,
+				ED91CB7423AA8AD50078E75F /* SPDevicePlatform.m in Sources */,
 				75F9C5D521FA357100A5B8FC /* OpenIDFA.m in Sources */,
 				75F9C5D621FA357100A5B8FC /* Snowplow.m in Sources */,
 				75F9C5D721FA357100A5B8FC /* SPTracker.m in Sources */,

--- a/Snowplow/SPDevicePlatform.h
+++ b/Snowplow/SPDevicePlatform.h
@@ -1,0 +1,22 @@
+//
+//  SPDevicePlatform.h
+//  Snowplow
+//
+//  Created by Alex Benini on 18/12/2019.
+//  Copyright © 2019 Snowplow Analytics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_CLOSED_ENUM(NSUInteger, SPDevicePlatform) {
+    SPDevicePlatformWeb = 0,
+    SPDevicePlatformMobile,
+    SPDevicePlatformDesktop,
+    SPDevicePlatformServerSideApp,
+    SPDevicePlatformGeneral,
+    SPDevicePlatformConnectedTV,
+    SPDevicePlatformGameConsole,
+    SPDevicePlatformInternetOfThings,
+};
+
+NSString *SPDevicePlatformToString(SPDevicePlatform devicePlatform);

--- a/Snowplow/SPDevicePlatform.m
+++ b/Snowplow/SPDevicePlatform.m
@@ -1,0 +1,23 @@
+//
+//  SPDevicePlatform.m
+//  Snowplow
+//
+//  Created by Alex Benini on 18/12/2019.
+//  Copyright © 2019 Snowplow Analytics. All rights reserved.
+//
+
+#import "SPDevicePlatform.h"
+
+NSString *SPDevicePlatformToString(SPDevicePlatform devicePlatform) {
+    switch (devicePlatform) {
+        case SPDevicePlatformWeb: return @"web";
+        case SPDevicePlatformMobile: return @"mob";
+        case SPDevicePlatformDesktop: return @"pc";
+        case SPDevicePlatformServerSideApp: return @"srv";
+        case SPDevicePlatformGeneral: return @"app";
+        case SPDevicePlatformConnectedTV: return @"tv";
+        case SPDevicePlatformGameConsole: return @"cnsl";
+        case SPDevicePlatformInternetOfThings: return @"iot";
+        default: return nil;
+    }
+}

--- a/Snowplow/SPSubject.m
+++ b/Snowplow/SPSubject.m
@@ -70,7 +70,6 @@
 // Standard Dictionary
 
 - (void) setStandardDict {
-    [_standardDict addValueToPayload:[SPUtilities getPlatform]   forKey:kSPPlatform];
     [_standardDict addValueToPayload:[SPUtilities getResolution] forKey:kSPResolution];
     [_standardDict addValueToPayload:[SPUtilities getViewPort]   forKey:kSPViewPort];
     [_standardDict addValueToPayload:[SPUtilities getLanguage]   forKey:kSPLanguage];

--- a/Snowplow/SPTracker.h
+++ b/Snowplow/SPTracker.h
@@ -27,6 +27,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SPDevicePlatform.h"
 
 void uncaughtExceptionHandler(NSException *exception);
 
@@ -90,6 +91,13 @@ void uncaughtExceptionHandler(NSException *exception);
  @param trackerNamespace The tracker's namespace.
  */
 - (void) setTrackerNamespace:(NSString *)trackerNamespace;
+
+/*!
+ @brief Tracker builder method to set the device platform the tracker is running on
+
+ @param devicePlatform The SPDevicePlatform enum indicating the current platform.
+ */
+- (void) setDevicePlatform:(SPDevicePlatform)devicePlatform;
 
 /*!
  @brief Tracker builder method to set whether events will include session context
@@ -183,6 +191,8 @@ void uncaughtExceptionHandler(NSException *exception);
 @property (readonly, nonatomic, strong) NSString * trackerNamespace;
 /*! @brief Whether to use Base64 encoding for events. */
 @property (readonly, nonatomic) BOOL base64Encoded;
+/*! @brief Whether to use Base64 encoding for events. */
+@property (readonly, nonatomic) SPDevicePlatform devicePlatform;
 /*! @brief Previous screen view state. */
 @property (readonly, nonatomic, strong) SPScreenState * previousScreenState;
 /*! @brief Current screen view state. */

--- a/Snowplow/SPTracker.m
+++ b/Snowplow/SPTracker.m
@@ -126,6 +126,7 @@ void uncaughtExceptionHandler(NSException *exception) {
     if (self) {
         _trackerNamespace = nil;
         _appId = nil;
+        _devicePlatform = [SPUtilities getPlatform];
         _base64Encoded = YES;
         _dataCollection = YES;
         _sessionContext = NO;
@@ -233,6 +234,10 @@ void uncaughtExceptionHandler(NSException *exception) {
     if (_builderFinished && _trackerData != nil) {
         [self setTrackerData];
     }
+}
+
+- (void) setDevicePlatform:(SPDevicePlatform)devicePlatform {
+    _devicePlatform = devicePlatform;
 }
 
 - (void) setSessionContext:(BOOL)sessionContext {
@@ -504,9 +509,8 @@ void uncaughtExceptionHandler(NSException *exception) {
     // Add Subject information
     if (_subject != nil) {
         [pb addDictionaryToPayload:[[_subject getStandardDict] getAsDictionary]];
-    } else {
-        [pb addValueToPayload:[SPUtilities getPlatform] forKey:kSPPlatform];
     }
+    [pb addValueToPayload:SPDevicePlatformToString(_devicePlatform) forKey:kSPPlatform];
 
     // Add the contexts
     SPSelfDescribingJson * context = [self getFinalContextWithContexts:contextArray andEventId:eventId];

--- a/Snowplow/SPUtilities.h
+++ b/Snowplow/SPUtilities.h
@@ -21,6 +21,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#include "SPDevicePlatform.h"
 
 @class SPPayload;
 @class SPSelfDescribingJson;
@@ -53,11 +54,11 @@
 + (NSString *) getLanguage;
 
 /*!
- @brief Returns the platform type of the device. This is always going to be "mob".
+ @brief Returns the platform type of the device..
 
  @return A string of the platform type.
  */
-+ (NSString *) getPlatform;
++ (SPDevicePlatform) getPlatform;
 
 /*!
  @brief Returns a randomly generated UUID (type 4).

--- a/Snowplow/SPUtilities.m
+++ b/Snowplow/SPUtilities.m
@@ -21,6 +21,7 @@
 //
 
 #import "Snowplow.h"
+#import "SPDevicePlatform.h"
 #import "SPUtilities.h"
 #import "SPPayload.h"
 #import "SPSelfDescribingJson.h"
@@ -59,11 +60,11 @@
     return [[NSLocale preferredLanguages] objectAtIndex:0];
 }
 
-+ (NSString *) getPlatform {
++ (SPDevicePlatform) getPlatform {
 #if SNOWPLOW_TARGET_IOS
-    return @"mob";
+    return SPDevicePlatformMobile;
 #else
-    return @"pc";
+    return SPDevicePlatformDesktop;
 #endif
 }
 

--- a/Snowplow/ios.modulemap
+++ b/Snowplow/ios.modulemap
@@ -8,5 +8,6 @@ framework module SnowplowTracker {
     header "SPRequestCallback.h"
     header "SPEvent.h"
     header "SPSelfDescribingJson.h"
+    header "SPDevicePlatform.h"
     export *
 }

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -35,7 +35,8 @@ Pod::Spec.new do |s|
     'Snowplow/SPRequestResponse.h',
     'Snowplow/SPEvent.h', 
     'Snowplow/SPSelfDescribingJson.h',
-    'Snowplow/SPScreenState.h'
+    'Snowplow/SPScreenState.h',
+    'Snowplow/SPDevicePlatform.h'
   ]
 
   s.ios.frameworks = 'CoreTelephony', 'UIKit', 'Foundation'
@@ -46,3 +47,4 @@ Pod::Spec.new do |s|
 
   s.dependency 'FMDB', '~> 2.6.2'
 end
+


### PR DESCRIPTION
Adapted the code to the same behaviour of the Android tracker where the platform parameter `p` can be overwritten by the developer.

## Proposed documentation improvement

By default iOS app sets automatically the parameter 'p' (platform) as `mob` and desktop app sets it to `pc`. However, there are cases where you want to specify that differently by the default option.

On the tracker setup you can override the device platform entry calling:

```
[tracker setDevicePlatform: SPDevicePlatformGameConsole];
```

It resets the parameter `p` (platform) to the new value.

[Here](https://github.com/snowplow/snowplow/wiki/snowplow-tracker-protocol#1-common-parameters-platform-and-event-independent) a full list of the supported platform values.
