### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
+++ b/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,394 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CEF26A06243CC5630051C2EB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */; };
+		CEF26A07243CC5630051C2EB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F8243CC5630051C2EB /* Main.storyboard */; };
+		CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FA243CC5630051C2EB /* AppDelegate.swift */; };
+		CEF26A09243CC5630051C2EB /* DemoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FB243CC5630051C2EB /* DemoUtils.swift */; };
+		CEF26A0A243CC5630051C2EB /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FC243CC5630051C2EB /* PageViewController.swift */; };
+		CEF26A0B243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */; };
+		CEF26A0C243CC5630051C2EB /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FF243CC5630051C2EB /* DemoViewController.swift */; };
+		CEF26A0D243CC5630051C2EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEF26A00243CC5630051C2EB /* Assets.xcassets */; };
+		CEF26A0E243CC5630051C2EB /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A01243CC5630051C2EB /* InterfaceController.swift */; };
+		CEF26A0F243CC5630051C2EB /* MetricsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A02243CC5630051C2EB /* MetricsViewController.swift */; };
+		CEF26A10243CC5630051C2EB /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A03243CC5630051C2EB /* ExtensionDelegate.swift */; };
+		CEF26A11243CC5630051C2EB /* AdditionalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnowplowSwiftSPMDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CEF269EE243CC5450051C2EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CEF269F7243CC5630051C2EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		CEF269F9243CC5630051C2EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Main.storyboard; sourceTree = "<group>"; };
+		CEF269FA243CC5630051C2EB /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = ../../CommonSwiftCode/AppDelegate.swift; sourceTree = "<group>"; };
+		CEF269FB243CC5630051C2EB /* DemoUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DemoUtils.swift; path = ../../CommonSwiftCode/DemoUtils.swift; sourceTree = "<group>"; };
+		CEF269FC243CC5630051C2EB /* PageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PageViewController.swift; path = ../../CommonSwiftCode/PageViewController.swift; sourceTree = "<group>"; };
+		CEF269FE243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SnowplowSwiftDemo.xcdatamodel; sourceTree = "<group>"; };
+		CEF269FF243CC5630051C2EB /* DemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DemoViewController.swift; path = ../../CommonSwiftCode/DemoViewController.swift; sourceTree = "<group>"; };
+		CEF26A00243CC5630051C2EB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = ../../CommonSwiftCode/Assets.xcassets; sourceTree = "<group>"; };
+		CEF26A01243CC5630051C2EB /* InterfaceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InterfaceController.swift; path = ../../CommonSwiftCode/InterfaceController.swift; sourceTree = "<group>"; };
+		CEF26A02243CC5630051C2EB /* MetricsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetricsViewController.swift; path = ../../CommonSwiftCode/MetricsViewController.swift; sourceTree = "<group>"; };
+		CEF26A03243CC5630051C2EB /* ExtensionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtensionDelegate.swift; path = ../../CommonSwiftCode/ExtensionDelegate.swift; sourceTree = "<group>"; };
+		CEF26A04243CC5630051C2EB /* SnowplowSwiftDemo.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = SnowplowSwiftDemo.entitlements; path = ../../CommonSwiftCode/SnowplowSwiftDemo.entitlements; sourceTree = "<group>"; };
+		CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdditionalViewController.swift; path = ../../CommonSwiftCode/AdditionalViewController.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CEF269DA243CC5440051C2EB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CEF269D4243CC5440051C2EB = {
+			isa = PBXGroup;
+			children = (
+				CEF269DE243CC5440051C2EB /* Products */,
+				CEF269DF243CC5440051C2EB /* SnowplowSwiftSPMDemo */,
+			);
+			sourceTree = "<group>";
+		};
+		CEF269DE243CC5440051C2EB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CEF269DF243CC5440051C2EB /* SnowplowSwiftSPMDemo */ = {
+			isa = PBXGroup;
+			children = (
+				CEF26A04243CC5630051C2EB /* SnowplowSwiftDemo.entitlements */,
+				CEF269EE243CC5450051C2EB /* Info.plist */,
+				CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */,
+				CEF269FA243CC5630051C2EB /* AppDelegate.swift */,
+				CEF269FB243CC5630051C2EB /* DemoUtils.swift */,
+				CEF269FF243CC5630051C2EB /* DemoViewController.swift */,
+				CEF26A03243CC5630051C2EB /* ExtensionDelegate.swift */,
+				CEF26A01243CC5630051C2EB /* InterfaceController.swift */,
+				CEF26A02243CC5630051C2EB /* MetricsViewController.swift */,
+				CEF269FC243CC5630051C2EB /* PageViewController.swift */,
+				CEF26A00243CC5630051C2EB /* Assets.xcassets */,
+				CEF269F5243CC5630051C2EB /* Base.lproj */,
+				CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */,
+			);
+			path = SnowplowSwiftSPMDemo;
+			sourceTree = "<group>";
+		};
+		CEF269F5243CC5630051C2EB /* Base.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */,
+				CEF269F8243CC5630051C2EB /* Main.storyboard */,
+			);
+			name = Base.lproj;
+			path = ../../CommonSwiftCode/Base.lproj;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CEF269DC243CC5440051C2EB /* SnowplowSwiftSPMDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CEF269F1243CC5450051C2EB /* Build configuration list for PBXNativeTarget "SnowplowSwiftSPMDemo" */;
+			buildPhases = (
+				CEF269D9243CC5440051C2EB /* Sources */,
+				CEF269DA243CC5440051C2EB /* Frameworks */,
+				CEF269DB243CC5440051C2EB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SnowplowSwiftSPMDemo;
+			productName = SnowplowSwiftSPMDemo;
+			productReference = CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CEF269D5243CC5440051C2EB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1140;
+				LastUpgradeCheck = 1140;
+				ORGANIZATIONNAME = Snowplow;
+				TargetAttributes = {
+					CEF269DC243CC5440051C2EB = {
+						CreatedOnToolsVersion = 11.4;
+						LastSwiftMigration = 1140;
+					};
+				};
+			};
+			buildConfigurationList = CEF269D8243CC5440051C2EB /* Build configuration list for PBXProject "SnowplowSwiftSPMDemo" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CEF269D4243CC5440051C2EB;
+			productRefGroup = CEF269DE243CC5440051C2EB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CEF269DC243CC5440051C2EB /* SnowplowSwiftSPMDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CEF269DB243CC5440051C2EB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CEF26A06243CC5630051C2EB /* LaunchScreen.storyboard in Resources */,
+				CEF26A0D243CC5630051C2EB /* Assets.xcassets in Resources */,
+				CEF26A07243CC5630051C2EB /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CEF269D9243CC5440051C2EB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CEF26A11243CC5630051C2EB /* AdditionalViewController.swift in Sources */,
+				CEF26A0A243CC5630051C2EB /* PageViewController.swift in Sources */,
+				CEF26A0B243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld in Sources */,
+				CEF26A10243CC5630051C2EB /* ExtensionDelegate.swift in Sources */,
+				CEF26A09243CC5630051C2EB /* DemoUtils.swift in Sources */,
+				CEF26A0F243CC5630051C2EB /* MetricsViewController.swift in Sources */,
+				CEF26A0E243CC5630051C2EB /* InterfaceController.swift in Sources */,
+				CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */,
+				CEF26A0C243CC5630051C2EB /* DemoViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CEF269F7243CC5630051C2EB /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		CEF269F8243CC5630051C2EB /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CEF269F9243CC5630051C2EB /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		CEF269EF243CC5450051C2EB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CEF269F0243CC5450051C2EB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CEF269F2243CC5450051C2EB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SnowplowSwiftSPMDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.snowplowanalytics.SnowplowSwiftSPMDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CEF269F3243CC5450051C2EB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = SnowplowSwiftSPMDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.snowplowanalytics.SnowplowSwiftSPMDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CEF269D8243CC5440051C2EB /* Build configuration list for PBXProject "SnowplowSwiftSPMDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CEF269EF243CC5450051C2EB /* Debug */,
+				CEF269F0243CC5450051C2EB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CEF269F1243CC5450051C2EB /* Build configuration list for PBXNativeTarget "SnowplowSwiftSPMDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CEF269F2243CC5450051C2EB /* Debug */,
+				CEF269F3243CC5450051C2EB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				CEF269FE243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodel */,
+			);
+			currentVersion = CEF269FE243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodel */;
+			name = SnowplowSwiftDemo.xcdatamodeld;
+			path = ../../CommonSwiftCode/SnowplowSwiftDemo.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = CEF269D5243CC5440051C2EB /* Project object */;
+}

