### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SnowplowTracker",
+    platforms: [
+        .iOS(.v8),
+        .macOS(.v10_10),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "SnowplowTracker",
+            targets: ["SnowplowTracker"]),
+    ],
+    dependencies: [
+        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "4.3.1"),
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("9b100cc3dd83ff88a17a4da8718eab4b08e2fe67"))
+    ],
+    targets: [
+        .target(
+            name: "SnowplowTracker",
+            dependencies: ["FMDB", "Reachability"],
+            path: "Snowplow",
+            publicHeadersPath: "Snowplow")
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .target(
             name: "SnowplowTracker",
             dependencies: ["FMDB"],
+            path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,12 +16,13 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
+        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "5.0.0"),
         .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("dcd5bb68b348b51af7c76a51aa9f86f676feb3fc"))
     ],
     targets: [
         .target(
             name: "SnowplowTracker",
-            dependencies: ["FMDB"],
+            dependencies: ["FMDB", "Reachability"],
             path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,6 @@ let package = Package(
             name: "SnowplowTracker",
             dependencies: ["FMDB", "Reachability"],
             path: "Snowplow",
-            publicHeadersPath: "Snowplow")
+            publicHeadersPath: ".")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,13 +17,12 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "4.3.1"),
-        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("9b100cc3dd83ff88a17a4da8718eab4b08e2fe67"))
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("d68317fc0d7a986872ebf389f8d09b870fc88a7d"))
     ],
     targets: [
         .target(
             name: "SnowplowTracker",
             dependencies: ["FMDB", "Reachability"],
-            path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,14 +16,12 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
-        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "4.3.1"),
-        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("d68317fc0d7a986872ebf389f8d09b870fc88a7d"))
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("dcd5bb68b348b51af7c76a51aa9f86f676feb3fc"))
     ],
     targets: [
         .target(
             name: "SnowplowTracker",
-            dependencies: ["FMDB", "Reachability"],
-            path: "Snowplow",
-            publicHeadersPath: ".")
+            dependencies: ["FMDB"],
+            publicHeadersPath: "Snowplow")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .target(
             name: "SnowplowTracker",
             dependencies: ["FMDB", "Reachability"],
+            path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]
 )

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,7 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
-#import <fmdb/FMDB.h>
+#import "FMDB.h"
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,7 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
-#import "FMDB.h"
+#import <FMDB.h>
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,7 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
-#import <FMDB.h>
+#import "FMDB.h"
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
@@ -6,6 +6,8 @@
 //  Copyright © 2019 Snowplow Analytics. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
+
 @class UIViewController;
 typedef NS_ENUM(NSInteger, SPScreenType);
 


### PR DESCRIPTION
Unfortunately I had to add an import to a header file and modify another one in an implementation.

I understand these changes would break many things, but I wanted to provide this Package manifest as a base ground and maybe somebody else could take it from here?

I was able to add successfully this package as a dependency on Swift 5.2