### PR TITLE
Fix screen context not correctly updated on screenView events (close #483)

### DIFF
--- a/Snowplow iOSTests/TestUtils.m
+++ b/Snowplow iOSTests/TestUtils.m
@@ -72,7 +72,7 @@
 }
 
 - (void)testGetEventId {
-    NSString *sample_uuid = [SPUtilities getEventId];
+    NSString *sample_uuid = [SPUtilities getUUIDString];
 
     // For regex pattern matching to verify if it's of UUID type 4
     NSString *pattern = @"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";

--- a/Snowplow/SPEvent.h
+++ b/Snowplow/SPEvent.h
@@ -211,11 +211,9 @@ NSString * stringWithSPScreenType(SPScreenType screenType);
  */
 - (void) setTransitionType:(NSString *)type;
 
-- (BOOL) setWithPreviousState:(SPScreenState *)previousState;
+- (void) setViewControllerClassName:(NSString *)className;
 
-- (BOOL) setWithCurrentState:(SPScreenState *)currentState previousState:(SPScreenState *)previousState;
-
-- (BOOL) setWithCurrentState:(SPScreenState *)currentState;
+- (void) setTopViewControllerClassName:(NSString *)className;
 
 @end
 
@@ -777,11 +775,7 @@ NSString * stringWithSPScreenType(SPScreenType screenType);
 + (instancetype) build:(void(^)(id<SPScreenViewBuilder>builder))buildBlock;
 - (SPSelfDescribingJson *) getPayload;
 - (SPScreenState *) getScreenState;
-- (BOOL) definesPreviousState;
-- (SPScreenState *) getPreviousState;
-- (BOOL) setWithPreviousState:(SPScreenState *)previousState;
-- (BOOL) setWithCurrentState:(SPScreenState *)currentState;
-- (BOOL) setWithCurrentState:(SPScreenState *)currentState previousState:(SPScreenState *)previousState;
+- (BOOL) updateWithPreviousState:(SPScreenState *)previousState;
 @end
 
 /*!

--- a/Snowplow/SPScreenState.h
+++ b/Snowplow/SPScreenState.h
@@ -37,9 +37,9 @@
 /** Screenview transition type */
 @property (nonatomic, copy, readonly) NSString * transitionType;
 /** Top view controller class name */
-@property (nonatomic, copy, readonly) NSString * topViewControllerClassName;
+@property (nonatomic, copy, readwrite) NSString * topViewControllerClassName;
 /** View controller class name */
-@property (nonatomic, copy, readonly) NSString * viewControllerClassName;
+@property (nonatomic, copy, readwrite) NSString * viewControllerClassName;
 
 - (id) init;
 

--- a/Snowplow/SPScreenState.m
+++ b/Snowplow/SPScreenState.m
@@ -78,7 +78,8 @@
 
 - (BOOL) isValid {
     return ([SPUtilities validateString:self.name] != nil) &&
-    ([SPUtilities validateString:self.screenId] != nil);
+    ([SPUtilities validateString:self.screenId] != nil) &&
+    [SPUtilities isUUIDString:self.screenId];
 }
 
 - (SPPayload *) getValidPayload {

--- a/Snowplow/SPSession.m
+++ b/Snowplow/SPSession.m
@@ -78,7 +78,7 @@ NSString * const kSessionSavePath = @"session.dict";
 
         NSDictionary * maybeSessionDict = [self getSessionFromFile];
         if (maybeSessionDict == nil) {
-            _userId = [SPUtilities getEventId];
+            _userId = [SPUtilities getUUIDString];
             _currentSessionId = nil;
         } else {
             _userId = [maybeSessionDict valueForKey:kSPSessionUserId];
@@ -244,7 +244,7 @@ NSString * const kSessionSavePath = @"session.dict";
 
 - (void) updateSession {
     _previousSessionId = _currentSessionId;
-    _currentSessionId = [SPUtilities getEventId];
+    _currentSessionId = [SPUtilities getUUIDString];
     _sessionIndex++;
     _firstEventId = nil;
 }

--- a/Snowplow/SPUtilities.h
+++ b/Snowplow/SPUtilities.h
@@ -62,10 +62,25 @@
 
 /*!
  @brief Returns a randomly generated UUID (type 4).
+ 
+ @return A string containing a formatted UUID for example E621E1F8-C36C-495A-93FC-0C247A3E6E5F.
+ @deprecated Use `getUUIDString` instead`.
+ */
++ (NSString *) getEventId __deprecated_msg("Use `getUUIDString` instead.");
+
+/*!
+ @brief Returns a randomly generated UUID (type 4).
 
  @return A string containing a formatted UUID for example E621E1F8-C36C-495A-93FC-0C247A3E6E5F.
  */
-+ (NSString *) getEventId;
++ (NSString *) getUUIDString;
+
+/*!
+ @brief Check if the value is a valid UUID (type 4).
+ @param uuidString UUID string to validate.
+ @return Weither is a valid UUID string.
+ */
++ (bool ) isUUIDString:(NSString *)uuidString;
 
 /*!
  @brief Returns a generated string unique to each device, used only for serving advertisements. This is similar to the native advertisingIdentifier supplied by Apple. If you do not want to use OpenIDFA, add the compiler flag <code>SNOWPLOW_NO_OPENIDFA</code> to your build settings.

--- a/Snowplow/SPUtilities.m
+++ b/Snowplow/SPUtilities.m
@@ -73,8 +73,16 @@
 }
 
 + (NSString *) getEventId {
+    return [SPUtilities getUUIDString];
+}
+
++ (NSString *) getUUIDString {
     // Generates type 4 UUID
     return [[NSUUID UUID] UUIDString].lowercaseString;
+}
+
++ (bool ) isUUIDString:(nonnull NSString *)uuidString {
+    return [[NSUUID alloc] initWithUUIDString:uuidString] != nil;
 }
 
 + (NSString *) getOpenIdfa {


### PR DESCRIPTION
Fix #483 

As reported in the linked issue, the screen context wasn't correctly updated when the app send a screenView event. It used to work correctly only with automatic screenView tracking.
The bug is related to the software design so I needed to refactor a bit the logic behind ScreenState updating.