--- a/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
+++ b/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CE39117F243CD84800DE5EC7 /* SnowplowTracker in Frameworks */ = {isa = PBXBuildFile; productRef = CE39117E243CD84800DE5EC7 /* SnowplowTracker */; };
 		CEF26A06243CC5630051C2EB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F6243CC5630051C2EB /* LaunchScreen.storyboard */; };
 		CEF26A07243CC5630051C2EB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEF269F8243CC5630051C2EB /* Main.storyboard */; };
 		CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FA243CC5630051C2EB /* AppDelegate.swift */; };
@@ -15,13 +16,12 @@
 		CEF26A0B243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */; };
 		CEF26A0C243CC5630051C2EB /* DemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF269FF243CC5630051C2EB /* DemoViewController.swift */; };
 		CEF26A0D243CC5630051C2EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CEF26A00243CC5630051C2EB /* Assets.xcassets */; };
-		CEF26A0E243CC5630051C2EB /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A01243CC5630051C2EB /* InterfaceController.swift */; };
 		CEF26A0F243CC5630051C2EB /* MetricsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A02243CC5630051C2EB /* MetricsViewController.swift */; };
-		CEF26A10243CC5630051C2EB /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A03243CC5630051C2EB /* ExtensionDelegate.swift */; };
 		CEF26A11243CC5630051C2EB /* AdditionalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		CE39117D243CD83F00DE5EC7 /* snowplow-objc-tracker */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "snowplow-objc-tracker"; path = ../..; sourceTree = "<group>"; };
 		CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnowplowSwiftSPMDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEF269EE243CC5450051C2EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CEF269F7243CC5630051C2EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -32,9 +32,7 @@
 		CEF269FE243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SnowplowSwiftDemo.xcdatamodel; sourceTree = "<group>"; };
 		CEF269FF243CC5630051C2EB /* DemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DemoViewController.swift; path = ../../CommonSwiftCode/DemoViewController.swift; sourceTree = "<group>"; };
 		CEF26A00243CC5630051C2EB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = ../../CommonSwiftCode/Assets.xcassets; sourceTree = "<group>"; };
-		CEF26A01243CC5630051C2EB /* InterfaceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InterfaceController.swift; path = ../../CommonSwiftCode/InterfaceController.swift; sourceTree = "<group>"; };
 		CEF26A02243CC5630051C2EB /* MetricsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetricsViewController.swift; path = ../../CommonSwiftCode/MetricsViewController.swift; sourceTree = "<group>"; };
-		CEF26A03243CC5630051C2EB /* ExtensionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtensionDelegate.swift; path = ../../CommonSwiftCode/ExtensionDelegate.swift; sourceTree = "<group>"; };
 		CEF26A04243CC5630051C2EB /* SnowplowSwiftDemo.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = SnowplowSwiftDemo.entitlements; path = ../../CommonSwiftCode/SnowplowSwiftDemo.entitlements; sourceTree = "<group>"; };
 		CEF26A05243CC5630051C2EB /* AdditionalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdditionalViewController.swift; path = ../../CommonSwiftCode/AdditionalViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -44,17 +42,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE39117F243CD84800DE5EC7 /* SnowplowTracker in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		CE57B9D7243CD152004C4941 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		CEF269D4243CC5440051C2EB = {
 			isa = PBXGroup;
 			children = (
+				CE39117D243CD83F00DE5EC7 /* snowplow-objc-tracker */,
 				CEF269DE243CC5440051C2EB /* Products */,
 				CEF269DF243CC5440051C2EB /* SnowplowSwiftSPMDemo */,
