### PR TITLE
Replace deprecated methods

### DIFF
--- a/Snowplow iOSTests/TestUtils.m
+++ b/Snowplow iOSTests/TestUtils.m
@@ -122,11 +122,6 @@
 #endif
 }
 
-- (void)testGetCarrierName {
-    NSLog(@"Carrier: %@", [SPUtilities getCarrierName]);
-    // No way to fake carrier in Travis simulator
-}
-
 - (void)testGetTransactionId {
     // Supressing deprecated warning only for tests
 #pragma clang diagnostic push

--- a/Snowplow/SPUtilities.m
+++ b/Snowplow/SPUtilities.m
@@ -272,17 +272,12 @@
     return [[NSBundle mainBundle] bundleIdentifier];
 }
 
-+ (NSString *)urlEncodeString:(NSString *)s {
-    if (!s) {
++ (NSString *)urlEncodeString:(NSString *)string {
+    if (!string) {
         return @"";   
     }
-    return (NSString *)CFBridgingRelease(
-            CFURLCreateStringByAddingPercentEscapes(
-                NULL, 
-                (CFStringRef) s, 
-                NULL, 
-                (CFStringRef)@"!*'\"();:@&=+$,/?%#[]% ",
-                CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding)));
+    NSCharacterSet *allowedCharSet = [NSCharacterSet characterSetWithCharactersInString:@"{}!*'\\\"();:@&=+$,/?%#[]% "].invertedSet;
+    return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharSet];
 }
 
 + (NSString *)urlEncodeDictionary:(NSDictionary *)d {

--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.m
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.m
@@ -148,7 +148,18 @@
 }
 
 - (UIViewController *) _SP_topViewController {
-    return [self _SP_topViewController:[UIApplication sharedApplication].keyWindow.rootViewController];
+    UIWindow *keyWindow = nil;
+    NSArray<UIWindow *> *windows = [UIApplication sharedApplication].windows;
+    for (UIWindow *window in windows) {
+        if (window.isKeyWindow) {
+            keyWindow = window;
+            break;
+        }
+    }
+    if (!keyWindow) {
+        return nil;
+    }
+    return [self _SP_topViewController:keyWindow.rootViewController];
 }
 
 - (UIViewController *) _SP_topViewController:(UIViewController *)rootViewController {


### PR DESCRIPTION
There are few methods deprecated in the last iOS versions:

- Fix deprecated keyWindow (#492)
- Fix deprecated CFURLCreateStringByAddingPercentEscapes (#493)
- Replace deprecated CTTelephonyNetworkInfo methods (#479)