+				CE57B9D7243CD152004C4941 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -75,8 +83,6 @@
 				CEF269FA243CC5630051C2EB /* AppDelegate.swift */,
 				CEF269FB243CC5630051C2EB /* DemoUtils.swift */,
 				CEF269FF243CC5630051C2EB /* DemoViewController.swift */,
-				CEF26A03243CC5630051C2EB /* ExtensionDelegate.swift */,
-				CEF26A01243CC5630051C2EB /* InterfaceController.swift */,
 				CEF26A02243CC5630051C2EB /* MetricsViewController.swift */,
 				CEF269FC243CC5630051C2EB /* PageViewController.swift */,
 				CEF26A00243CC5630051C2EB /* Assets.xcassets */,
@@ -112,6 +118,9 @@
 			dependencies = (
 			);
 			name = SnowplowSwiftSPMDemo;
+			packageProductDependencies = (
+				CE39117E243CD84800DE5EC7 /* SnowplowTracker */,
+			);
 			productName = SnowplowSwiftSPMDemo;
 			productReference = CEF269DD243CC5440051C2EB /* SnowplowSwiftSPMDemo.app */;
 			productType = "com.apple.product-type.application";
@@ -141,6 +150,8 @@
 				Base,
 			);
 			mainGroup = CEF269D4243CC5440051C2EB;
+			packageReferences = (
+			);
 			productRefGroup = CEF269DE243CC5440051C2EB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -171,10 +182,8 @@
 				CEF26A11243CC5630051C2EB /* AdditionalViewController.swift in Sources */,
 				CEF26A0A243CC5630051C2EB /* PageViewController.swift in Sources */,
 				CEF26A0B243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld in Sources */,
-				CEF26A10243CC5630051C2EB /* ExtensionDelegate.swift in Sources */,
 				CEF26A09243CC5630051C2EB /* DemoUtils.swift in Sources */,
 				CEF26A0F243CC5630051C2EB /* MetricsViewController.swift in Sources */,
-				CEF26A0E243CC5630051C2EB /* InterfaceController.swift in Sources */,
 				CEF26A08243CC5630051C2EB /* AppDelegate.swift in Sources */,
 				CEF26A0C243CC5630051C2EB /* DemoViewController.swift in Sources */,
 			);
@@ -375,6 +384,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CE39117E243CD84800DE5EC7 /* SnowplowTracker */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SnowplowTracker;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		CEF269FD243CC5630051C2EB /* SnowplowSwiftDemo.xcdatamodeld */ = {

--- a/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:SnowplowSwiftSPMDemo.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:SnowplowSwiftSPMDemo.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo/Info.plist
+++ b/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo/Info.plist
+++ b/Examples/SnowplowSwiftSPMDemo/SnowplowSwiftSPMDemo/Info.plist
@@ -20,24 +20,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIApplicationSceneManifest</key>
+	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
-				</dict>
-			</array>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SnowplowTracker",
+    platforms: [
+        .iOS(.v8),
+        .macOS(.v10_10),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "SnowplowTracker",
+            targets: ["SnowplowTracker"]),
+    ],
+    dependencies: [
+        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "4.3.1"),
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("9b100cc3dd83ff88a17a4da8718eab4b08e2fe67"))
+    ],
+    targets: [
+        .target(
+            name: "SnowplowTracker",
+            dependencies: ["FMDB", "Reachability"],
+            path: "Snowplow",
+            publicHeadersPath: "Snowplow")
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .target(
             name: "SnowplowTracker",
             dependencies: ["FMDB"],
+            path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,12 +16,13 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
+        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "5.0.0"),
         .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("dcd5bb68b348b51af7c76a51aa9f86f676feb3fc"))
     ],
     targets: [
         .target(
             name: "SnowplowTracker",
-            dependencies: ["FMDB"],
+            dependencies: ["FMDB", "Reachability"],
             path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,14 +16,13 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
-        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "5.0.0"),
         .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("dcd5bb68b348b51af7c76a51aa9f86f676feb3fc"))
     ],
     targets: [
         .target(
             name: "SnowplowTracker",
-            dependencies: ["FMDB", "Reachability"],
+            dependencies: ["FMDB"],
             path: "Snowplow",
-            publicHeadersPath: "Snowplow")
+            publicHeadersPath: ".")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,6 @@ let package = Package(
             name: "SnowplowTracker",
             dependencies: ["FMDB", "Reachability"],
             path: "Snowplow",
-            publicHeadersPath: "Snowplow")
+            publicHeadersPath: ".")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,7 @@ import PackageDescription
 let package = Package(
     name: "SnowplowTracker",
     platforms: [
-        .iOS(.v8),
-        .macOS(.v10_10),
-        .tvOS(.v9),
-        .watchOS(.v2)
+        .iOS(.v8)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -17,13 +17,12 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "4.3.1"),
-        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("9b100cc3dd83ff88a17a4da8718eab4b08e2fe67"))
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("d68317fc0d7a986872ebf389f8d09b870fc88a7d"))
     ],
     targets: [
         .target(
             name: "SnowplowTracker",
             dependencies: ["FMDB", "Reachability"],
-            path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,14 +16,12 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
-        .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "4.3.1"),
-        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("d68317fc0d7a986872ebf389f8d09b870fc88a7d"))
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("dcd5bb68b348b51af7c76a51aa9f86f676feb3fc"))
     ],
     targets: [
         .target(
             name: "SnowplowTracker",
-            dependencies: ["FMDB", "Reachability"],
-            path: "Snowplow",
-            publicHeadersPath: ".")
+            dependencies: ["FMDB"],
+            publicHeadersPath: "Snowplow")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,10 @@ let package = Package(
             name: "SnowplowTracker",
             dependencies: ["FMDB"],
             path: "Snowplow",
-            publicHeadersPath: ".")
+            publicHeadersPath: "."),
+        .target(
+            name: "Snowplow-iOSTests",
+            dependencies: ["SnowplowTracker"],
+            path: "Snowplow iOSTests")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
-        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("dcd5bb68b348b51af7c76a51aa9f86f676feb3fc"))
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("d68317fc0d7a986872ebf389f8d09b870fc88a7d"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .target(
             name: "SnowplowTracker",
             dependencies: ["FMDB", "Reachability"],
+            path: "Snowplow",
             publicHeadersPath: "Snowplow")
     ]
 )

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,7 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
-#import <fmdb/FMDB.h>
+#import "FMDB.h"
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,7 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
-#import "FMDB.h"
+#import <FMDB.h>
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,7 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
-#import <FMDB.h>
+#import "FMDB.h"
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/SPEventStore.m
+++ b/Snowplow/SPEventStore.m
@@ -24,7 +24,12 @@
 #import "SPEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
-#import <FMDB.h>
+
+#if SWIFT_PACKAGE
+    #import <FMDB.h>
+#else
+    #import <fmdb/FMDB.h>
+#endif
 
 @implementation SPEventStore {
     NSString *        _dbPath;

--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
@@ -6,7 +6,9 @@
 //  Copyright © 2019 Snowplow Analytics. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#if SWIFT_PACKAGE
+    #import <UIKit/UIKit.h>
+#endif
 
 @class UIViewController;
 typedef NS_ENUM(NSInteger, SPScreenType);

--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
@@ -6,9 +6,7 @@
 //  Copyright © 2019 Snowplow Analytics. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
-    #import <UIKit/UIKit.h>
-#endif
+#import <UIKit/UIKit.h>
 
 @class UIViewController;
 typedef NS_ENUM(NSInteger, SPScreenType);

--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
@@ -6,6 +6,8 @@
 //  Copyright © 2019 Snowplow Analytics. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
+
 @class UIViewController;
 typedef NS_ENUM(NSInteger, SPScreenType);
 


### PR DESCRIPTION
Adding support for Swift Package Manager would allow your users to stop using CocoaPods or Carthage and move a solution already integrated on Xcode.

Unfortunately 2 of your headers had to be modified in order for the package to build using SPM.

I understand these changes will break things, but my knowledge handling header files is not that good, maybe somebody in your team knows how to avoid changing:

`#import <fmdb/FMDB.h>`
to
`#import <FMDB.h>`



I was able to add successfully this package as a dependency on a project using Swift 5.2

I'm sorry for spamming your CI, there is no other way to test if the configuration on the Package Manifest is going to work and if the changes I made on your headers are affecting other deployment options.
