### PR TITLE
Add GDPR context (close #425)

### DIFF
--- a/Examples/CommonSwiftCode/InterfaceController.swift
+++ b/Examples/CommonSwiftCode/InterfaceController.swift
@@ -39,6 +39,7 @@ class InterfaceController: WKInterfaceController, SPRequestCallback {
             builder!.setApplicationContext(true)
             builder!.setExceptionEvents(true)
             builder!.setInstallEvent(true)
+            builder!.setGdprContextWith(SPGdprProcessingBasis.consent, documentId: "id", documentVersion: "1.0", documentDescription: "description")
         })
         return newTracker!
     }

--- a/Examples/CommonSwiftCode/PageViewController.swift
+++ b/Examples/CommonSwiftCode/PageViewController.swift
@@ -52,6 +52,7 @@ class PageViewController:  UIPageViewController, UIPageViewControllerDelegate, U
                 "ruleSetExampleTag": self.ruleSetGlobalContextExample(),
                 "staticExampleTag": self.staticGlobalContextExample(),
             ])
+            builder!.setGdprContextWith(SPGdprProcessingBasis.consent, documentId: "id", documentVersion: "1.0", documentDescription: "description")
         })
         return newTracker!
     }

--- a/Examples/SnowplowSwiftCocoapodsDemo/Pods/Headers/Private/SnowplowTracker/SPGdprContext.h
+++ b/Examples/SnowplowSwiftCocoapodsDemo/Pods/Headers/Private/SnowplowTracker/SPGdprContext.h
@@ -1,0 +1,1 @@
+../../../../../../Snowplow/SPGdprContext.h

--- a/Examples/SnowplowSwiftCocoapodsDemo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/SnowplowSwiftCocoapodsDemo/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,200 +7,204 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00BE14243074C63828C806CFC9778CB8 /* SPConsentDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 4192C7B18424525CF1AE011D41F252F0 /* SPConsentDocument.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		00F92513F60BDC636321A9AA26015139 /* SPSelfDescribingJson.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D126FC6A89BBD65EA039156C0C1B50 /* SPSelfDescribingJson.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0100F55E2B34119913E6BB17FD9DE63E /* SPScreenState.h in Headers */ = {isa = PBXBuildFile; fileRef = E0E2D5B164F36963FF4E32B9F36684E4 /* SPScreenState.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		02C57B51A10D34471740D1F351BE0A96 /* SPForeground.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D4AC9791F0B97078BE8681D2F11BAF /* SPForeground.m */; };
-		03E368F37601202B2C7D72066E9A0A39 /* SPSession.m in Sources */ = {isa = PBXBuildFile; fileRef = C41558F2CBF9D411CA5B3BC9613A84C7 /* SPSession.m */; };
-		0DFB7A37CCBF2737DFEE1C1EA2513356 /* SPEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0C55235CD5F960224B215D21672D66 /* SPEmitter.m */; };
-		104AB419D000C0C69C1FE24E5AE037E8 /* SPConsentWithdrawn.m in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEE24AE48292728C3080205D44E3E /* SPConsentWithdrawn.m */; };
-		10740CC4CA3F1BE3695A883D084F47AA /* SPGlobalContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF295946CA09F8B82FB788E9445912 /* SPGlobalContext.m */; };
-		107468FB40583FE7B7DF9BF390BB5426 /* SPEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCE732A246430537539367A91CEF663 /* SPEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		13487BC07D3A0284AA29C6E6F00F2D66 /* OpenIDFA.h in Headers */ = {isa = PBXBuildFile; fileRef = 39172F96ADF63594CCC04B40F5125814 /* OpenIDFA.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		14825D387D34945A94000E4E07A456DA /* SPUnstructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 769FCF91E1A238B36B2DEE5FB0E1D315 /* SPUnstructured.m */; };
+		001C92A36719997130A05A7C14E2E957 /* SPForeground.h in Headers */ = {isa = PBXBuildFile; fileRef = 6760CA4DB840AF32CC8203EDECF6DB82 /* SPForeground.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		03880BB0EA934F4281A3991934957F76 /* SPSelfDescribingJson.m in Sources */ = {isa = PBXBuildFile; fileRef = 52ED3540F886045CC2336DCA44EFB336 /* SPSelfDescribingJson.m */; };
+		0492EF8D2CDD054A22AF01DA12B48E49 /* SPGlobalContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A7F308D60E7987B3663C0ABEE0D0948 /* SPGlobalContext.m */; };
+		081BAB1FA58194CE60099CA595A8D2DE /* SPEcommerceItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A089FAAF93751141812CC5F1278BB1D2 /* SPEcommerceItem.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		09D73D1365A539FD202E93AD6BD1DBA0 /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = EC6F529CE7B6623A7C01A659556981BE /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0BA275988B9317BC6765342DB53C5239 /* SNOWReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = A917ED154D38192D934F43595040BE73 /* SNOWReachability.m */; };
+		0F68587E8A33FDDA2D014BCDF7159522 /* SPRequestCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B1C9AE05A393F7431D2A8CC058819F /* SPRequestCallback.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		10A4200B86CD34D42FBB6D2C408B8760 /* SPWeakTimerTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 7299C777ACC18DE61D3DA53A0F66A597 /* SPWeakTimerTarget.m */; };
+		147849EFDF6F68D528363763CE97A0E9 /* SPEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF02A9364051926CBAAE70119F63E40 /* SPEventStore.m */; };
+		14C3FAE08CD744D72E71FE52B70F8736 /* SPStructured.h in Headers */ = {isa = PBXBuildFile; fileRef = EC39C1E160A54CEEFC952574BDB23522 /* SPStructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		14CDDF45837AD619D82ED7FC673326B5 /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = BA9C1DF037B68B7AD1B9588B0FC026B7 /* FMDB.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		14DCC754081F15CDC974D6B276C6696E /* SPSelfDescribingJson.m in Sources */ = {isa = PBXBuildFile; fileRef = 91E158CC66242C043B861CCCC6493CC4 /* SPSelfDescribingJson.m */; };
-		1674CD7BD0A8AA09DCA89D61DE29571D /* SPUnstructured.h in Headers */ = {isa = PBXBuildFile; fileRef = 46EE8A54D57A8B56B267A78815270041 /* SPUnstructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1A74E92AA9B44C350329926A705215FF /* Snowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = 43532480A83AE1848925BCEE4FB341C4 /* Snowplow.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1BD8B65C7FEF0109D22811AA0D6426BE /* SPScreenView.h in Headers */ = {isa = PBXBuildFile; fileRef = CBDDFA300BBAD1247EC28712110B3402 /* SPScreenView.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1C208381613D9B8CE432A80BAC34C5C7 /* SPTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 44FACA306C61D037F67E9EF006078242 /* SPTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1DC1DEF8AD8DC37D26942B2DE86AA90E /* SPEcommerceItem.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7F78E9A33D7DF6A490ECA73E288A8E /* SPEcommerceItem.m */; };
-		1F85204CF3F8178E0CAD35D1E601B971 /* SPUnstructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 769FCF91E1A238B36B2DEE5FB0E1D315 /* SPUnstructured.m */; };
-		1FB5AEDA5B1F25F2214CB03EC7697839 /* SPUnstructured.h in Headers */ = {isa = PBXBuildFile; fileRef = 46EE8A54D57A8B56B267A78815270041 /* SPUnstructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1FF7EFD332E71484C098FC696991BF8B /* SPTrackerEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CC017846EF50BE27A2B400024B3EA17 /* SPTrackerEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		21844DD3827D6ED4CB7A616F55C82326 /* SPSchemaRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 40A4D2F514C96192DA1B47D1E3822E28 /* SPSchemaRule.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		24FF5C083868E9A0DE6A9B602B1D0E46 /* SPEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 1106C9E0CA9017FEE46F568B2757BB42 /* SPEventStore.m */; };
+		17CE28AD1A6259CA25FF97552D029245 /* SPTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ECC74416B8A75A2D42F2453A8E7BAB5 /* SPTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1AEEE612C90F6233B4C5D7CB7D77878E /* UIViewController+SPScreenView_SWIZZLE.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E9E5730B8C63AB7E40E6358B7F4555A /* UIViewController+SPScreenView_SWIZZLE.m */; };
+		1B1999B71014A817C1593C58115425E5 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F7661C393326A03E023BD8799258610B /* SPTracker.m */; };
+		1BF34171DFD93278656E2B46D814E4B4 /* SPEcommerce.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B8C3A74C72ED43B650569CDB3DB365B /* SPEcommerce.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1F1DFF76DDC077EE1A6577131EDD2F11 /* SPTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ECC74416B8A75A2D42F2453A8E7BAB5 /* SPTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2260BB5AF18DD6F00F0102AD10059717 /* Snowplow.m in Sources */ = {isa = PBXBuildFile; fileRef = 58BEE0C6BA4B47975F16FD40372765ED /* Snowplow.m */; };
+		22AFA68FB3641EDE0CA7F8AF752DCB55 /* SPWeakTimerTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 299EBFEABA734CF515696BAB4509297B /* SPWeakTimerTarget.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		252E957D6510BA86E696B4A47845ED2F /* FMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 96B115927304BF776027CABE66A99EE1 /* FMDatabaseQueue.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2572D72496791FEDCCC201894864679D /* SPRequestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 745657B50904CF3D80604481D4FCC9D4 /* SPRequestResponse.m */; };
-		26F66A43855B524E2464803E2D3344FE /* OpenIDFA.h in Headers */ = {isa = PBXBuildFile; fileRef = 39172F96ADF63594CCC04B40F5125814 /* OpenIDFA.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		2A382926E356427588E3870C82BA8468 /* SPEcommerce.m in Sources */ = {isa = PBXBuildFile; fileRef = 3832DE3131E77A9F1A63A41E163A8E4D /* SPEcommerce.m */; };
-		2A7F38EFA30831CE3A17D6FE9BA258DA /* SNOWReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 7835C513F442CFDDFE4CF9E5412861F7 /* SNOWReachability.m */; };
+		26061DD8E8B41043853DEC9F747185F0 /* SPEventBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E628E00C41745C72D875839DFEC56B7 /* SPEventBase.m */; };
+		2732385C42EA171617CC44BB3A14BD04 /* SPUnstructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B65DD5DCCBD4F1B478E67D53AF2C3A /* SPUnstructured.m */; };
+		2A78957033F0385536B8525931F889CD /* SPPushNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 76F5CEA69167B444F958EEB76CB43C5B /* SPPushNotification.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		2AE6648B208555206F3FD14A8AD0DA45 /* FMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 96B115927304BF776027CABE66A99EE1 /* FMDatabaseQueue.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2CA4BE43FAD7344E1F7F4044F25A0A2F /* OpenIDFA.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FB8CF785F6FA7FAFA305738326DE2E /* OpenIDFA.m */; };
-		2D6F0DA0B274DC14BBBCA20C0809C41F /* SPGlobalContext.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA2AFFBFDA3F1D3640D144F3495ED31 /* SPGlobalContext.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		2E05E556BE848BAB4D986C28E8E9BDDF /* Pods-SnowplowSwiftWatch Extension-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CDA891F2116C5951C20FF3A3BB6EDEA /* Pods-SnowplowSwiftWatch Extension-dummy.m */; };
-		2E2078F99C644B6DCC43BE3006893AF5 /* SPConsentDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 04313E2F6ACF4851B1FDA1D00CBDEB4E /* SPConsentDocument.m */; };
-		30E0DB6FD2ACE99361D5511B58208562 /* SPSession.m in Sources */ = {isa = PBXBuildFile; fileRef = C41558F2CBF9D411CA5B3BC9613A84C7 /* SPSession.m */; };
-		31B8F7B8EE9418CA222EC831B05AFF3F /* SPTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = F63DBF8241A89E09E0941D9B9C89001A /* SPTiming.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2E6F07A7A5194C68FE29F87BBAD24470 /* SPSchemaRuleset.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F407BA6D65A4CAD586BB28F28B56D3 /* SPSchemaRuleset.m */; };
+		309E30E0A8304E432B82D4BD1BD73946 /* SPEcommerce.m in Sources */ = {isa = PBXBuildFile; fileRef = 47965AB43CA5DD176808B10D0719D325 /* SPEcommerce.m */; };
+		331A92B10A30B900C77026CA2C228C3C /* SPSchemaRuleset.h in Headers */ = {isa = PBXBuildFile; fileRef = A0061164AA43C66D391E339E38A4E3D8 /* SPSchemaRuleset.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		344E158543ABF68B7DD6D1E0DD7C77CC /* FMDB-watchOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4733F956ECE944F563BCFA581B85CF /* FMDB-watchOS-dummy.m */; };
+		345AAD61A74CCB13B2AB8E2F1C4879DD /* SPEcommerce.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B8C3A74C72ED43B650569CDB3DB365B /* SPEcommerce.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		34CE0106B08A1CF0D3F45B9D03BBABD2 /* SPConsentDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = E6448B48322141639D0DB1C6644974D8 /* SPConsentDocument.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		37721087B1B8EB3A47B56D68094242ED /* FMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 11A42E4E752DD44F0DD2AF9C167CE80C /* FMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		38BB6FA50E50BD0C939534AA71C25D54 /* SPConsentDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 04313E2F6ACF4851B1FDA1D00CBDEB4E /* SPConsentDocument.m */; };
-		39DDA5454E86498E1C214D19F40EBEA3 /* SPSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B682E957D9529D6F942A4B497906DA8 /* SPSession.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3A6007DFF23A3B6EA157DEDE47E9B38A /* SNOWError.m in Sources */ = {isa = PBXBuildFile; fileRef = 986B090505B17E5DBCC2C09D44E83C19 /* SNOWError.m */; };
-		3ABBD81BF9CDA4F5333350B2258D7B4A /* SNOWReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 27DF6985B123CE982C5FF7083241FC4E /* SNOWReachability.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3D86BC43E6BF41B1437E28DEEC6119D0 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA029DC645F5979559D41B6CFBE2A87 /* SPTracker.m */; };
+		39A5DAF09A48A5156CF72D0B38E06594 /* SPConsentGranted.h in Headers */ = {isa = PBXBuildFile; fileRef = 8956D62775F45D181461594B1BE9C213 /* SPConsentGranted.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		39E2BF95DF70177283D2B9C83C2B87F2 /* SPSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF190263B845069E56970CFA8E65A70 /* SPSession.m */; };
+		3CFF1C3151DDF442B90535CAFF7F0BDB /* SPRequestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 86318E25F86D5AAEBB39922EEF04E185 /* SPRequestResponse.m */; };
 		3DFCC6E5BC3299DE9EB41FBB8566FFBF /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9763D98E2E3FCCFA0F85EDE72A7EA0 /* FMDatabaseAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		3F618F6ACFB21154593CB39B9040B1D3 /* SPSchemaRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 149DDAF76D07D60E36809E04AE925E88 /* SPSchemaRule.m */; };
-		3F9A8CD951D5B1C284F75B26243DE06C /* SnowplowTracker-watchOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D8A3BD2A5233DEDC48F747FB6DF50E /* SnowplowTracker-watchOS-dummy.m */; };
-		41A883F77D8F8E84B2B295B307B984CF /* SPPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F4D78DCDE8045BCF5905C99BEDA89E4 /* SPPayload.m */; };
+		40823ABE6443EFD62E88D0516F5F98A3 /* SPSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D378A30AC0787B470454C06AEDEE2487 /* SPSubject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		409C551E3B8051FBA9E9C57D29E0FD26 /* SPUnstructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B65DD5DCCBD4F1B478E67D53AF2C3A /* SPUnstructured.m */; };
+		40B94ABC8B7F398009CC4539F4EE9AED /* SPPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C0E33FF697FB8E862C4727D67D6AB9 /* SPPayload.m */; };
+		41343463E50C875C65C86CA4A45A5FA9 /* SPForeground.m in Sources */ = {isa = PBXBuildFile; fileRef = B6241236EF99FCB2D3371EF0D8D9FAF3 /* SPForeground.m */; };
+		42EBCA5E5937841BAEB97FEEBB6A08EC /* SPGlobalContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A7F308D60E7987B3663C0ABEE0D0948 /* SPGlobalContext.m */; };
 		4335DF4C024AB554CF20CE1C50660E39 /* FMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 11A42E4E752DD44F0DD2AF9C167CE80C /* FMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4537983EF37237CE84E6AEA5FA203F98 /* SPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CE30BE47477BF1DA2685E202F4EABF6 /* SPUtilities.m */; };
-		468E3B9C705EF9463811CFEF98167E4A /* SPSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B682E957D9529D6F942A4B497906DA8 /* SPSession.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4693A29649993C0ED8E3EDC9CFB4E647 /* SPTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = F63DBF8241A89E09E0941D9B9C89001A /* SPTiming.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		47CBBD651375F160CD1B2C1910F0B55A /* SPWeakTimerTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 6033E0E2AB830295AA031DD289F038CF /* SPWeakTimerTarget.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		43D5D423F5A459A1266EAA587BD44FD8 /* SPTrackerEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDCA4A88F1CB33AA23D99BAD54A82D2 /* SPTrackerEvent.m */; };
+		447B8BB5F908D0A835CE1A640B07A0B0 /* SPEventStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 589819ADA8D09F0A2AC3CE4A2D6572BE /* SPEventStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		456EB769871E7B088ECBD299F1EE653E /* SPPushNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 76F5CEA69167B444F958EEB76CB43C5B /* SPPushNotification.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		45BD5D72CD7FCCEDC13A8C82D3B5EDDF /* SPConsentGranted.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6DB151902450771BE616AFC5AED50E /* SPConsentGranted.m */; };
+		465CA4E77E9441DEECCC2F95839440EF /* SPBackground.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A4913102F52A784E5AEC4E13ED1AF7F /* SPBackground.m */; };
+		470FB6F078C6D446176EA803AC3458F2 /* SPGdprContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B82E6854B154BE7FC627115D305A03C1 /* SPGdprContext.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		4909B2708C4C49402E76874DA529F2E6 /* SPScreenState.h in Headers */ = {isa = PBXBuildFile; fileRef = 8139BD0316B68878E1C37F657199EE79 /* SPScreenState.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		4955C9144BD757A9B96C0E2E7975A548 /* FMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 460BF5B58AE5C9FDC86F4B7C4477CB0E /* FMDatabaseQueue.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		4965714F7D4C889C89AEE929666286E7 /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F6FCB618A922A24FC0963518F544335 /* FMResultSet.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4B546680F2EF7079F63B96023DC4D631 /* SPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CE30BE47477BF1DA2685E202F4EABF6 /* SPUtilities.m */; };
-		4C7A91515902DB65623FD1B88D8D49D2 /* SPEventBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED919B0D2EF1DB556F287435B195D /* SPEventBase.m */; };
-		4CDC29764D44802F4F2B61FB05079E73 /* SPStructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 4724DB7994EC3F6BA4D430C39BADA8A5 /* SPStructured.m */; };
-		4CF981D7C586EE5C41969E44D98E6AA8 /* SPBackground.m in Sources */ = {isa = PBXBuildFile; fileRef = E38FF48204A51BEEE9F5047251B5E189 /* SPBackground.m */; };
-		4D97A821780CC52198EBD06D49D6BEDF /* SPEventBase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E911136B08DB79D86AFEE4D26C2003 /* SPEventBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4E377D1F62597AE5101B677629C19D43 /* SPEmitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 565C0C8DE9220F1279C67ACC6BA7D649 /* SPEmitter.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		500A883354CB4D3FB7B80AE512916017 /* SPConsentDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 4192C7B18424525CF1AE011D41F252F0 /* SPConsentDocument.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		52A082B412AB1D6CA34B6BF0E23B60DF /* SPWeakTimerTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 77FFA7F674FBFE3FA4FADFAFD808FEC5 /* SPWeakTimerTarget.m */; };
-		52E08E56C33670213FE4DEB1BED65CB2 /* SPEventBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED919B0D2EF1DB556F287435B195D /* SPEventBase.m */; };
-		54DF0C8CC16EB7C86C1DF70D4DFEB907 /* SPForeground.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D290CF7F927A5403A069A822AC52A0A /* SPForeground.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		56098A65FF35AB756B78FA9AF8DE6A8A /* OpenIDFA.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FB8CF785F6FA7FAFA305738326DE2E /* OpenIDFA.m */; };
-		561F6FC647479ECF2FDB0ABEFDDA9EDB /* SPScreenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F6049DC5E80A123DF22D865FCBAA89 /* SPScreenView.m */; };
+		4BD36CE0EF5F51D4460580668BF3401B /* SPForeground.h in Headers */ = {isa = PBXBuildFile; fileRef = 6760CA4DB840AF32CC8203EDECF6DB82 /* SPForeground.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		4E414739778DCC9C3600570D7335A5F3 /* SPScreenState.m in Sources */ = {isa = PBXBuildFile; fileRef = 79B0AC92B9C49E0D9236A1DBC81509E3 /* SPScreenState.m */; };
+		4EDAF9A5FFD1A2EED3FE5F56ED87E982 /* Snowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = A6D661A6F1A397C8CEB9D7B7092668C8 /* Snowplow.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		530AE57AD9F2DF3197681CB34580D0CC /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F7661C393326A03E023BD8799258610B /* SPTracker.m */; };
+		537CFCDCE720FD6687A98F6D704491D1 /* SnowplowTracker-watchOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 849F976616D2568A5EA2D35F331B2A2A /* SnowplowTracker-watchOS-dummy.m */; };
 		5767FE912579A60AE4AD9DF040FED3B0 /* FMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = EBB498F1F7FF6164DAE8B346AE0D4199 /* FMDatabasePool.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		5804A3D0156B0DD548A5986670ADADD9 /* SPEventStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C1BA24586CB32DFFE4924051133A0DA /* SPEventStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		59DB7BEAF35572802ACCE3620F456F56 /* SPWeakTimerTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 7299C777ACC18DE61D3DA53A0F66A597 /* SPWeakTimerTarget.m */; };
 		5A7883C5FF97A56FB3B61D6DDF4FE443 /* FMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 28D9414185480BCBFCF9562EAFD02900 /* FMResultSet.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5AA12245F7B55368878B902FE4E4DD22 /* SPTiming.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E1799F25FFE4791ABCD785FE2978B3E /* SPTiming.m */; };
-		5B3301841B26C90A9C7DB40913523DBA /* SPStructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 4724DB7994EC3F6BA4D430C39BADA8A5 /* SPStructured.m */; };
-		5B67B25AE176286A8B3393F20AEA6C3B /* SPGlobalContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BDF295946CA09F8B82FB788E9445912 /* SPGlobalContext.m */; };
-		5C297AC85AC443D6E4E0BA636C25AB8A /* SPSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 810549DF8E9DBAB9A7FF6B180B2904D3 /* SPSubject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5E02D55EF95F80053E7E902D50EDD2AB /* UIViewController+SPScreenView_SWIZZLE.h in Headers */ = {isa = PBXBuildFile; fileRef = CEE8308B2A7E8B74E25AE0AA9960BF09 /* UIViewController+SPScreenView_SWIZZLE.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		645D64047AC3433EB0F4A3A86D843E42 /* SPSchemaRuleset.h in Headers */ = {isa = PBXBuildFile; fileRef = BA87AE2FC7B65314C37E009CD86E9924 /* SPSchemaRuleset.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		654768DD38BC298825EEF608D1E962DE /* SPSchemaRuleset.h in Headers */ = {isa = PBXBuildFile; fileRef = BA87AE2FC7B65314C37E009CD86E9924 /* SPSchemaRuleset.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5C4ABF8E7FFBE26E3F4EFFF565E7836D /* SPPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 80D677A87A42371368BDBE93DB4A2D2D /* SPPayload.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5DEA56CA21AEF2914C233D6296D64648 /* SPConsentWithdrawn.m in Sources */ = {isa = PBXBuildFile; fileRef = C3D26EE8DD24B64B02E623901F411F79 /* SPConsentWithdrawn.m */; };
+		629D0821EAD457874CB340B2F4F2BEB0 /* SPGdprContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 574F3828DE7203FFD1E06E5473F1256C /* SPGdprContext.m */; };
+		631A91D3D9A88A4760FC110A44EE7247 /* Snowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = A6D661A6F1A397C8CEB9D7B7092668C8 /* Snowplow.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6457B7D9BDB4575DD43B3A3C663ADB94 /* SPConsentDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C595277E82C22545E33387462A565FD /* SPConsentDocument.m */; };
+		6527C4C884DA09418A4CD8C0EE30ABDF /* Snowplow-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 17B53433C3F99525322BA749574049B2 /* Snowplow-Bridging-Header.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		656227F4BB0D4AB3435D32FF0347741C /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2122444A3A19CF228037E51CC61F4E8A /* FMDatabase.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6574C5C44B04835092148EEAE71498DC /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA029DC645F5979559D41B6CFBE2A87 /* SPTracker.m */; };
-		65A715FA439EC5A863683E4E76640A3C /* SPPushNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 35299ECB5BEEC16542BFABA28DA3746B /* SPPushNotification.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		66AF63941A7B446E85C55D5B6435ADAF /* SPTrackerEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 593A7A7DE30E24D745A9E130BC87BB50 /* SPTrackerEvent.m */; };
-		67805F70395F9A34AA35F0F332054E6A /* SPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0F61C8C665D47D784FB693CD576124 /* SPUtilities.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		685E7B8C2B86867AAFDE2E5B3D288C0B /* SPConsentWithdrawn.m in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEE24AE48292728C3080205D44E3E /* SPConsentWithdrawn.m */; };
-		6A47749EC74BE019318A536DBD4195E6 /* SPConsentWithdrawn.h in Headers */ = {isa = PBXBuildFile; fileRef = B5641FC662515C92981B4D2D87536B7F /* SPConsentWithdrawn.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6BC2AAF62BA9293C06AE01BD87A579AA /* Snowplow-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCEBCF254803F8B1D6A1EFB812AF2DE /* Snowplow-Bridging-Header.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6C879AFDACC524203D565A8FC2236D1A /* SPPageView.h in Headers */ = {isa = PBXBuildFile; fileRef = A13686CA254E184281B8B38DEA5B9DB9 /* SPPageView.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6D8374B67DE82F584E049E8C3AD35E13 /* SPPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = CDAD2595891B82DB00A62091F137F33C /* SPPageView.m */; };
-		6FD835F8ABC7E01F378573E6B8BB4AC8 /* SPConsentGranted.h in Headers */ = {isa = PBXBuildFile; fileRef = 867CC28144D01136EA3AA29EF89F03F4 /* SPConsentGranted.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		7083CE9DF1840115A2E4617E22BB7041 /* SPConsentWithdrawn.h in Headers */ = {isa = PBXBuildFile; fileRef = B5641FC662515C92981B4D2D87536B7F /* SPConsentWithdrawn.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		72F491248C5C3628F8F91701A14C7FFF /* SPBackground.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B46DD8D463A393AE86640B6861743C2 /* SPBackground.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		742453BE8104349D648C244C82AADC4F /* SPPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F4D78DCDE8045BCF5905C99BEDA89E4 /* SPPayload.m */; };
-		74894A0CF17E7C6E302B3B3AEE153BC5 /* SPRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = FB986C2ABBC2679A4631EBD417305464 /* SPRequestResponse.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		77C32A3BC56F986E02B7FCE6C06C7DEC /* SPSchemaRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 149DDAF76D07D60E36809E04AE925E88 /* SPSchemaRule.m */; };
-		78038367C64C2C74B1BFFB7BB6AE217B /* SPStructured.h in Headers */ = {isa = PBXBuildFile; fileRef = A407E2616A51D86192A69C7C49846FB1 /* SPStructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		789B6C0413A923C6E54CF7A2AC0F6F77 /* SPForeground.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D4AC9791F0B97078BE8681D2F11BAF /* SPForeground.m */; };
-		7B73B37F5833893DAB5365B113439586 /* SPPushNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = EBFBE3EF2B858B7CC377F0CEF8CB6475 /* SPPushNotification.m */; };
+		6669D5EA23DC2651FC8ED6FF695649CC /* SPScreenState.h in Headers */ = {isa = PBXBuildFile; fileRef = 8139BD0316B68878E1C37F657199EE79 /* SPScreenState.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6760AF35AC08DD84C8059CEC3BC3CFDE /* SPTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E586F7251853D37DA094E2A98C39B75 /* SPTiming.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6B624B1628CFA53376D613A1A520E098 /* SPEcommerce.m in Sources */ = {isa = PBXBuildFile; fileRef = 47965AB43CA5DD176808B10D0719D325 /* SPEcommerce.m */; };
+		6C6815D915F21F52B9B078017D5DE765 /* SPSchemaRule.h in Headers */ = {isa = PBXBuildFile; fileRef = C084615DD0D603EEDC66CD91C4C2A281 /* SPSchemaRule.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6E12A8D2AA83A32F5E6E4A699B397933 /* SPPushNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 73443323F868E5DA2B742A867DC0E001 /* SPPushNotification.m */; };
+		6E755CA013B735066171E93D32D8F3DE /* SPEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = F28F8DE4370930DF884E6987C1CBBB03 /* SPEmitter.m */; };
+		6E8698DBB8EA592D5C08AEEBAF7B230A /* SPTiming.m in Sources */ = {isa = PBXBuildFile; fileRef = A541A077C592B269D1773A5167EB1BC8 /* SPTiming.m */; };
+		717A691330A232415E69480809245039 /* SPSchemaRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 60378FF3FBA3875362D001591445C68D /* SPSchemaRule.m */; };
+		74CDAD94C90F0BC6DE50865571631A5F /* SPEventBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E628E00C41745C72D875839DFEC56B7 /* SPEventBase.m */; };
+		785545731EDDD7725F2896DB8AA81968 /* SPScreenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CE6A0A45F17F0AB850C6F88152AB9AD /* SPScreenView.m */; };
+		7AA1D0658A58579D9FBBC7E704929D91 /* SPSelfDescribingJson.h in Headers */ = {isa = PBXBuildFile; fileRef = 105B4EF8F182DB70AE1F84A214F2FBC2 /* SPSelfDescribingJson.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7D17573C6741451F4EC489315985B73A /* SPRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = B2A725E0FFD2D2130A6C79F3DC0C5201 /* SPRequestResponse.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		7DD8E73614A6695AFE7D7CC069598C0C /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9763D98E2E3FCCFA0F85EDE72A7EA0 /* FMDatabaseAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		8030A0E9783011945F9B8AD4F6AA719A /* Snowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = 43532480A83AE1848925BCEE4FB341C4 /* Snowplow.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8039EE1CC9FCA6F783643EE72DDD55DF /* SPRequestCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 982B1DA7F0C2F6B661AFD6AE4D97CD02 /* SPRequestCallback.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		81AC80467309ABAFF87E15F1B4859248 /* SPEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0C55235CD5F960224B215D21672D66 /* SPEmitter.m */; };
-		83D5CA787370518F536D1AB81F5CF6F2 /* SPTrackerEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 593A7A7DE30E24D745A9E130BC87BB50 /* SPTrackerEvent.m */; };
-		85629B6CFF8C85999A257339CA66967A /* UIViewController+SPScreenView_SWIZZLE.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EECF815E28F507BFE57FF477D056E02 /* UIViewController+SPScreenView_SWIZZLE.m */; };
-		857E218F56C70683EDF32B0FCB987F1B /* SPBackground.m in Sources */ = {isa = PBXBuildFile; fileRef = E38FF48204A51BEEE9F5047251B5E189 /* SPBackground.m */; };
-		859F08C921C25E48A62118CBF31D3F09 /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 64E3792B805031B245A0845FAFC7CD0D /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7E144925513FAECA897844553095B4A4 /* SnowplowTracker-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 56918A4533313B573CB5F913FBFDDCC1 /* SnowplowTracker-iOS-dummy.m */; };
+		7E22ABAE23F3CB5E1BCA9AFC8AE371D9 /* SPGdprContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B82E6854B154BE7FC627115D305A03C1 /* SPGdprContext.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7F60DD094FDBC8041E02A2969D87874A /* SPTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E586F7251853D37DA094E2A98C39B75 /* SPTiming.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		84581985C8C81A1C7D90CC4EA2016010 /* SPInstallTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = E1645EF0125FE49639703C696EC3927A /* SPInstallTracker.m */; };
+		85ED0DCF67C1FC9C7DD2383E74A8107E /* SPConsentWithdrawn.m in Sources */ = {isa = PBXBuildFile; fileRef = C3D26EE8DD24B64B02E623901F411F79 /* SPConsentWithdrawn.m */; };
 		8680713AF29C66B068C5E7A09385B1FA /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2122444A3A19CF228037E51CC61F4E8A /* FMDatabase.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		89C60CD056B3F3CE6640B8F4B35289C5 /* SPPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 0418AC55F3AAD4E1439344BAC6DDA0B8 /* SPPayload.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8683D204FACD5FAAC3CE8A390928F1CA /* SPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D8F13539E14FAA8C4923C4F7A89EE9E /* SPUtilities.m */; };
+		887BEB86B8CBD2BF7E2400671B2D4135 /* SPSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF190263B845069E56970CFA8E65A70 /* SPSession.m */; };
+		894EC57FE3B0EBD9D19D40D5262E4281 /* SPPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 89B9ADAE8C0DB1CDD3D1A448A9C475F7 /* SPPageView.m */; };
+		8ADC2453400F286CD49F39A1E8E018CD /* SPUnstructured.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E88C576A06CC91126A4521E4BC29F4 /* SPUnstructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8B1F792504DEABD3ADB13AC2221F6276 /* SnowplowTracker-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 734CFF7A00B0AA3370FD7B2A9C710FE8 /* SnowplowTracker-iOS-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		8C9CA0FF4C96F036DA3C42E1A5DB358D /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = B19CD9406F5126230FCA0E2401D33525 /* FMDatabase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8D261F005F84447D6083CF7CBA40A698 /* SPEcommerceItem.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7F78E9A33D7DF6A490ECA73E288A8E /* SPEcommerceItem.m */; };
+		8D16F62DD09D0649D59E1714A44C1939 /* SPSchemaRule.h in Headers */ = {isa = PBXBuildFile; fileRef = C084615DD0D603EEDC66CD91C4C2A281 /* SPSchemaRule.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		8D7CAE7714EA0D2184956D70FEF2AF7D /* FMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 28D9414185480BCBFCF9562EAFD02900 /* FMResultSet.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		901115D2BAE58D90022CCA32A2AE0574 /* SPRequestCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 982B1DA7F0C2F6B661AFD6AE4D97CD02 /* SPRequestCallback.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		90B6AF735CEDBB22818BF0DB6ABCE6C8 /* SPGlobalContext.h in Headers */ = {isa = PBXBuildFile; fileRef = AEA2AFFBFDA3F1D3640D144F3495ED31 /* SPGlobalContext.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9322739DC4E3EFB2E7FFCE36FE06065F /* SNOWError.h in Headers */ = {isa = PBXBuildFile; fileRef = 33AB6E268A2BEA6E943A373C57E47E11 /* SNOWError.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		93A1433B0F45AD070D66F11A413FF9F5 /* SPWeakTimerTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 6033E0E2AB830295AA031DD289F038CF /* SPWeakTimerTarget.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		943F41C8B9D46ABC837916574BAE27D9 /* SPEventStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C1BA24586CB32DFFE4924051133A0DA /* SPEventStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8DD0DD439A42F472E2368F10F5AD79EF /* SPEventBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B6D31D9B20052337E90962E7D6062DB /* SPEventBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8EC9D32271EA5B28197908286500D2B8 /* SPSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = CB328B4B2C2C01482C1807A42FB15B57 /* SPSubject.m */; };
+		92874BC359278654A273EF8951147E1C /* SPPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = A0C0E33FF697FB8E862C4727D67D6AB9 /* SPPayload.m */; };
+		944A2129D92359A5B75FBDD852C7935F /* SPSession.h in Headers */ = {isa = PBXBuildFile; fileRef = A283F35361AE54E3A2013689CC50310B /* SPSession.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		959E1AA97F6D151112F6711D0ECF8862 /* SPStructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 66105F762C057AAAAB3F0081FEB78ACF /* SPStructured.m */; };
+		977997435B2DB253AD1BFB96F3C7ACE6 /* SPTrackerEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 76DF44300B420D13FF7F83A9BAA8666F /* SPTrackerEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		97A712E88C9B1310F6081A08BC42B3B7 /* SPEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF02A9364051926CBAAE70119F63E40 /* SPEventStore.m */; };
+		98C95D21A80C88C2CF44E89E7B5EDAAB /* SPGdprContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 574F3828DE7203FFD1E06E5473F1256C /* SPGdprContext.m */; };
+		999218F1B26E5010174306A0465FB879 /* OpenIDFA.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F10C3AAB07021C8B735773CBDEF0B68 /* OpenIDFA.m */; };
+		99C13209870BD343A0B626CAA58CDABB /* SPUnstructured.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E88C576A06CC91126A4521E4BC29F4 /* SPUnstructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9AFB55F8383C2F4FC248904A9ED35707 /* SPBackground.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BCB84DEC1824B596374DFE66A85A5DE /* SPBackground.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9B7E69DD92B3683F87D55C36D9448842 /* SPConsentDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = E6448B48322141639D0DB1C6644974D8 /* SPConsentDocument.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9DBD93831FB44044063DC799CDC34DA8 /* SPPageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 523ACA500BA48422E494D74FD6474F09 /* SPPageView.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		9E00E5EF4E68C426A7FDD1AA4CCF53F7 /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = BA9C1DF037B68B7AD1B9588B0FC026B7 /* FMDB.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9E2AA932E745B527BCC1A6EF8F4CB6C5 /* SPSchemaRuleset.h in Headers */ = {isa = PBXBuildFile; fileRef = A0061164AA43C66D391E339E38A4E3D8 /* SPSchemaRuleset.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		9EAAA42DB03B8AED892DE62A3E053E3F /* FMDB-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C94FC268661CB762D1FA9380D86BAA09 /* FMDB-iOS-dummy.m */; };
-		9F94CC5D2FB4BA6EB23D2911FA919423 /* SPTiming.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E1799F25FFE4791ABCD785FE2978B3E /* SPTiming.m */; };
+		9FE29F8364C2DD4BF7435C4F6A01EBE1 /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3861FC2B36778ED599F2CAA0F018F4 /* SPDevicePlatform.m */; };
 		A0FD08CA1EC21C3AEB21425AB6FC0BAA /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = B19CD9406F5126230FCA0E2401D33525 /* FMDatabase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A3B32F7E4305D2FF4D2C7AFB8E9723E0 /* SPEcommerce.h in Headers */ = {isa = PBXBuildFile; fileRef = 934C97D64B3A7FC38BADCDDD1611F44E /* SPEcommerce.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A499F9291BA8F55D83C23F9BA3E077C5 /* SPPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = CDAD2595891B82DB00A62091F137F33C /* SPPageView.m */; };
-		A6C654753CD0BC1091115E92545A6663 /* SPStructured.h in Headers */ = {isa = PBXBuildFile; fileRef = A407E2616A51D86192A69C7C49846FB1 /* SPStructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A7729227D63D60536FDFF9B8FF78DA8F /* SnowplowTracker-watchOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DABC2CC71C1AECC7804516E5015B7697 /* SnowplowTracker-watchOS-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		ACA1544E07C29C319D00603B93F6E472 /* SPPushNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = EBFBE3EF2B858B7CC377F0CEF8CB6475 /* SPPushNotification.m */; };
-		ADFC3E00FFF8B900B9E5751B2D9B72E9 /* SPConsentGranted.m in Sources */ = {isa = PBXBuildFile; fileRef = BB4C9B72D19D490925C531ECA3F891B5 /* SPConsentGranted.m */; };
-		AE8E7C0FDE70A3E2B4FCD95F2C60EE41 /* SPPageView.h in Headers */ = {isa = PBXBuildFile; fileRef = A13686CA254E184281B8B38DEA5B9DB9 /* SPPageView.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		AEE3982E05D6AB29F66D51A23B87A447 /* SPEcommerce.m in Sources */ = {isa = PBXBuildFile; fileRef = 3832DE3131E77A9F1A63A41E163A8E4D /* SPEcommerce.m */; };
-		B1D5869B75050E6BD309DF84384D0F03 /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = C3C0E6B7A30A76B4ADF1EEC29633BC81 /* SPDevicePlatform.m */; };
-		B2A8DB5116A1F863065CC91BF9BA8EF1 /* SPTrackerEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CC017846EF50BE27A2B400024B3EA17 /* SPTrackerEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B3D7698A7920233BCECE2E01F8E1904C /* SPEventBase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E911136B08DB79D86AFEE4D26C2003 /* SPEventBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B46097153E2E3F439231E6AE68994F3B /* SPRequestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 745657B50904CF3D80604481D4FCC9D4 /* SPRequestResponse.m */; };
-		B69C37375A1A130F1D5A093AA3A68272 /* SPSelfDescribingJson.m in Sources */ = {isa = PBXBuildFile; fileRef = 91E158CC66242C043B861CCCC6493CC4 /* SPSelfDescribingJson.m */; };
-		B922D57104F686B9A4983C510CBD02E2 /* SPSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = D32E81473609251379375F7B7236EC2E /* SPSubject.m */; };
+		A2B6C73CE0E0518E7100009ABC2CD9C6 /* SPPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 80D677A87A42371368BDBE93DB4A2D2D /* SPPayload.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A326E17D51114EF9BCDF8D30A49D3B74 /* SPForeground.m in Sources */ = {isa = PBXBuildFile; fileRef = B6241236EF99FCB2D3371EF0D8D9FAF3 /* SPForeground.m */; };
+		A81B90A652D6C47C908A3A077C92CCA9 /* SNOWError.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CD8ABC0E41075F5A538696E55CBF451 /* SNOWError.m */; };
+		A8836ABB6EB294E442C9C90F20A053CB /* SPWeakTimerTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 299EBFEABA734CF515696BAB4509297B /* SPWeakTimerTarget.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A97B3790432F8D6CDFDF869E7A813516 /* SPEventBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B6D31D9B20052337E90962E7D6062DB /* SPEventBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		ABD3610F7F4A039B98D854007FCD6E80 /* SPRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = B2A725E0FFD2D2130A6C79F3DC0C5201 /* SPRequestResponse.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		AC41360C0892B343538D579638CDCBE1 /* SPEventStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 589819ADA8D09F0A2AC3CE4A2D6572BE /* SPEventStore.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		AF1279714267CA62A9A04632AC187831 /* SPScreenView.h in Headers */ = {isa = PBXBuildFile; fileRef = CB45E31342B50AE10697CF45839DB909 /* SPScreenView.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		AF172FFD74F09DCA2E05ADE5C8AD74AF /* SPSelfDescribingJson.h in Headers */ = {isa = PBXBuildFile; fileRef = 105B4EF8F182DB70AE1F84A214F2FBC2 /* SPSelfDescribingJson.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B094716A30DDBBFCF4004EABBC95A156 /* SPConsentDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C595277E82C22545E33387462A565FD /* SPConsentDocument.m */; };
+		B297F05E322F395090ECAE4254D051D0 /* SPScreenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CE6A0A45F17F0AB850C6F88152AB9AD /* SPScreenView.m */; };
+		B4CB34A4FACF3BAA3E0B066AD31F83F6 /* SPSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = CB328B4B2C2C01482C1807A42FB15B57 /* SPSubject.m */; };
+		B56193F879CC89C7FBCCC23594BBA975 /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = EC6F529CE7B6623A7C01A659556981BE /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B6726B29BF4CE91DA90ACF29C4FC3AE4 /* SNOWError.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B7ECEE477EA523C178DD5BB91744232 /* SNOWError.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		BA166098CD5FFC1B6E9ACACBD7D19ED8 /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F6FCB618A922A24FC0963518F544335 /* FMResultSet.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		BBB1810E130C1C9E3998CBFEF4D11096 /* Snowplow-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCEBCF254803F8B1D6A1EFB812AF2DE /* Snowplow-Bridging-Header.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BC8211D579DD2176C17A64FEB391F95D /* SPEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 1106C9E0CA9017FEE46F568B2757BB42 /* SPEventStore.m */; };
-		BF3A7479C372DFE35C8D318084531A74 /* SPScreenState.h in Headers */ = {isa = PBXBuildFile; fileRef = E0E2D5B164F36963FF4E32B9F36684E4 /* SPScreenState.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C0C9F5B69F26892D22A3D90F252AA9EF /* SPScreenState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7299C7A56C7A35667D83719076A38D9F /* SPScreenState.m */; };
-		C1500EFADDB5CBC36CDD989ED9D0C015 /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = C3C0E6B7A30A76B4ADF1EEC29633BC81 /* SPDevicePlatform.m */; };
-		C2F13505BD764EF64B657CB2D72FEBBD /* SPEmitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 565C0C8DE9220F1279C67ACC6BA7D649 /* SPEmitter.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C3032354B606DF6B82FC3F51ACD4EFEB /* SPScreenView.h in Headers */ = {isa = PBXBuildFile; fileRef = CBDDFA300BBAD1247EC28712110B3402 /* SPScreenView.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C40ADD8451658DC13EE49F6478C5E3DD /* SPBackground.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B46DD8D463A393AE86640B6861743C2 /* SPBackground.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C5BA17ED194FCBF55D9839D9E553905B /* SPScreenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F6049DC5E80A123DF22D865FCBAA89 /* SPScreenView.m */; };
+		BB3E17FA39DA8FA848AB5B9AC1F65CEA /* SPStructured.h in Headers */ = {isa = PBXBuildFile; fileRef = EC39C1E160A54CEEFC952574BDB23522 /* SPStructured.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		BCC146B2D522388C89340320122BD185 /* SPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8722615B04D16E0D66613F3D018CAFE6 /* SPUtilities.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		BE2573D80C29440309C74ADE0681BCAB /* SPSelfDescribingJson.m in Sources */ = {isa = PBXBuildFile; fileRef = 52ED3540F886045CC2336DCA44EFB336 /* SPSelfDescribingJson.m */; };
+		BE87F37D7802873CCA13230B537358B3 /* SPEmitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E6301B5F3556EA2AD0D119A11905959 /* SPEmitter.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C32DE046F563502E06B60661C352EECD /* SPTrackerEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 76DF44300B420D13FF7F83A9BAA8666F /* SPTrackerEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C4174EE0AD42BEF8FF8C708B1789955D /* SPGlobalContext.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD72B3DE579561000C5260EE96EA642 /* SPGlobalContext.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C4278438BF6DB206C9B62AC52C53C6E1 /* SnowplowTracker-watchOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A7F7912D4B1FF42265D58CEDCB29A7E0 /* SnowplowTracker-watchOS-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C4B76157D4879569BC1DC4186BC1DA4D /* SPInstallTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = E1645EF0125FE49639703C696EC3927A /* SPInstallTracker.m */; };
 		C5ED4CAE6B70A84DAE1263307A1A5BEE /* Pods-SnowplowSwiftDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 94E5724D1D9B1B94855B7713519E0CDD /* Pods-SnowplowSwiftDemo-dummy.m */; };
-		C5F8E84B296D2A7F6BCAC95B40D46F8D /* SPTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 44FACA306C61D037F67E9EF006078242 /* SPTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C82B878763C9CDC1C81738A1C28B89B6 /* SPConsentGranted.h in Headers */ = {isa = PBXBuildFile; fileRef = 867CC28144D01136EA3AA29EF89F03F4 /* SPConsentGranted.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C60D092192882D3333598D3FC68C93E1 /* SPSchemaRuleset.m in Sources */ = {isa = PBXBuildFile; fileRef = 20F407BA6D65A4CAD586BB28F28B56D3 /* SPSchemaRuleset.m */; };
+		C71F5E6560B03B9451C5C75A99E7216C /* Snowplow.m in Sources */ = {isa = PBXBuildFile; fileRef = 58BEE0C6BA4B47975F16FD40372765ED /* Snowplow.m */; };
+		C9C0349D1BCBF7EB3CC0EF2F035E66DA /* SPEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A5A5DCC55BBA32D09D960244613674 /* SPEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CAC41337BF47CEB2C14EBF080F8DA130 /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = A9A5393454029F15A5B25C519A318742 /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		CC0780A0101A36E9A7B289606B6D2371 /* FMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = EBB498F1F7FF6164DAE8B346AE0D4199 /* FMDatabasePool.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CEA805BFA9A60672B6D6FEB85940CCD8 /* SPForeground.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D290CF7F927A5403A069A822AC52A0A /* SPForeground.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D29802B7F83B72679513CCF051A09626 /* Snowplow.m in Sources */ = {isa = PBXBuildFile; fileRef = 038EFFBE900AE3BB2033C28AB80FE32A /* Snowplow.m */; };
+		CD75D364545222D51DC2C4A8BA05E196 /* SPStructured.m in Sources */ = {isa = PBXBuildFile; fileRef = 66105F762C057AAAAB3F0081FEB78ACF /* SPStructured.m */; };
+		CE07082163FFAF27824C98FF619D0DA9 /* SPScreenView.h in Headers */ = {isa = PBXBuildFile; fileRef = CB45E31342B50AE10697CF45839DB909 /* SPScreenView.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D20DCC69B03EB63B42DBF7622C1C9023 /* SPTrackerEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDCA4A88F1CB33AA23D99BAD54A82D2 /* SPTrackerEvent.m */; };
 		D4269428B6BA9D7B867A06DDDC58DE38 /* FMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = A1FD0A1B7FF3CDA4BCD53ADDAB3AFCF3 /* FMDatabasePool.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D560B1139EEDC9C44E120538B1D6E5D7 /* SNOWError.h in Headers */ = {isa = PBXBuildFile; fileRef = 33AB6E268A2BEA6E943A373C57E47E11 /* SNOWError.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D6EA9323F0F7FEB2CA8D512345F07DD1 /* SPRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = FB986C2ABBC2679A4631EBD417305464 /* SPRequestResponse.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D8120049C0AEAE79D8BB3C8A70CC43D7 /* SPScreenState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7299C7A56C7A35667D83719076A38D9F /* SPScreenState.m */; };
-		D879F59F32A27E7918E5CAFBA5ECD58B /* SPSelfDescribingJson.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D126FC6A89BBD65EA039156C0C1B50 /* SPSelfDescribingJson.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D457B7C342FB0B72E4A1BF281F42A2DD /* SPPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 89B9ADAE8C0DB1CDD3D1A448A9C475F7 /* SPPageView.m */; };
+		D50629EDD16DA824056DE31EC2A8C15F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = A9A5393454029F15A5B25C519A318742 /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D5988F8E090DA58915835F8B4BF97033 /* SPConsentGranted.h in Headers */ = {isa = PBXBuildFile; fileRef = 8956D62775F45D181461594B1BE9C213 /* SPConsentGranted.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D5BD625EB88F70880CBE5EF0974C401C /* SPPushNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 73443323F868E5DA2B742A867DC0E001 /* SPPushNotification.m */; };
+		D73EDA6A4F7C0ACC02B0A81F92E8DC81 /* Snowplow-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 17B53433C3F99525322BA749574049B2 /* Snowplow-Bridging-Header.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		D8BC4E09D7E5BE66481EF68F457B034D /* FMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 460BF5B58AE5C9FDC86F4B7C4477CB0E /* FMDatabaseQueue.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DA498568B5DDDE5529F60E78893DFCCC /* SPPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 0418AC55F3AAD4E1439344BAC6DDA0B8 /* SPPayload.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DB63D5241F96625D13A9247D664896C2 /* SPWeakTimerTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 77FFA7F674FBFE3FA4FADFAFD808FEC5 /* SPWeakTimerTarget.m */; };
-		E2104606DCBEF70923AFA0F545E0DF83 /* SPSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = D32E81473609251379375F7B7236EC2E /* SPSubject.m */; };
-		E3007ACB08E06ED2D2645EBBF7D2E24D /* Snowplow.m in Sources */ = {isa = PBXBuildFile; fileRef = 038EFFBE900AE3BB2033C28AB80FE32A /* Snowplow.m */; };
-		E42A1D0A91D895CD1E890AC7CA28C3B0 /* SPPushNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 35299ECB5BEEC16542BFABA28DA3746B /* SPPushNotification.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		E64706D65115697CD7F98387FF38DB50 /* SnowplowTracker-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E05919F28927AD4CCAB75EBF5C2D50C /* SnowplowTracker-iOS-dummy.m */; };
-		E80E1E5976F69AA19E474A0C8328BA7C /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 44AF294AB2D274315CCA7281B782DB2E /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EA4784617F1F69487459AE2A191E5D62 /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 44AF294AB2D274315CCA7281B782DB2E /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EB4DD583E0C1AB33A69396E15B116FE8 /* SPInstallTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B2ED593B8A1D4B7AD53DE4F488DFCF9E /* SPInstallTracker.m */; };
+		D8F3C4C3C0F33D5EB446F944F79D40E2 /* OpenIDFA.h in Headers */ = {isa = PBXBuildFile; fileRef = F25D6749607EEEAD973316DA225F9876 /* OpenIDFA.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		DB3344AD5A8B680F6E3B7808F5DA8D24 /* SPEcommerceItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 22BF1D6FED46E4E0BEBE8777265AF012 /* SPEcommerceItem.m */; };
+		DB53B8461D20DF0F6206ED88966E98D0 /* SPPageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 523ACA500BA48422E494D74FD6474F09 /* SPPageView.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		DD467FEDCA3D727A758EF8B0C166D3D3 /* SNOWError.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B7ECEE477EA523C178DD5BB91744232 /* SNOWError.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E152F1D6495895E7D009851ED693E8DC /* SPRequestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 86318E25F86D5AAEBB39922EEF04E185 /* SPRequestResponse.m */; };
+		E192D89E7C6DC46DC7460AFADB078BF6 /* SPEcommerceItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A089FAAF93751141812CC5F1278BB1D2 /* SPEcommerceItem.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E245BE72BDA4C12CAAC4DD7E12307A5C /* OpenIDFA.h in Headers */ = {isa = PBXBuildFile; fileRef = F25D6749607EEEAD973316DA225F9876 /* OpenIDFA.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E41B8248A174D5B1483459491027BDC3 /* SPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D8F13539E14FAA8C4923C4F7A89EE9E /* SPUtilities.m */; };
+		E5850B23BA075BC53EE611318A1D6DFF /* SNOWReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 07F07861181A90BE22D1B5F6DD551589 /* SNOWReachability.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E863D1FCE2FD31CABBB4752D6E3EF998 /* SPEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = A6A5A5DCC55BBA32D09D960244613674 /* SPEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E891E7C5E43AFF37DF7A2B5E9EA58911 /* SPBackground.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A4913102F52A784E5AEC4E13ED1AF7F /* SPBackground.m */; };
+		E9A10E88058E878F01B38236CF9CFE80 /* SPSchemaRule.m in Sources */ = {isa = PBXBuildFile; fileRef = 60378FF3FBA3875362D001591445C68D /* SPSchemaRule.m */; };
+		EB296C39D03215EB28B3C50E24D609B6 /* SPBackground.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BCB84DEC1824B596374DFE66A85A5DE /* SPBackground.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EB356B1B84BBB2A0202E419A9F928FFF /* SNOWError.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CD8ABC0E41075F5A538696E55CBF451 /* SNOWError.m */; };
+		EC44F6FB47141E3A58027A05D82A988C /* SPEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = F28F8DE4370930DF884E6987C1CBBB03 /* SPEmitter.m */; };
 		ED472FC977FC446347F07E88D1681169 /* FMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = A1FD0A1B7FF3CDA4BCD53ADDAB3AFCF3 /* FMDatabasePool.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EE01BE751EC04F9017249BD15FE236FB /* SPSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 810549DF8E9DBAB9A7FF6B180B2904D3 /* SPSubject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EE63CB46D2C6D52955D3CA7FEA2CB8DE /* SPEcommerce.h in Headers */ = {isa = PBXBuildFile; fileRef = 934C97D64B3A7FC38BADCDDD1611F44E /* SPEcommerce.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EFC260742563B511CB6AAA67EDEC2472 /* SnowplowTracker-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8046A473110921411EAD2261F5FAC01E /* SnowplowTracker-iOS-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F1DDBECB30FD7AF156D7B39F0CF9E479 /* SPConsentGranted.m in Sources */ = {isa = PBXBuildFile; fileRef = BB4C9B72D19D490925C531ECA3F891B5 /* SPConsentGranted.m */; };
-		F2A862BF0EF4F8D072220B2601492E31 /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 64E3792B805031B245A0845FAFC7CD0D /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F3615D1D3B18CFAC9780AF5CCFE53531 /* SPSchemaRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 40A4D2F514C96192DA1B47D1E3822E28 /* SPSchemaRule.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F458236CC48A949994386AA4FAB9B05D /* SPSchemaRuleset.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F3DC20A37516AE4C270DD60432ED99A /* SPSchemaRuleset.m */; };
-		F4B6C6ABC456E3CB884C65629ACC0B79 /* SPSchemaRuleset.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F3DC20A37516AE4C270DD60432ED99A /* SPSchemaRuleset.m */; };
-		FB2EE06EA74A73F93FE7CB5BCF165042 /* SPInstallTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B2ED593B8A1D4B7AD53DE4F488DFCF9E /* SPInstallTracker.m */; };
-		FBFF3B9818C00AB5D8FD0C2FC1F37692 /* SNOWError.m in Sources */ = {isa = PBXBuildFile; fileRef = 986B090505B17E5DBCC2C09D44E83C19 /* SNOWError.m */; };
-		FC6F0C8FFB9FA1DFC6E1BCF529B417F9 /* SPEcommerceItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D818E2659D0104BB846CC4AAA2586C /* SPEcommerceItem.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		FD15AB49C4CFA5270E5B0E4D705DB2C4 /* SPEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCE732A246430537539367A91CEF663 /* SPEvent.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		FD2FF3DAE35AB42F607D266466BC3EF0 /* SPEcommerceItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D818E2659D0104BB846CC4AAA2586C /* SPEcommerceItem.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		FDDCF01617E4F73727F9F1703D47771D /* SPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0F61C8C665D47D784FB693CD576124 /* SPUtilities.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EEC836E68009970B3F83EBF55357E558 /* SPConsentWithdrawn.h in Headers */ = {isa = PBXBuildFile; fileRef = 781FBAA8C23961DF2311470BDA79FE1A /* SPConsentWithdrawn.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EF0DF7A0DA773B640630D40669C93EC8 /* SPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8722615B04D16E0D66613F3D018CAFE6 /* SPUtilities.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F1382CC3DBBA2EB9FB58A6C5E90F7251 /* SPEmitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E6301B5F3556EA2AD0D119A11905959 /* SPEmitter.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F1668AE38EA7718B59360951F03200B7 /* SPScreenState.m in Sources */ = {isa = PBXBuildFile; fileRef = 79B0AC92B9C49E0D9236A1DBC81509E3 /* SPScreenState.m */; };
+		F28DDE4A0C96B9107F2EB89DA98723CA /* SPEcommerceItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 22BF1D6FED46E4E0BEBE8777265AF012 /* SPEcommerceItem.m */; };
+		F3D445B2E46176B7FE0730010D6D7435 /* SPTiming.m in Sources */ = {isa = PBXBuildFile; fileRef = A541A077C592B269D1773A5167EB1BC8 /* SPTiming.m */; };
+		F43DC99363B7FAA5FCBCEB4D060AE5D4 /* SPConsentGranted.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6DB151902450771BE616AFC5AED50E /* SPConsentGranted.m */; };
+		F5DD1EB9E7B9B112F80AE885C72F194D /* OpenIDFA.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F10C3AAB07021C8B735773CBDEF0B68 /* OpenIDFA.m */; };
+		F8233ED777E4B5703F24E102F3CF8CF1 /* SPConsentWithdrawn.h in Headers */ = {isa = PBXBuildFile; fileRef = 781FBAA8C23961DF2311470BDA79FE1A /* SPConsentWithdrawn.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F86672CF7C4CEEDF04236C886BC1BBB9 /* SPSession.h in Headers */ = {isa = PBXBuildFile; fileRef = A283F35361AE54E3A2013689CC50310B /* SPSession.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F9BED15A1378720BE4E3151E29A94E13 /* SPRequestCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B1C9AE05A393F7431D2A8CC058819F /* SPRequestCallback.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FB0012A88633462604CB38B5EA8D3BB8 /* SPSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D378A30AC0787B470454C06AEDEE2487 /* SPSubject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FC777AB3EF0DB2B00D3F58A1159CA00F /* SPDevicePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3861FC2B36778ED599F2CAA0F018F4 /* SPDevicePlatform.m */; };
+		FDF37946C94A8595552FD4A5CA15C29C /* UIViewController+SPScreenView_SWIZZLE.h in Headers */ = {isa = PBXBuildFile; fileRef = 76362E814024CE05CD69328DE4F26507 /* UIViewController+SPScreenView_SWIZZLE.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FF4BCE037042F9035B091BADA6A47FA9 /* SPGlobalContext.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD72B3DE579561000C5260EE96EA642 /* SPGlobalContext.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		1634672C88F6D03900F3A248EC3BC48E /* PBXContainerItemProxy */ = {
+		03B1384583D93A89EE0A9136455CBBAC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 09D8936C24020EE35FD4BBC3796A95DB;
 			remoteInfo = "FMDB-watchOS";
 		};
-		28E012D10EDC545880A50928AFF56994 /* PBXContainerItemProxy */ = {
+		1EF338902947B4F3B19044861F472122 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 3FDEFF0D795E620F69126992BD6EFE0C;
 			remoteInfo = "FMDB-iOS";
 		};
-		36C6770EF8562827155BC9B3D790A63C /* PBXContainerItemProxy */ = {
+		28E012D10EDC545880A50928AFF56994 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
@@ -231,127 +235,129 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		038EFFBE900AE3BB2033C28AB80FE32A /* Snowplow.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = Snowplow.m; path = Snowplow/Snowplow.m; sourceTree = "<group>"; };
-		0418AC55F3AAD4E1439344BAC6DDA0B8 /* SPPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPPayload.h; path = Snowplow/SPPayload.h; sourceTree = "<group>"; };
-		04313E2F6ACF4851B1FDA1D00CBDEB4E /* SPConsentDocument.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPConsentDocument.m; sourceTree = "<group>"; };
+		01558289857AA3EFEE9CA85709FDAA0D /* SnowplowTracker.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = SnowplowTracker.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		062209C6B025C421F5055877C0DA7F5C /* Pods-SnowplowSwiftDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnowplowSwiftDemo-acknowledgements.plist"; sourceTree = "<group>"; };
 		062584DCD796EBB320349214997232E8 /* FMDB-watchOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "FMDB-watchOS.xcconfig"; path = "../FMDB-watchOS/FMDB-watchOS.xcconfig"; sourceTree = "<group>"; };
-		0BD4900F50D91416AC99D51EE4BC03F3 /* SnowplowTracker-watchOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "SnowplowTracker-watchOS.xcconfig"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS.xcconfig"; sourceTree = "<group>"; };
+		07B65DD5DCCBD4F1B478E67D53AF2C3A /* SPUnstructured.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPUnstructured.m; sourceTree = "<group>"; };
+		07F07861181A90BE22D1B5F6DD551589 /* SNOWReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SNOWReachability.h; path = Snowplow/SNOWReachability.h; sourceTree = "<group>"; };
+		0BF190263B845069E56970CFA8E65A70 /* SPSession.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPSession.m; path = Snowplow/SPSession.m; sourceTree = "<group>"; };
+		0C595277E82C22545E33387462A565FD /* SPConsentDocument.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPConsentDocument.m; sourceTree = "<group>"; };
 		0EE5F41DD3ACCDE1D6EB5031C5810222 /* Pods-SnowplowSwiftWatch Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnowplowSwiftWatch Extension.release.xcconfig"; sourceTree = "<group>"; };
-		0F711317B693152F4D975687F01CA266 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		1106C9E0CA9017FEE46F568B2757BB42 /* SPEventStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPEventStore.m; path = Snowplow/SPEventStore.m; sourceTree = "<group>"; };
+		105B4EF8F182DB70AE1F84A214F2FBC2 /* SPSelfDescribingJson.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPSelfDescribingJson.h; path = Snowplow/SPSelfDescribingJson.h; sourceTree = "<group>"; };
 		11A42E4E752DD44F0DD2AF9C167CE80C /* FMDatabaseAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FMDatabaseAdditions.h; path = src/fmdb/FMDatabaseAdditions.h; sourceTree = "<group>"; };
-		149DDAF76D07D60E36809E04AE925E88 /* SPSchemaRule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPSchemaRule.m; sourceTree = "<group>"; };
+		17B53433C3F99525322BA749574049B2 /* Snowplow-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Snowplow-Bridging-Header.h"; path = "Snowplow/Snowplow-Bridging-Header.h"; sourceTree = "<group>"; };
 		198C5F66B3D419404182CFCF310550D7 /* Pods-SnowplowSwiftWatch Extension-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SnowplowSwiftWatch Extension-acknowledgements.plist"; sourceTree = "<group>"; };
-		1B682E957D9529D6F942A4B497906DA8 /* SPSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPSession.h; path = Snowplow/SPSession.h; sourceTree = "<group>"; };
+		1B8C3A74C72ED43B650569CDB3DB365B /* SPEcommerce.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEcommerce.h; sourceTree = "<group>"; };
 		1CDA891F2116C5951C20FF3A3BB6EDEA /* Pods-SnowplowSwiftWatch Extension-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnowplowSwiftWatch Extension-dummy.m"; sourceTree = "<group>"; };
-		1F0C55235CD5F960224B215D21672D66 /* SPEmitter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPEmitter.m; path = Snowplow/SPEmitter.m; sourceTree = "<group>"; };
+		1F10C3AAB07021C8B735773CBDEF0B68 /* OpenIDFA.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OpenIDFA.m; path = Snowplow/OpenIDFA.m; sourceTree = "<group>"; };
 		1F6FCB618A922A24FC0963518F544335 /* FMResultSet.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMResultSet.m; path = src/fmdb/FMResultSet.m; sourceTree = "<group>"; };
-		20F6049DC5E80A123DF22D865FCBAA89 /* SPScreenView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPScreenView.m; sourceTree = "<group>"; };
+		20F407BA6D65A4CAD586BB28F28B56D3 /* SPSchemaRuleset.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPSchemaRuleset.m; sourceTree = "<group>"; };
 		2122444A3A19CF228037E51CC61F4E8A /* FMDatabase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMDatabase.m; path = src/fmdb/FMDatabase.m; sourceTree = "<group>"; };
-		278364C32FF24E6B784FCFDB8E67A606 /* SnowplowTracker-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnowplowTracker-iOS-prefix.pch"; sourceTree = "<group>"; };
-		27DF6985B123CE982C5FF7083241FC4E /* SNOWReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SNOWReachability.h; path = Snowplow/SNOWReachability.h; sourceTree = "<group>"; };
+		22BF1D6FED46E4E0BEBE8777265AF012 /* SPEcommerceItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPEcommerceItem.m; sourceTree = "<group>"; };
 		28D9414185480BCBFCF9562EAFD02900 /* FMResultSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FMResultSet.h; path = src/fmdb/FMResultSet.h; sourceTree = "<group>"; };
 		29409DC311CC1ECE9A2E8281409EDEDB /* Pods-SnowplowSwiftDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnowplowSwiftDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
-		2C1BA24586CB32DFFE4924051133A0DA /* SPEventStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPEventStore.h; path = Snowplow/SPEventStore.h; sourceTree = "<group>"; };
-		2E1799F25FFE4791ABCD785FE2978B3E /* SPTiming.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPTiming.m; sourceTree = "<group>"; };
-		33AB6E268A2BEA6E943A373C57E47E11 /* SNOWError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SNOWError.h; sourceTree = "<group>"; };
-		35299ECB5BEEC16542BFABA28DA3746B /* SPPushNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPPushNotification.h; sourceTree = "<group>"; };
-		37FB8CF785F6FA7FAFA305738326DE2E /* OpenIDFA.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OpenIDFA.m; path = Snowplow/OpenIDFA.m; sourceTree = "<group>"; };
-		3832DE3131E77A9F1A63A41E163A8E4D /* SPEcommerce.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPEcommerce.m; sourceTree = "<group>"; };
+		299EBFEABA734CF515696BAB4509297B /* SPWeakTimerTarget.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPWeakTimerTarget.h; path = Snowplow/SPWeakTimerTarget.h; sourceTree = "<group>"; };
+		2CE6A0A45F17F0AB850C6F88152AB9AD /* SPScreenView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPScreenView.m; sourceTree = "<group>"; };
+		2E586F7251853D37DA094E2A98C39B75 /* SPTiming.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPTiming.h; sourceTree = "<group>"; };
+		2E628E00C41745C72D875839DFEC56B7 /* SPEventBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPEventBase.m; sourceTree = "<group>"; };
+		2E6301B5F3556EA2AD0D119A11905959 /* SPEmitter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPEmitter.h; path = Snowplow/SPEmitter.h; sourceTree = "<group>"; };
+		32A2BBE5AC07A1C9AF6F70BE0A877CB1 /* SnowplowTracker-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "SnowplowTracker-iOS.modulemap"; sourceTree = "<group>"; };
 		388E16DFC440BB70AE5BD4C8927D3C13 /* FMDB-watchOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "FMDB-watchOS-prefix.pch"; path = "../FMDB-watchOS/FMDB-watchOS-prefix.pch"; sourceTree = "<group>"; };
-		39172F96ADF63594CCC04B40F5125814 /* OpenIDFA.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OpenIDFA.h; path = Snowplow/OpenIDFA.h; sourceTree = "<group>"; };
-		3B46DD8D463A393AE86640B6861743C2 /* SPBackground.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPBackground.h; sourceTree = "<group>"; };
-		3CC017846EF50BE27A2B400024B3EA17 /* SPTrackerEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPTrackerEvent.h; sourceTree = "<group>"; };
-		3E05919F28927AD4CCAB75EBF5C2D50C /* SnowplowTracker-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SnowplowTracker-iOS-dummy.m"; sourceTree = "<group>"; };
-		40A4D2F514C96192DA1B47D1E3822E28 /* SPSchemaRule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPSchemaRule.h; sourceTree = "<group>"; };
-		4192C7B18424525CF1AE011D41F252F0 /* SPConsentDocument.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPConsentDocument.h; sourceTree = "<group>"; };
-		43532480A83AE1848925BCEE4FB341C4 /* Snowplow.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Snowplow.h; path = Snowplow/Snowplow.h; sourceTree = "<group>"; };
-		44AF294AB2D274315CCA7281B782DB2E /* SPInstallTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPInstallTracker.h; path = Snowplow/SPInstallTracker.h; sourceTree = "<group>"; };
-		44FACA306C61D037F67E9EF006078242 /* SPTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTracker.h; path = Snowplow/SPTracker.h; sourceTree = "<group>"; };
+		3B6D31D9B20052337E90962E7D6062DB /* SPEventBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEventBase.h; sourceTree = "<group>"; };
 		460BF5B58AE5C9FDC86F4B7C4477CB0E /* FMDatabaseQueue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FMDatabaseQueue.h; path = src/fmdb/FMDatabaseQueue.h; sourceTree = "<group>"; };
-		46EE8A54D57A8B56B267A78815270041 /* SPUnstructured.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPUnstructured.h; sourceTree = "<group>"; };
-		4724DB7994EC3F6BA4D430C39BADA8A5 /* SPStructured.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPStructured.m; sourceTree = "<group>"; };
-		565C0C8DE9220F1279C67ACC6BA7D649 /* SPEmitter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPEmitter.h; path = Snowplow/SPEmitter.h; sourceTree = "<group>"; };
-		593A7A7DE30E24D745A9E130BC87BB50 /* SPTrackerEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPTrackerEvent.m; sourceTree = "<group>"; };
-		6033E0E2AB830295AA031DD289F038CF /* SPWeakTimerTarget.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPWeakTimerTarget.h; path = Snowplow/SPWeakTimerTarget.h; sourceTree = "<group>"; };
+		47965AB43CA5DD176808B10D0719D325 /* SPEcommerce.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPEcommerce.m; sourceTree = "<group>"; };
+		4B7ECEE477EA523C178DD5BB91744232 /* SNOWError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SNOWError.h; sourceTree = "<group>"; };
+		51B1C9AE05A393F7431D2A8CC058819F /* SPRequestCallback.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPRequestCallback.h; path = Snowplow/SPRequestCallback.h; sourceTree = "<group>"; };
+		523ACA500BA48422E494D74FD6474F09 /* SPPageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPPageView.h; sourceTree = "<group>"; };
+		52ED3540F886045CC2336DCA44EFB336 /* SPSelfDescribingJson.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPSelfDescribingJson.m; path = Snowplow/SPSelfDescribingJson.m; sourceTree = "<group>"; };
+		5588E7BB041A9EA09EE3C7D9F5BDB3D5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		56918A4533313B573CB5F913FBFDDCC1 /* SnowplowTracker-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SnowplowTracker-iOS-dummy.m"; sourceTree = "<group>"; };
+		574F3828DE7203FFD1E06E5473F1256C /* SPGdprContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPGdprContext.m; path = Snowplow/SPGdprContext.m; sourceTree = "<group>"; };
+		589819ADA8D09F0A2AC3CE4A2D6572BE /* SPEventStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPEventStore.h; path = Snowplow/SPEventStore.h; sourceTree = "<group>"; };
+		58BEE0C6BA4B47975F16FD40372765ED /* Snowplow.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = Snowplow.m; path = Snowplow/Snowplow.m; sourceTree = "<group>"; };
+		5A6DB151902450771BE616AFC5AED50E /* SPConsentGranted.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPConsentGranted.m; sourceTree = "<group>"; };
+		5A7F308D60E7987B3663C0ABEE0D0948 /* SPGlobalContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPGlobalContext.m; sourceTree = "<group>"; };
+		5AF02A9364051926CBAAE70119F63E40 /* SPEventStore.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPEventStore.m; path = Snowplow/SPEventStore.m; sourceTree = "<group>"; };
+		5C83F86A5A8E5023EE30965BF13BF1EB /* SnowplowTracker-watchOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "SnowplowTracker-watchOS-prefix.pch"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS-prefix.pch"; sourceTree = "<group>"; };
+		5CD8ABC0E41075F5A538696E55CBF451 /* SNOWError.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SNOWError.m; sourceTree = "<group>"; };
+		60378FF3FBA3875362D001591445C68D /* SPSchemaRule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPSchemaRule.m; sourceTree = "<group>"; };
 		623A93F13EA425E16BD69F79729C42DB /* libFMDB-watchOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libFMDB-watchOS.a"; path = "libFMDB-watchOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		64E3792B805031B245A0845FAFC7CD0D /* SPDevicePlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPDevicePlatform.h; path = Snowplow/SPDevicePlatform.h; sourceTree = "<group>"; };
-		67AB30063E87F11139501023838774ED /* SnowplowTracker-watchOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "SnowplowTracker-watchOS.modulemap"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS.modulemap"; sourceTree = "<group>"; };
-		68900E73F8FECBA07B2955B24043241F /* SnowplowTracker-watchOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "SnowplowTracker-watchOS-prefix.pch"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS-prefix.pch"; sourceTree = "<group>"; };
-		6BDF295946CA09F8B82FB788E9445912 /* SPGlobalContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPGlobalContext.m; sourceTree = "<group>"; };
-		6D290CF7F927A5403A069A822AC52A0A /* SPForeground.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPForeground.h; sourceTree = "<group>"; };
-		6D3587CF7E96B8D5032B822CB608A9AC /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		6EECF815E28F507BFE57FF477D056E02 /* UIViewController+SPScreenView_SWIZZLE.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+SPScreenView_SWIZZLE.m"; path = "Snowplow/UIViewController+SPScreenView_SWIZZLE.m"; sourceTree = "<group>"; };
-		7299C7A56C7A35667D83719076A38D9F /* SPScreenState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPScreenState.m; path = Snowplow/SPScreenState.m; sourceTree = "<group>"; };
-		72FED919B0D2EF1DB556F287435B195D /* SPEventBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPEventBase.m; sourceTree = "<group>"; };
-		745657B50904CF3D80604481D4FCC9D4 /* SPRequestResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPRequestResponse.m; path = Snowplow/SPRequestResponse.m; sourceTree = "<group>"; };
-		769FCF91E1A238B36B2DEE5FB0E1D315 /* SPUnstructured.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPUnstructured.m; sourceTree = "<group>"; };
-		77D4AC9791F0B97078BE8681D2F11BAF /* SPForeground.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPForeground.m; sourceTree = "<group>"; };
-		77D8A3BD2A5233DEDC48F747FB6DF50E /* SnowplowTracker-watchOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "SnowplowTracker-watchOS-dummy.m"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS-dummy.m"; sourceTree = "<group>"; };
-		77FFA7F674FBFE3FA4FADFAFD808FEC5 /* SPWeakTimerTarget.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPWeakTimerTarget.m; path = Snowplow/SPWeakTimerTarget.m; sourceTree = "<group>"; };
-		7835C513F442CFDDFE4CF9E5412861F7 /* SNOWReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SNOWReachability.m; path = Snowplow/SNOWReachability.m; sourceTree = "<group>"; };
+		62E88C576A06CC91126A4521E4BC29F4 /* SPUnstructured.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPUnstructured.h; sourceTree = "<group>"; };
+		66105F762C057AAAAB3F0081FEB78ACF /* SPStructured.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPStructured.m; sourceTree = "<group>"; };
+		6760CA4DB840AF32CC8203EDECF6DB82 /* SPForeground.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPForeground.h; sourceTree = "<group>"; };
+		6A4913102F52A784E5AEC4E13ED1AF7F /* SPBackground.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPBackground.m; sourceTree = "<group>"; };
+		7299C777ACC18DE61D3DA53A0F66A597 /* SPWeakTimerTarget.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPWeakTimerTarget.m; path = Snowplow/SPWeakTimerTarget.m; sourceTree = "<group>"; };
+		73443323F868E5DA2B742A867DC0E001 /* SPPushNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPPushNotification.m; sourceTree = "<group>"; };
+		734CFF7A00B0AA3370FD7B2A9C710FE8 /* SnowplowTracker-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnowplowTracker-iOS-umbrella.h"; sourceTree = "<group>"; };
+		76362E814024CE05CD69328DE4F26507 /* UIViewController+SPScreenView_SWIZZLE.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+SPScreenView_SWIZZLE.h"; path = "Snowplow/UIViewController+SPScreenView_SWIZZLE.h"; sourceTree = "<group>"; };
+		76DF44300B420D13FF7F83A9BAA8666F /* SPTrackerEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPTrackerEvent.h; sourceTree = "<group>"; };
+		76F5CEA69167B444F958EEB76CB43C5B /* SPPushNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPPushNotification.h; sourceTree = "<group>"; };
+		781FBAA8C23961DF2311470BDA79FE1A /* SPConsentWithdrawn.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPConsentWithdrawn.h; sourceTree = "<group>"; };
 		797ACF2C22338F2141DB858EF48F4CA8 /* FMDB-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FMDB-iOS-prefix.pch"; sourceTree = "<group>"; };
-		7A405EE4B6FFAC277CF7889DD810719E /* SnowplowTracker.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = SnowplowTracker.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		8046A473110921411EAD2261F5FAC01E /* SnowplowTracker-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnowplowTracker-iOS-umbrella.h"; sourceTree = "<group>"; };
-		810549DF8E9DBAB9A7FF6B180B2904D3 /* SPSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPSubject.h; path = Snowplow/SPSubject.h; sourceTree = "<group>"; };
-		867CC28144D01136EA3AA29EF89F03F4 /* SPConsentGranted.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPConsentGranted.h; sourceTree = "<group>"; };
-		8BCEBCF254803F8B1D6A1EFB812AF2DE /* Snowplow-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Snowplow-Bridging-Header.h"; path = "Snowplow/Snowplow-Bridging-Header.h"; sourceTree = "<group>"; };
+		79B0AC92B9C49E0D9236A1DBC81509E3 /* SPScreenState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPScreenState.m; path = Snowplow/SPScreenState.m; sourceTree = "<group>"; };
+		7BCB84DEC1824B596374DFE66A85A5DE /* SPBackground.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPBackground.h; sourceTree = "<group>"; };
+		7D8F13539E14FAA8C4923C4F7A89EE9E /* SPUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPUtilities.m; path = Snowplow/SPUtilities.m; sourceTree = "<group>"; };
+		7ECC74416B8A75A2D42F2453A8E7BAB5 /* SPTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTracker.h; path = Snowplow/SPTracker.h; sourceTree = "<group>"; };
+		80D677A87A42371368BDBE93DB4A2D2D /* SPPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPPayload.h; path = Snowplow/SPPayload.h; sourceTree = "<group>"; };
+		8139BD0316B68878E1C37F657199EE79 /* SPScreenState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPScreenState.h; path = Snowplow/SPScreenState.h; sourceTree = "<group>"; };
+		849F976616D2568A5EA2D35F331B2A2A /* SnowplowTracker-watchOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "SnowplowTracker-watchOS-dummy.m"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS-dummy.m"; sourceTree = "<group>"; };
+		86318E25F86D5AAEBB39922EEF04E185 /* SPRequestResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPRequestResponse.m; path = Snowplow/SPRequestResponse.m; sourceTree = "<group>"; };
+		8722615B04D16E0D66613F3D018CAFE6 /* SPUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPUtilities.h; path = Snowplow/SPUtilities.h; sourceTree = "<group>"; };
+		887AEFD00C3C4251592F79CE45FF53C4 /* SnowplowTracker-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnowplowTracker-iOS-prefix.pch"; sourceTree = "<group>"; };
+		8956D62775F45D181461594B1BE9C213 /* SPConsentGranted.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPConsentGranted.h; sourceTree = "<group>"; };
+		89B9ADAE8C0DB1CDD3D1A448A9C475F7 /* SPPageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPPageView.m; sourceTree = "<group>"; };
+		8AA910C8154FCC2394724FE78EC285DC /* SnowplowTracker-watchOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "SnowplowTracker-watchOS.xcconfig"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS.xcconfig"; sourceTree = "<group>"; };
 		8C3CB60C63172CFDF0BEE44C7CFC412D /* libSnowplowTracker-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libSnowplowTracker-iOS.a"; path = "libSnowplowTracker-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8F3DC20A37516AE4C270DD60432ED99A /* SPSchemaRuleset.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPSchemaRuleset.m; sourceTree = "<group>"; };
-		8F4D78DCDE8045BCF5905C99BEDA89E4 /* SPPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPPayload.m; path = Snowplow/SPPayload.m; sourceTree = "<group>"; };
-		91E158CC66242C043B861CCCC6493CC4 /* SPSelfDescribingJson.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPSelfDescribingJson.m; path = Snowplow/SPSelfDescribingJson.m; sourceTree = "<group>"; };
-		934C97D64B3A7FC38BADCDDD1611F44E /* SPEcommerce.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEcommerce.h; sourceTree = "<group>"; };
+		8E9E5730B8C63AB7E40E6358B7F4555A /* UIViewController+SPScreenView_SWIZZLE.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+SPScreenView_SWIZZLE.m"; path = "Snowplow/UIViewController+SPScreenView_SWIZZLE.m"; sourceTree = "<group>"; };
 		94E5724D1D9B1B94855B7713519E0CDD /* Pods-SnowplowSwiftDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SnowplowSwiftDemo-dummy.m"; sourceTree = "<group>"; };
 		96B115927304BF776027CABE66A99EE1 /* FMDatabaseQueue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMDatabaseQueue.m; path = src/fmdb/FMDatabaseQueue.m; sourceTree = "<group>"; };
-		982B1DA7F0C2F6B661AFD6AE4D97CD02 /* SPRequestCallback.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPRequestCallback.h; path = Snowplow/SPRequestCallback.h; sourceTree = "<group>"; };
-		986B090505B17E5DBCC2C09D44E83C19 /* SNOWError.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SNOWError.m; sourceTree = "<group>"; };
 		987CEC26216D30EFD857D4CA96370E64 /* FMDB-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "FMDB-iOS.xcconfig"; sourceTree = "<group>"; };
-		98D818E2659D0104BB846CC4AAA2586C /* SPEcommerceItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEcommerceItem.h; sourceTree = "<group>"; };
-		9CE30BE47477BF1DA2685E202F4EABF6 /* SPUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPUtilities.m; path = Snowplow/SPUtilities.m; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A13686CA254E184281B8B38DEA5B9DB9 /* SPPageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPPageView.h; sourceTree = "<group>"; };
+		A0061164AA43C66D391E339E38A4E3D8 /* SPSchemaRuleset.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPSchemaRuleset.h; sourceTree = "<group>"; };
+		A089FAAF93751141812CC5F1278BB1D2 /* SPEcommerceItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEcommerceItem.h; sourceTree = "<group>"; };
+		A0C0E33FF697FB8E862C4727D67D6AB9 /* SPPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPPayload.m; path = Snowplow/SPPayload.m; sourceTree = "<group>"; };
 		A1FD0A1B7FF3CDA4BCD53ADDAB3AFCF3 /* FMDatabasePool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FMDatabasePool.h; path = src/fmdb/FMDatabasePool.h; sourceTree = "<group>"; };
-		A407E2616A51D86192A69C7C49846FB1 /* SPStructured.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPStructured.h; sourceTree = "<group>"; };
-		A7E911136B08DB79D86AFEE4D26C2003 /* SPEventBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEventBase.h; sourceTree = "<group>"; };
-		AEA2AFFBFDA3F1D3640D144F3495ED31 /* SPGlobalContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPGlobalContext.h; sourceTree = "<group>"; };
+		A283F35361AE54E3A2013689CC50310B /* SPSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPSession.h; path = Snowplow/SPSession.h; sourceTree = "<group>"; };
+		A541A077C592B269D1773A5167EB1BC8 /* SPTiming.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPTiming.m; sourceTree = "<group>"; };
+		A6A5A5DCC55BBA32D09D960244613674 /* SPEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEvent.h; sourceTree = "<group>"; };
+		A6D661A6F1A397C8CEB9D7B7092668C8 /* Snowplow.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Snowplow.h; path = Snowplow/Snowplow.h; sourceTree = "<group>"; };
+		A7C12B35D125A6CA40FFC694BE27E6DC /* SnowplowTracker-watchOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "SnowplowTracker-watchOS.modulemap"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS.modulemap"; sourceTree = "<group>"; };
+		A7F7912D4B1FF42265D58CEDCB29A7E0 /* SnowplowTracker-watchOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "SnowplowTracker-watchOS-umbrella.h"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS-umbrella.h"; sourceTree = "<group>"; };
+		A917ED154D38192D934F43595040BE73 /* SNOWReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SNOWReachability.m; path = Snowplow/SNOWReachability.m; sourceTree = "<group>"; };
+		A9A5393454029F15A5B25C519A318742 /* SPDevicePlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPDevicePlatform.h; path = Snowplow/SPDevicePlatform.h; sourceTree = "<group>"; };
 		B19CD9406F5126230FCA0E2401D33525 /* FMDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FMDatabase.h; path = src/fmdb/FMDatabase.h; sourceTree = "<group>"; };
-		B2ED593B8A1D4B7AD53DE4F488DFCF9E /* SPInstallTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPInstallTracker.m; path = Snowplow/SPInstallTracker.m; sourceTree = "<group>"; };
+		B2A725E0FFD2D2130A6C79F3DC0C5201 /* SPRequestResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPRequestResponse.h; path = Snowplow/SPRequestResponse.h; sourceTree = "<group>"; };
 		B3CC26F0EF114CEA1C05D68FF94000A1 /* libPods-SnowplowSwiftDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-SnowplowSwiftDemo.a"; path = "libPods-SnowplowSwiftDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B5641FC662515C92981B4D2D87536B7F /* SPConsentWithdrawn.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPConsentWithdrawn.h; sourceTree = "<group>"; };
+		B6241236EF99FCB2D3371EF0D8D9FAF3 /* SPForeground.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPForeground.m; sourceTree = "<group>"; };
+		B82E6854B154BE7FC627115D305A03C1 /* SPGdprContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPGdprContext.h; path = Snowplow/SPGdprContext.h; sourceTree = "<group>"; };
 		B9BD7101B86BF791068BCE9A1057A076 /* libSnowplowTracker-watchOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libSnowplowTracker-watchOS.a"; path = "libSnowplowTracker-watchOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BA7F78E9A33D7DF6A490ECA73E288A8E /* SPEcommerceItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPEcommerceItem.m; sourceTree = "<group>"; };
-		BA87AE2FC7B65314C37E009CD86E9924 /* SPSchemaRuleset.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPSchemaRuleset.h; sourceTree = "<group>"; };
 		BA9C1DF037B68B7AD1B9588B0FC026B7 /* FMDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FMDB.h; path = src/fmdb/FMDB.h; sourceTree = "<group>"; };
-		BB4C9B72D19D490925C531ECA3F891B5 /* SPConsentGranted.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPConsentGranted.m; sourceTree = "<group>"; };
-		BCA029DC645F5979559D41B6CFBE2A87 /* SPTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTracker.m; path = Snowplow/SPTracker.m; sourceTree = "<group>"; };
-		BE0EA012A2860418E86037D2FA091212 /* SnowplowTracker-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "SnowplowTracker-iOS.modulemap"; sourceTree = "<group>"; };
-		BE7AEE24AE48292728C3080205D44E3E /* SPConsentWithdrawn.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPConsentWithdrawn.m; sourceTree = "<group>"; };
 		BEF809A916251B7FFF769E051BA48A58 /* Pods-SnowplowSwiftWatch Extension-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SnowplowSwiftWatch Extension-acknowledgements.markdown"; sourceTree = "<group>"; };
-		C3C0E6B7A30A76B4ADF1EEC29633BC81 /* SPDevicePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPDevicePlatform.m; path = Snowplow/SPDevicePlatform.m; sourceTree = "<group>"; };
-		C41558F2CBF9D411CA5B3BC9613A84C7 /* SPSession.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPSession.m; path = Snowplow/SPSession.m; sourceTree = "<group>"; };
+		C084615DD0D603EEDC66CD91C4C2A281 /* SPSchemaRule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPSchemaRule.h; sourceTree = "<group>"; };
+		C3D26EE8DD24B64B02E623901F411F79 /* SPConsentWithdrawn.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPConsentWithdrawn.m; sourceTree = "<group>"; };
 		C94FC268661CB762D1FA9380D86BAA09 /* FMDB-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FMDB-iOS-dummy.m"; sourceTree = "<group>"; };
+		CB328B4B2C2C01482C1807A42FB15B57 /* SPSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPSubject.m; path = Snowplow/SPSubject.m; sourceTree = "<group>"; };
+		CB45E31342B50AE10697CF45839DB909 /* SPScreenView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPScreenView.h; sourceTree = "<group>"; };
 		CB9763D98E2E3FCCFA0F85EDE72A7EA0 /* FMDatabaseAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMDatabaseAdditions.m; path = src/fmdb/FMDatabaseAdditions.m; sourceTree = "<group>"; };
-		CBCE732A246430537539367A91CEF663 /* SPEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPEvent.h; sourceTree = "<group>"; };
-		CBDDFA300BBAD1247EC28712110B3402 /* SPScreenView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPScreenView.h; sourceTree = "<group>"; };
+		CC3861FC2B36778ED599F2CAA0F018F4 /* SPDevicePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPDevicePlatform.m; path = Snowplow/SPDevicePlatform.m; sourceTree = "<group>"; };
 		CC57DEF7B44129F10BD0D080D1B363ED /* libFMDB-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libFMDB-iOS.a"; path = "libFMDB-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CDAD2595891B82DB00A62091F137F33C /* SPPageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPPageView.m; sourceTree = "<group>"; };
-		CEE8308B2A7E8B74E25AE0AA9960BF09 /* UIViewController+SPScreenView_SWIZZLE.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+SPScreenView_SWIZZLE.h"; path = "Snowplow/UIViewController+SPScreenView_SWIZZLE.h"; sourceTree = "<group>"; };
-		D32E81473609251379375F7B7236EC2E /* SPSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPSubject.m; path = Snowplow/SPSubject.m; sourceTree = "<group>"; };
-		D5284D47C6A2D58062C69E95DF3B56BA /* SnowplowTracker-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "SnowplowTracker-iOS.xcconfig"; sourceTree = "<group>"; };
-		DABC2CC71C1AECC7804516E5015B7697 /* SnowplowTracker-watchOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "SnowplowTracker-watchOS-umbrella.h"; path = "../SnowplowTracker-watchOS/SnowplowTracker-watchOS-umbrella.h"; sourceTree = "<group>"; };
+		CDDCA4A88F1CB33AA23D99BAD54A82D2 /* SPTrackerEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPTrackerEvent.m; sourceTree = "<group>"; };
+		D378A30AC0787B470454C06AEDEE2487 /* SPSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPSubject.h; path = Snowplow/SPSubject.h; sourceTree = "<group>"; };
 		DD4733F956ECE944F563BCFA581B85CF /* FMDB-watchOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "FMDB-watchOS-dummy.m"; path = "../FMDB-watchOS/FMDB-watchOS-dummy.m"; sourceTree = "<group>"; };
-		E0E2D5B164F36963FF4E32B9F36684E4 /* SPScreenState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPScreenState.h; path = Snowplow/SPScreenState.h; sourceTree = "<group>"; };
-		E38FF48204A51BEEE9F5047251B5E189 /* SPBackground.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPBackground.m; sourceTree = "<group>"; };
+		E1645EF0125FE49639703C696EC3927A /* SPInstallTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPInstallTracker.m; path = Snowplow/SPInstallTracker.m; sourceTree = "<group>"; };
+		E6448B48322141639D0DB1C6644974D8 /* SPConsentDocument.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPConsentDocument.h; sourceTree = "<group>"; };
+		EA1FB6987B9D62D84CA1DCDC708115D1 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		EBB498F1F7FF6164DAE8B346AE0D4199 /* FMDatabasePool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FMDatabasePool.m; path = src/fmdb/FMDatabasePool.m; sourceTree = "<group>"; };
 		EBD26D3C00095F0077CA9C8E3064A980 /* Pods-SnowplowSwiftDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnowplowSwiftDemo.release.xcconfig"; sourceTree = "<group>"; };
-		EBFBE3EF2B858B7CC377F0CEF8CB6475 /* SPPushNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SPPushNotification.m; sourceTree = "<group>"; };
-		EE0F61C8C665D47D784FB693CD576124 /* SPUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPUtilities.h; path = Snowplow/SPUtilities.h; sourceTree = "<group>"; };
+		EC39C1E160A54CEEFC952574BDB23522 /* SPStructured.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPStructured.h; sourceTree = "<group>"; };
+		EC6F529CE7B6623A7C01A659556981BE /* SPInstallTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPInstallTracker.h; path = Snowplow/SPInstallTracker.h; sourceTree = "<group>"; };
+		F25D6749607EEEAD973316DA225F9876 /* OpenIDFA.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OpenIDFA.h; path = Snowplow/OpenIDFA.h; sourceTree = "<group>"; };
+		F28F8DE4370930DF884E6987C1CBBB03 /* SPEmitter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPEmitter.m; path = Snowplow/SPEmitter.m; sourceTree = "<group>"; };
 		F2F52BAC24768F73915DD2C2EA957A95 /* Pods-SnowplowSwiftDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnowplowSwiftDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		F3D126FC6A89BBD65EA039156C0C1B50 /* SPSelfDescribingJson.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPSelfDescribingJson.h; path = Snowplow/SPSelfDescribingJson.h; sourceTree = "<group>"; };
-		F63DBF8241A89E09E0941D9B9C89001A /* SPTiming.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPTiming.h; sourceTree = "<group>"; };
 		F74922206F57CA1BA45BC8F956415AE7 /* libPods-SnowplowSwiftWatch Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-SnowplowSwiftWatch Extension.a"; path = "libPods-SnowplowSwiftWatch Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FB986C2ABBC2679A4631EBD417305464 /* SPRequestResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPRequestResponse.h; path = Snowplow/SPRequestResponse.h; sourceTree = "<group>"; };
+		F7661C393326A03E023BD8799258610B /* SPTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTracker.m; path = Snowplow/SPTracker.m; sourceTree = "<group>"; };
+		F775E6AB3889D1DF600E20977AF0124B /* SnowplowTracker-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "SnowplowTracker-iOS.xcconfig"; sourceTree = "<group>"; };
+		FAD72B3DE579561000C5260EE96EA642 /* SPGlobalContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SPGlobalContext.h; sourceTree = "<group>"; };
 		FFFAA16BDF4DF1FD5CE78B875C542FDE /* Pods-SnowplowSwiftWatch Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SnowplowSwiftWatch Extension.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -364,13 +370,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		40533302FB00C319E8A9235FD8643D8F /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		827A4258CF9F2764EDBC24F78CB6B8DA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -391,7 +390,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E4A7F600808B8B10EB63FC0A4A4B7840 /* Frameworks */ = {
+		E2894FE00195EAAF2EC0959330F97202 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E9B7D18019602DBCC874BFD5A3CF2026 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -414,6 +420,47 @@
 			path = "Target Support Files/Pods-SnowplowSwiftDemo";
 			sourceTree = "<group>";
 		};
+		1B1ADE2747341E39D5337C5EA1300D69 /* Events */ = {
+			isa = PBXGroup;
+			children = (
+				4B7ECEE477EA523C178DD5BB91744232 /* SNOWError.h */,
+				5CD8ABC0E41075F5A538696E55CBF451 /* SNOWError.m */,
+				7BCB84DEC1824B596374DFE66A85A5DE /* SPBackground.h */,
+				6A4913102F52A784E5AEC4E13ED1AF7F /* SPBackground.m */,
+				E6448B48322141639D0DB1C6644974D8 /* SPConsentDocument.h */,
+				0C595277E82C22545E33387462A565FD /* SPConsentDocument.m */,
+				8956D62775F45D181461594B1BE9C213 /* SPConsentGranted.h */,
+				5A6DB151902450771BE616AFC5AED50E /* SPConsentGranted.m */,
+				781FBAA8C23961DF2311470BDA79FE1A /* SPConsentWithdrawn.h */,
+				C3D26EE8DD24B64B02E623901F411F79 /* SPConsentWithdrawn.m */,
+				1B8C3A74C72ED43B650569CDB3DB365B /* SPEcommerce.h */,
+				47965AB43CA5DD176808B10D0719D325 /* SPEcommerce.m */,
+				A089FAAF93751141812CC5F1278BB1D2 /* SPEcommerceItem.h */,
+				22BF1D6FED46E4E0BEBE8777265AF012 /* SPEcommerceItem.m */,
+				A6A5A5DCC55BBA32D09D960244613674 /* SPEvent.h */,
+				3B6D31D9B20052337E90962E7D6062DB /* SPEventBase.h */,
+				2E628E00C41745C72D875839DFEC56B7 /* SPEventBase.m */,
+				6760CA4DB840AF32CC8203EDECF6DB82 /* SPForeground.h */,
+				B6241236EF99FCB2D3371EF0D8D9FAF3 /* SPForeground.m */,
+				523ACA500BA48422E494D74FD6474F09 /* SPPageView.h */,
+				89B9ADAE8C0DB1CDD3D1A448A9C475F7 /* SPPageView.m */,
+				76F5CEA69167B444F958EEB76CB43C5B /* SPPushNotification.h */,
+				73443323F868E5DA2B742A867DC0E001 /* SPPushNotification.m */,
+				CB45E31342B50AE10697CF45839DB909 /* SPScreenView.h */,
+				2CE6A0A45F17F0AB850C6F88152AB9AD /* SPScreenView.m */,
+				EC39C1E160A54CEEFC952574BDB23522 /* SPStructured.h */,
+				66105F762C057AAAAB3F0081FEB78ACF /* SPStructured.m */,
+				2E586F7251853D37DA094E2A98C39B75 /* SPTiming.h */,
+				A541A077C592B269D1773A5167EB1BC8 /* SPTiming.m */,
+				76DF44300B420D13FF7F83A9BAA8666F /* SPTrackerEvent.h */,
+				CDDCA4A88F1CB33AA23D99BAD54A82D2 /* SPTrackerEvent.m */,
+				62E88C576A06CC91126A4521E4BC29F4 /* SPUnstructured.h */,
+				07B65DD5DCCBD4F1B478E67D53AF2C3A /* SPUnstructured.m */,
+			);
+			name = Events;
+			path = Snowplow/Events;
+			sourceTree = "<group>";
+		};
 		1DB0D188546EB1906208FF05980240A3 /* Pods-SnowplowSwiftWatch Extension */ = {
 			isa = PBXGroup;
 			children = (
@@ -425,16 +472,6 @@
 			);
 			name = "Pods-SnowplowSwiftWatch Extension";
 			path = "Target Support Files/Pods-SnowplowSwiftWatch Extension";
-			sourceTree = "<group>";
-		};
-		34424345927D8BE080800A7F6C41BF08 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				6D3587CF7E96B8D5032B822CB608A9AC /* LICENSE */,
-				0F711317B693152F4D975687F01CA266 /* README.md */,
-				7A405EE4B6FFAC277CF7889DD810719E /* SnowplowTracker.podspec */,
-			);
-			name = Pod;
 			sourceTree = "<group>";
 		};
 		4223599807EE61860C1530CC83025477 /* standard */ = {
@@ -453,6 +490,70 @@
 				1F6FCB618A922A24FC0963518F544335 /* FMResultSet.m */,
 			);
 			name = standard;
+			sourceTree = "<group>";
+		};
+		4DAF714624210FA01D4BBAD96C967AFB /* SnowplowTracker */ = {
+			isa = PBXGroup;
+			children = (
+				F25D6749607EEEAD973316DA225F9876 /* OpenIDFA.h */,
+				1F10C3AAB07021C8B735773CBDEF0B68 /* OpenIDFA.m */,
+				A6D661A6F1A397C8CEB9D7B7092668C8 /* Snowplow.h */,
+				58BEE0C6BA4B47975F16FD40372765ED /* Snowplow.m */,
+				17B53433C3F99525322BA749574049B2 /* Snowplow-Bridging-Header.h */,
+				07F07861181A90BE22D1B5F6DD551589 /* SNOWReachability.h */,
+				A917ED154D38192D934F43595040BE73 /* SNOWReachability.m */,
+				A9A5393454029F15A5B25C519A318742 /* SPDevicePlatform.h */,
+				CC3861FC2B36778ED599F2CAA0F018F4 /* SPDevicePlatform.m */,
+				2E6301B5F3556EA2AD0D119A11905959 /* SPEmitter.h */,
+				F28F8DE4370930DF884E6987C1CBBB03 /* SPEmitter.m */,
+				589819ADA8D09F0A2AC3CE4A2D6572BE /* SPEventStore.h */,
+				5AF02A9364051926CBAAE70119F63E40 /* SPEventStore.m */,
+				B82E6854B154BE7FC627115D305A03C1 /* SPGdprContext.h */,
+				574F3828DE7203FFD1E06E5473F1256C /* SPGdprContext.m */,
+				EC6F529CE7B6623A7C01A659556981BE /* SPInstallTracker.h */,
+				E1645EF0125FE49639703C696EC3927A /* SPInstallTracker.m */,
+				80D677A87A42371368BDBE93DB4A2D2D /* SPPayload.h */,
+				A0C0E33FF697FB8E862C4727D67D6AB9 /* SPPayload.m */,
+				51B1C9AE05A393F7431D2A8CC058819F /* SPRequestCallback.h */,
+				B2A725E0FFD2D2130A6C79F3DC0C5201 /* SPRequestResponse.h */,
+				86318E25F86D5AAEBB39922EEF04E185 /* SPRequestResponse.m */,
+				8139BD0316B68878E1C37F657199EE79 /* SPScreenState.h */,
+				79B0AC92B9C49E0D9236A1DBC81509E3 /* SPScreenState.m */,
+				105B4EF8F182DB70AE1F84A214F2FBC2 /* SPSelfDescribingJson.h */,
+				52ED3540F886045CC2336DCA44EFB336 /* SPSelfDescribingJson.m */,
+				A283F35361AE54E3A2013689CC50310B /* SPSession.h */,
+				0BF190263B845069E56970CFA8E65A70 /* SPSession.m */,
+				D378A30AC0787B470454C06AEDEE2487 /* SPSubject.h */,
+				CB328B4B2C2C01482C1807A42FB15B57 /* SPSubject.m */,
+				7ECC74416B8A75A2D42F2453A8E7BAB5 /* SPTracker.h */,
+				F7661C393326A03E023BD8799258610B /* SPTracker.m */,
+				8722615B04D16E0D66613F3D018CAFE6 /* SPUtilities.h */,
+				7D8F13539E14FAA8C4923C4F7A89EE9E /* SPUtilities.m */,
+				299EBFEABA734CF515696BAB4509297B /* SPWeakTimerTarget.h */,
+				7299C777ACC18DE61D3DA53A0F66A597 /* SPWeakTimerTarget.m */,
+				76362E814024CE05CD69328DE4F26507 /* UIViewController+SPScreenView_SWIZZLE.h */,
+				8E9E5730B8C63AB7E40E6358B7F4555A /* UIViewController+SPScreenView_SWIZZLE.m */,
+				1B1ADE2747341E39D5337C5EA1300D69 /* Events */,
+				57B5FE1EAEA08779F26C979AAB1F5B3B /* GlobalContext */,
+				F8DB996ADC1B9E4798FC15C773226FC9 /* Pod */,
+				C51A445B4CD717A705C77C201CAF507B /* Support Files */,
+			);
+			name = SnowplowTracker;
+			path = ../../..;
+			sourceTree = "<group>";
+		};
+		57B5FE1EAEA08779F26C979AAB1F5B3B /* GlobalContext */ = {
+			isa = PBXGroup;
+			children = (
+				FAD72B3DE579561000C5260EE96EA642 /* SPGlobalContext.h */,
+				5A7F308D60E7987B3663C0ABEE0D0948 /* SPGlobalContext.m */,
+				C084615DD0D603EEDC66CD91C4C2A281 /* SPSchemaRule.h */,
+				60378FF3FBA3875362D001591445C68D /* SPSchemaRule.m */,
+				A0061164AA43C66D391E339E38A4E3D8 /* SPSchemaRuleset.h */,
+				20F407BA6D65A4CAD586BB28F28B56D3 /* SPSchemaRuleset.m */,
+			);
+			name = GlobalContext;
+			path = Snowplow/GlobalContext;
 			sourceTree = "<group>";
 		};
 		61D62BB83C78C2D3D915A9096BB9AE31 /* Support Files */ = {
@@ -477,53 +578,12 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		6B40DB0C881BC049B62CA1E0A1A94F1D /* Development Pods */ = {
+		856F67F32C2120977D5A2D139EF83D4F /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D75F8028812CEF50B914E517F4B0AC09 /* SnowplowTracker */,
+				4DAF714624210FA01D4BBAD96C967AFB /* SnowplowTracker */,
 			);
 			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		81B9E5ABB2A28EECCB07EEDC21D61DA8 /* Events */ = {
-			isa = PBXGroup;
-			children = (
-				33AB6E268A2BEA6E943A373C57E47E11 /* SNOWError.h */,
-				986B090505B17E5DBCC2C09D44E83C19 /* SNOWError.m */,
-				3B46DD8D463A393AE86640B6861743C2 /* SPBackground.h */,
-				E38FF48204A51BEEE9F5047251B5E189 /* SPBackground.m */,
-				4192C7B18424525CF1AE011D41F252F0 /* SPConsentDocument.h */,
-				04313E2F6ACF4851B1FDA1D00CBDEB4E /* SPConsentDocument.m */,
-				867CC28144D01136EA3AA29EF89F03F4 /* SPConsentGranted.h */,
-				BB4C9B72D19D490925C531ECA3F891B5 /* SPConsentGranted.m */,
-				B5641FC662515C92981B4D2D87536B7F /* SPConsentWithdrawn.h */,
-				BE7AEE24AE48292728C3080205D44E3E /* SPConsentWithdrawn.m */,
-				934C97D64B3A7FC38BADCDDD1611F44E /* SPEcommerce.h */,
-				3832DE3131E77A9F1A63A41E163A8E4D /* SPEcommerce.m */,
-				98D818E2659D0104BB846CC4AAA2586C /* SPEcommerceItem.h */,
-				BA7F78E9A33D7DF6A490ECA73E288A8E /* SPEcommerceItem.m */,
-				CBCE732A246430537539367A91CEF663 /* SPEvent.h */,
-				A7E911136B08DB79D86AFEE4D26C2003 /* SPEventBase.h */,
-				72FED919B0D2EF1DB556F287435B195D /* SPEventBase.m */,
-				6D290CF7F927A5403A069A822AC52A0A /* SPForeground.h */,
-				77D4AC9791F0B97078BE8681D2F11BAF /* SPForeground.m */,
-				A13686CA254E184281B8B38DEA5B9DB9 /* SPPageView.h */,
-				CDAD2595891B82DB00A62091F137F33C /* SPPageView.m */,
-				35299ECB5BEEC16542BFABA28DA3746B /* SPPushNotification.h */,
-				EBFBE3EF2B858B7CC377F0CEF8CB6475 /* SPPushNotification.m */,
-				CBDDFA300BBAD1247EC28712110B3402 /* SPScreenView.h */,
-				20F6049DC5E80A123DF22D865FCBAA89 /* SPScreenView.m */,
-				A407E2616A51D86192A69C7C49846FB1 /* SPStructured.h */,
-				4724DB7994EC3F6BA4D430C39BADA8A5 /* SPStructured.m */,
-				F63DBF8241A89E09E0941D9B9C89001A /* SPTiming.h */,
-				2E1799F25FFE4791ABCD785FE2978B3E /* SPTiming.m */,
-				3CC017846EF50BE27A2B400024B3EA17 /* SPTrackerEvent.h */,
-				593A7A7DE30E24D745A9E130BC87BB50 /* SPTrackerEvent.m */,
-				46EE8A54D57A8B56B267A78815270041 /* SPUnstructured.h */,
-				769FCF91E1A238B36B2DEE5FB0E1D315 /* SPUnstructured.m */,
-			);
-			name = Events;
-			path = Snowplow/Events;
 			sourceTree = "<group>";
 		};
 		9CD3B949BE2D7A216C56A90AA067ADAB /* Products */ = {
@@ -539,19 +599,19 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		AAA6F7F30416DE41CA7A4C7077F5991C /* Support Files */ = {
+		C51A445B4CD717A705C77C201CAF507B /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				BE0EA012A2860418E86037D2FA091212 /* SnowplowTracker-iOS.modulemap */,
-				D5284D47C6A2D58062C69E95DF3B56BA /* SnowplowTracker-iOS.xcconfig */,
-				3E05919F28927AD4CCAB75EBF5C2D50C /* SnowplowTracker-iOS-dummy.m */,
-				278364C32FF24E6B784FCFDB8E67A606 /* SnowplowTracker-iOS-prefix.pch */,
-				8046A473110921411EAD2261F5FAC01E /* SnowplowTracker-iOS-umbrella.h */,
-				67AB30063E87F11139501023838774ED /* SnowplowTracker-watchOS.modulemap */,
-				0BD4900F50D91416AC99D51EE4BC03F3 /* SnowplowTracker-watchOS.xcconfig */,
-				77D8A3BD2A5233DEDC48F747FB6DF50E /* SnowplowTracker-watchOS-dummy.m */,
-				68900E73F8FECBA07B2955B24043241F /* SnowplowTracker-watchOS-prefix.pch */,
-				DABC2CC71C1AECC7804516E5015B7697 /* SnowplowTracker-watchOS-umbrella.h */,
+				32A2BBE5AC07A1C9AF6F70BE0A877CB1 /* SnowplowTracker-iOS.modulemap */,
+				F775E6AB3889D1DF600E20977AF0124B /* SnowplowTracker-iOS.xcconfig */,
+				56918A4533313B573CB5F913FBFDDCC1 /* SnowplowTracker-iOS-dummy.m */,
+				887AEFD00C3C4251592F79CE45FF53C4 /* SnowplowTracker-iOS-prefix.pch */,
+				734CFF7A00B0AA3370FD7B2A9C710FE8 /* SnowplowTracker-iOS-umbrella.h */,
+				A7C12B35D125A6CA40FFC694BE27E6DC /* SnowplowTracker-watchOS.modulemap */,
+				8AA910C8154FCC2394724FE78EC285DC /* SnowplowTracker-watchOS.xcconfig */,
+				849F976616D2568A5EA2D35F331B2A2A /* SnowplowTracker-watchOS-dummy.m */,
+				5C83F86A5A8E5023EE30965BF13BF1EB /* SnowplowTracker-watchOS-prefix.pch */,
+				A7F7912D4B1FF42265D58CEDCB29A7E0 /* SnowplowTracker-watchOS-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "Examples/SnowplowSwiftCocoapodsDemo/Pods/Target Support Files/SnowplowTracker-iOS";
@@ -561,7 +621,7 @@
 			isa = PBXGroup;
 			children = (
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
-				6B40DB0C881BC049B62CA1E0A1A94F1D /* Development Pods */,
+				856F67F32C2120977D5A2D139EF83D4F /* Development Pods */,
 				D89477F20FB1DE18A04690586D7808C4 /* Frameworks */,
 				68DB21AE5492FC581291330CF6E902BA /* Pods */,
 				9CD3B949BE2D7A216C56A90AA067ADAB /* Products */,
@@ -577,54 +637,6 @@
 			);
 			name = FMDB;
 			path = FMDB;
-			sourceTree = "<group>";
-		};
-		D75F8028812CEF50B914E517F4B0AC09 /* SnowplowTracker */ = {
-			isa = PBXGroup;
-			children = (
-				39172F96ADF63594CCC04B40F5125814 /* OpenIDFA.h */,
-				37FB8CF785F6FA7FAFA305738326DE2E /* OpenIDFA.m */,
-				43532480A83AE1848925BCEE4FB341C4 /* Snowplow.h */,
-				038EFFBE900AE3BB2033C28AB80FE32A /* Snowplow.m */,
-				8BCEBCF254803F8B1D6A1EFB812AF2DE /* Snowplow-Bridging-Header.h */,
-				27DF6985B123CE982C5FF7083241FC4E /* SNOWReachability.h */,
-				7835C513F442CFDDFE4CF9E5412861F7 /* SNOWReachability.m */,
-				64E3792B805031B245A0845FAFC7CD0D /* SPDevicePlatform.h */,
-				C3C0E6B7A30A76B4ADF1EEC29633BC81 /* SPDevicePlatform.m */,
-				565C0C8DE9220F1279C67ACC6BA7D649 /* SPEmitter.h */,
-				1F0C55235CD5F960224B215D21672D66 /* SPEmitter.m */,
-				2C1BA24586CB32DFFE4924051133A0DA /* SPEventStore.h */,
-				1106C9E0CA9017FEE46F568B2757BB42 /* SPEventStore.m */,
-				44AF294AB2D274315CCA7281B782DB2E /* SPInstallTracker.h */,
-				B2ED593B8A1D4B7AD53DE4F488DFCF9E /* SPInstallTracker.m */,
-				0418AC55F3AAD4E1439344BAC6DDA0B8 /* SPPayload.h */,
-				8F4D78DCDE8045BCF5905C99BEDA89E4 /* SPPayload.m */,
-				982B1DA7F0C2F6B661AFD6AE4D97CD02 /* SPRequestCallback.h */,
-				FB986C2ABBC2679A4631EBD417305464 /* SPRequestResponse.h */,
-				745657B50904CF3D80604481D4FCC9D4 /* SPRequestResponse.m */,
-				E0E2D5B164F36963FF4E32B9F36684E4 /* SPScreenState.h */,
-				7299C7A56C7A35667D83719076A38D9F /* SPScreenState.m */,
-				F3D126FC6A89BBD65EA039156C0C1B50 /* SPSelfDescribingJson.h */,
-				91E158CC66242C043B861CCCC6493CC4 /* SPSelfDescribingJson.m */,
-				1B682E957D9529D6F942A4B497906DA8 /* SPSession.h */,
-				C41558F2CBF9D411CA5B3BC9613A84C7 /* SPSession.m */,
-				810549DF8E9DBAB9A7FF6B180B2904D3 /* SPSubject.h */,
-				D32E81473609251379375F7B7236EC2E /* SPSubject.m */,
-				44FACA306C61D037F67E9EF006078242 /* SPTracker.h */,
-				BCA029DC645F5979559D41B6CFBE2A87 /* SPTracker.m */,
-				EE0F61C8C665D47D784FB693CD576124 /* SPUtilities.h */,
-				9CE30BE47477BF1DA2685E202F4EABF6 /* SPUtilities.m */,
-				6033E0E2AB830295AA031DD289F038CF /* SPWeakTimerTarget.h */,
-				77FFA7F674FBFE3FA4FADFAFD808FEC5 /* SPWeakTimerTarget.m */,
-				CEE8308B2A7E8B74E25AE0AA9960BF09 /* UIViewController+SPScreenView_SWIZZLE.h */,
-				6EECF815E28F507BFE57FF477D056E02 /* UIViewController+SPScreenView_SWIZZLE.m */,
-				81B9E5ABB2A28EECCB07EEDC21D61DA8 /* Events */,
-				FD54C929970059AFA75434195605B81D /* GlobalContext */,
-				34424345927D8BE080800A7F6C41BF08 /* Pod */,
-				AAA6F7F30416DE41CA7A4C7077F5991C /* Support Files */,
-			);
-			name = SnowplowTracker;
-			path = ../../..;
 			sourceTree = "<group>";
 		};
 		D89477F20FB1DE18A04690586D7808C4 /* Frameworks */ = {
@@ -643,18 +655,14 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		FD54C929970059AFA75434195605B81D /* GlobalContext */ = {
+		F8DB996ADC1B9E4798FC15C773226FC9 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				AEA2AFFBFDA3F1D3640D144F3495ED31 /* SPGlobalContext.h */,
-				6BDF295946CA09F8B82FB788E9445912 /* SPGlobalContext.m */,
-				40A4D2F514C96192DA1B47D1E3822E28 /* SPSchemaRule.h */,
-				149DDAF76D07D60E36809E04AE925E88 /* SPSchemaRule.m */,
-				BA87AE2FC7B65314C37E009CD86E9924 /* SPSchemaRuleset.h */,
-				8F3DC20A37516AE4C270DD60432ED99A /* SPSchemaRuleset.m */,
+				EA1FB6987B9D62D84CA1DCDC708115D1 /* LICENSE */,
+				5588E7BB041A9EA09EE3C7D9F5BDB3D5 /* README.md */,
+				01558289857AA3EFEE9CA85709FDAA0D /* SnowplowTracker.podspec */,
 			);
-			name = GlobalContext;
-			path = Snowplow/GlobalContext;
+			name = Pod;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -673,6 +681,52 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		282D7607FD5822F5C501D83ACE5B54A1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D8F3C4C3C0F33D5EB446F944F79D40E2 /* OpenIDFA.h in Headers */,
+				B6726B29BF4CE91DA90ACF29C4FC3AE4 /* SNOWError.h in Headers */,
+				6527C4C884DA09418A4CD8C0EE30ABDF /* Snowplow-Bridging-Header.h in Headers */,
+				4EDAF9A5FFD1A2EED3FE5F56ED87E982 /* Snowplow.h in Headers */,
+				C4278438BF6DB206C9B62AC52C53C6E1 /* SnowplowTracker-watchOS-umbrella.h in Headers */,
+				EB296C39D03215EB28B3C50E24D609B6 /* SPBackground.h in Headers */,
+				34CE0106B08A1CF0D3F45B9D03BBABD2 /* SPConsentDocument.h in Headers */,
+				39A5DAF09A48A5156CF72D0B38E06594 /* SPConsentGranted.h in Headers */,
+				F8233ED777E4B5703F24E102F3CF8CF1 /* SPConsentWithdrawn.h in Headers */,
+				D50629EDD16DA824056DE31EC2A8C15F /* SPDevicePlatform.h in Headers */,
+				345AAD61A74CCB13B2AB8E2F1C4879DD /* SPEcommerce.h in Headers */,
+				081BAB1FA58194CE60099CA595A8D2DE /* SPEcommerceItem.h in Headers */,
+				BE87F37D7802873CCA13230B537358B3 /* SPEmitter.h in Headers */,
+				C9C0349D1BCBF7EB3CC0EF2F035E66DA /* SPEvent.h in Headers */,
+				8DD0DD439A42F472E2368F10F5AD79EF /* SPEventBase.h in Headers */,
+				447B8BB5F908D0A835CE1A640B07A0B0 /* SPEventStore.h in Headers */,
+				001C92A36719997130A05A7C14E2E957 /* SPForeground.h in Headers */,
+				7E22ABAE23F3CB5E1BCA9AFC8AE371D9 /* SPGdprContext.h in Headers */,
+				FF4BCE037042F9035B091BADA6A47FA9 /* SPGlobalContext.h in Headers */,
+				09D73D1365A539FD202E93AD6BD1DBA0 /* SPInstallTracker.h in Headers */,
+				9DBD93831FB44044063DC799CDC34DA8 /* SPPageView.h in Headers */,
+				A2B6C73CE0E0518E7100009ABC2CD9C6 /* SPPayload.h in Headers */,
+				2A78957033F0385536B8525931F889CD /* SPPushNotification.h in Headers */,
+				0F68587E8A33FDDA2D014BCDF7159522 /* SPRequestCallback.h in Headers */,
+				ABD3610F7F4A039B98D854007FCD6E80 /* SPRequestResponse.h in Headers */,
+				8D16F62DD09D0649D59E1714A44C1939 /* SPSchemaRule.h in Headers */,
+				331A92B10A30B900C77026CA2C228C3C /* SPSchemaRuleset.h in Headers */,
+				4909B2708C4C49402E76874DA529F2E6 /* SPScreenState.h in Headers */,
+				AF1279714267CA62A9A04632AC187831 /* SPScreenView.h in Headers */,
+				7AA1D0658A58579D9FBBC7E704929D91 /* SPSelfDescribingJson.h in Headers */,
+				944A2129D92359A5B75FBDD852C7935F /* SPSession.h in Headers */,
+				14C3FAE08CD744D72E71FE52B70F8736 /* SPStructured.h in Headers */,
+				FB0012A88633462604CB38B5EA8D3BB8 /* SPSubject.h in Headers */,
+				7F60DD094FDBC8041E02A2969D87874A /* SPTiming.h in Headers */,
+				1F1DFF76DDC077EE1A6577131EDD2F11 /* SPTracker.h in Headers */,
+				977997435B2DB253AD1BFB96F3C7ACE6 /* SPTrackerEvent.h in Headers */,
+				99C13209870BD343A0B626CAA58CDABB /* SPUnstructured.h in Headers */,
+				EF0DF7A0DA773B640630D40669C93EC8 /* SPUtilities.h in Headers */,
+				22AFA68FB3641EDE0CA7F8AF752DCB55 /* SPWeakTimerTarget.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4174386F932EB9AE7AE735B2FE12A02A /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -680,102 +734,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4DF67101D931419B630EE24F8987559C /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				13487BC07D3A0284AA29C6E6F00F2D66 /* OpenIDFA.h in Headers */,
-				D560B1139EEDC9C44E120538B1D6E5D7 /* SNOWError.h in Headers */,
-				6BC2AAF62BA9293C06AE01BD87A579AA /* Snowplow-Bridging-Header.h in Headers */,
-				1A74E92AA9B44C350329926A705215FF /* Snowplow.h in Headers */,
-				EFC260742563B511CB6AAA67EDEC2472 /* SnowplowTracker-iOS-umbrella.h in Headers */,
-				3ABBD81BF9CDA4F5333350B2258D7B4A /* SNOWReachability.h in Headers */,
-				72F491248C5C3628F8F91701A14C7FFF /* SPBackground.h in Headers */,
-				500A883354CB4D3FB7B80AE512916017 /* SPConsentDocument.h in Headers */,
-				6FD835F8ABC7E01F378573E6B8BB4AC8 /* SPConsentGranted.h in Headers */,
-				6A47749EC74BE019318A536DBD4195E6 /* SPConsentWithdrawn.h in Headers */,
-				859F08C921C25E48A62118CBF31D3F09 /* SPDevicePlatform.h in Headers */,
-				EE63CB46D2C6D52955D3CA7FEA2CB8DE /* SPEcommerce.h in Headers */,
-				FC6F0C8FFB9FA1DFC6E1BCF529B417F9 /* SPEcommerceItem.h in Headers */,
-				4E377D1F62597AE5101B677629C19D43 /* SPEmitter.h in Headers */,
-				FD15AB49C4CFA5270E5B0E4D705DB2C4 /* SPEvent.h in Headers */,
-				4D97A821780CC52198EBD06D49D6BEDF /* SPEventBase.h in Headers */,
-				943F41C8B9D46ABC837916574BAE27D9 /* SPEventStore.h in Headers */,
-				54DF0C8CC16EB7C86C1DF70D4DFEB907 /* SPForeground.h in Headers */,
-				2D6F0DA0B274DC14BBBCA20C0809C41F /* SPGlobalContext.h in Headers */,
-				EA4784617F1F69487459AE2A191E5D62 /* SPInstallTracker.h in Headers */,
-				AE8E7C0FDE70A3E2B4FCD95F2C60EE41 /* SPPageView.h in Headers */,
-				89C60CD056B3F3CE6640B8F4B35289C5 /* SPPayload.h in Headers */,
-				65A715FA439EC5A863683E4E76640A3C /* SPPushNotification.h in Headers */,
-				8039EE1CC9FCA6F783643EE72DDD55DF /* SPRequestCallback.h in Headers */,
-				D6EA9323F0F7FEB2CA8D512345F07DD1 /* SPRequestResponse.h in Headers */,
-				21844DD3827D6ED4CB7A616F55C82326 /* SPSchemaRule.h in Headers */,
-				654768DD38BC298825EEF608D1E962DE /* SPSchemaRuleset.h in Headers */,
-				BF3A7479C372DFE35C8D318084531A74 /* SPScreenState.h in Headers */,
-				1BD8B65C7FEF0109D22811AA0D6426BE /* SPScreenView.h in Headers */,
-				00F92513F60BDC636321A9AA26015139 /* SPSelfDescribingJson.h in Headers */,
-				39DDA5454E86498E1C214D19F40EBEA3 /* SPSession.h in Headers */,
-				A6C654753CD0BC1091115E92545A6663 /* SPStructured.h in Headers */,
-				EE01BE751EC04F9017249BD15FE236FB /* SPSubject.h in Headers */,
-				4693A29649993C0ED8E3EDC9CFB4E647 /* SPTiming.h in Headers */,
-				1C208381613D9B8CE432A80BAC34C5C7 /* SPTracker.h in Headers */,
-				1FF7EFD332E71484C098FC696991BF8B /* SPTrackerEvent.h in Headers */,
-				1FB5AEDA5B1F25F2214CB03EC7697839 /* SPUnstructured.h in Headers */,
-				67805F70395F9A34AA35F0F332054E6A /* SPUtilities.h in Headers */,
-				47CBBD651375F160CD1B2C1910F0B55A /* SPWeakTimerTarget.h in Headers */,
-				5E02D55EF95F80053E7E902D50EDD2AB /* UIViewController+SPScreenView_SWIZZLE.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		7F39E702D5189BD34F5FD95A14F7F4CC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A6B357BF07D37205BCAABE4CE80E91FB /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				26F66A43855B524E2464803E2D3344FE /* OpenIDFA.h in Headers */,
-				9322739DC4E3EFB2E7FFCE36FE06065F /* SNOWError.h in Headers */,
-				BBB1810E130C1C9E3998CBFEF4D11096 /* Snowplow-Bridging-Header.h in Headers */,
-				8030A0E9783011945F9B8AD4F6AA719A /* Snowplow.h in Headers */,
-				A7729227D63D60536FDFF9B8FF78DA8F /* SnowplowTracker-watchOS-umbrella.h in Headers */,
-				C40ADD8451658DC13EE49F6478C5E3DD /* SPBackground.h in Headers */,
-				00BE14243074C63828C806CFC9778CB8 /* SPConsentDocument.h in Headers */,
-				C82B878763C9CDC1C81738A1C28B89B6 /* SPConsentGranted.h in Headers */,
-				7083CE9DF1840115A2E4617E22BB7041 /* SPConsentWithdrawn.h in Headers */,
-				F2A862BF0EF4F8D072220B2601492E31 /* SPDevicePlatform.h in Headers */,
-				A3B32F7E4305D2FF4D2C7AFB8E9723E0 /* SPEcommerce.h in Headers */,
-				FD2FF3DAE35AB42F607D266466BC3EF0 /* SPEcommerceItem.h in Headers */,
-				C2F13505BD764EF64B657CB2D72FEBBD /* SPEmitter.h in Headers */,
-				107468FB40583FE7B7DF9BF390BB5426 /* SPEvent.h in Headers */,
-				B3D7698A7920233BCECE2E01F8E1904C /* SPEventBase.h in Headers */,
-				5804A3D0156B0DD548A5986670ADADD9 /* SPEventStore.h in Headers */,
-				CEA805BFA9A60672B6D6FEB85940CCD8 /* SPForeground.h in Headers */,
-				90B6AF735CEDBB22818BF0DB6ABCE6C8 /* SPGlobalContext.h in Headers */,
-				E80E1E5976F69AA19E474A0C8328BA7C /* SPInstallTracker.h in Headers */,
-				6C879AFDACC524203D565A8FC2236D1A /* SPPageView.h in Headers */,
-				DA498568B5DDDE5529F60E78893DFCCC /* SPPayload.h in Headers */,
-				E42A1D0A91D895CD1E890AC7CA28C3B0 /* SPPushNotification.h in Headers */,
-				901115D2BAE58D90022CCA32A2AE0574 /* SPRequestCallback.h in Headers */,
-				74894A0CF17E7C6E302B3B3AEE153BC5 /* SPRequestResponse.h in Headers */,
-				F3615D1D3B18CFAC9780AF5CCFE53531 /* SPSchemaRule.h in Headers */,
-				645D64047AC3433EB0F4A3A86D843E42 /* SPSchemaRuleset.h in Headers */,
-				0100F55E2B34119913E6BB17FD9DE63E /* SPScreenState.h in Headers */,
-				C3032354B606DF6B82FC3F51ACD4EFEB /* SPScreenView.h in Headers */,
-				D879F59F32A27E7918E5CAFBA5ECD58B /* SPSelfDescribingJson.h in Headers */,
-				468E3B9C705EF9463811CFEF98167E4A /* SPSession.h in Headers */,
-				78038367C64C2C74B1BFFB7BB6AE217B /* SPStructured.h in Headers */,
-				5C297AC85AC443D6E4E0BA636C25AB8A /* SPSubject.h in Headers */,
-				31B8F7B8EE9418CA222EC831B05AFF3F /* SPTiming.h in Headers */,
-				C5F8E84B296D2A7F6BCAC95B40D46F8D /* SPTracker.h in Headers */,
-				B2A8DB5116A1F863065CC91BF9BA8EF1 /* SPTrackerEvent.h in Headers */,
-				1674CD7BD0A8AA09DCA89D61DE29571D /* SPUnstructured.h in Headers */,
-				FDDCF01617E4F73727F9F1703D47771D /* SPUtilities.h in Headers */,
-				93A1433B0F45AD070D66F11A413FF9F5 /* SPWeakTimerTarget.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -789,6 +751,54 @@
 				D8BC4E09D7E5BE66481EF68F457B034D /* FMDatabaseQueue.h in Headers */,
 				14CDDF45837AD619D82ED7FC673326B5 /* FMDB.h in Headers */,
 				8D7CAE7714EA0D2184956D70FEF2AF7D /* FMResultSet.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F796137CCA26B6EB79484061C0563E1E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E245BE72BDA4C12CAAC4DD7E12307A5C /* OpenIDFA.h in Headers */,
+				DD467FEDCA3D727A758EF8B0C166D3D3 /* SNOWError.h in Headers */,
+				D73EDA6A4F7C0ACC02B0A81F92E8DC81 /* Snowplow-Bridging-Header.h in Headers */,
+				631A91D3D9A88A4760FC110A44EE7247 /* Snowplow.h in Headers */,
+				8B1F792504DEABD3ADB13AC2221F6276 /* SnowplowTracker-iOS-umbrella.h in Headers */,
+				E5850B23BA075BC53EE611318A1D6DFF /* SNOWReachability.h in Headers */,
+				9AFB55F8383C2F4FC248904A9ED35707 /* SPBackground.h in Headers */,
+				9B7E69DD92B3683F87D55C36D9448842 /* SPConsentDocument.h in Headers */,
+				D5988F8E090DA58915835F8B4BF97033 /* SPConsentGranted.h in Headers */,
+				EEC836E68009970B3F83EBF55357E558 /* SPConsentWithdrawn.h in Headers */,
+				CAC41337BF47CEB2C14EBF080F8DA130 /* SPDevicePlatform.h in Headers */,
+				1BF34171DFD93278656E2B46D814E4B4 /* SPEcommerce.h in Headers */,
+				E192D89E7C6DC46DC7460AFADB078BF6 /* SPEcommerceItem.h in Headers */,
+				F1382CC3DBBA2EB9FB58A6C5E90F7251 /* SPEmitter.h in Headers */,
+				E863D1FCE2FD31CABBB4752D6E3EF998 /* SPEvent.h in Headers */,
+				A97B3790432F8D6CDFDF869E7A813516 /* SPEventBase.h in Headers */,
+				AC41360C0892B343538D579638CDCBE1 /* SPEventStore.h in Headers */,
+				4BD36CE0EF5F51D4460580668BF3401B /* SPForeground.h in Headers */,
+				470FB6F078C6D446176EA803AC3458F2 /* SPGdprContext.h in Headers */,
+				C4174EE0AD42BEF8FF8C708B1789955D /* SPGlobalContext.h in Headers */,
+				B56193F879CC89C7FBCCC23594BBA975 /* SPInstallTracker.h in Headers */,
+				DB53B8461D20DF0F6206ED88966E98D0 /* SPPageView.h in Headers */,
+				5C4ABF8E7FFBE26E3F4EFFF565E7836D /* SPPayload.h in Headers */,
+				456EB769871E7B088ECBD299F1EE653E /* SPPushNotification.h in Headers */,
+				F9BED15A1378720BE4E3151E29A94E13 /* SPRequestCallback.h in Headers */,
+				7D17573C6741451F4EC489315985B73A /* SPRequestResponse.h in Headers */,
+				6C6815D915F21F52B9B078017D5DE765 /* SPSchemaRule.h in Headers */,
+				9E2AA932E745B527BCC1A6EF8F4CB6C5 /* SPSchemaRuleset.h in Headers */,
+				6669D5EA23DC2651FC8ED6FF695649CC /* SPScreenState.h in Headers */,
+				CE07082163FFAF27824C98FF619D0DA9 /* SPScreenView.h in Headers */,
+				AF172FFD74F09DCA2E05ADE5C8AD74AF /* SPSelfDescribingJson.h in Headers */,
+				F86672CF7C4CEEDF04236C886BC1BBB9 /* SPSession.h in Headers */,
+				BB3E17FA39DA8FA848AB5B9AC1F65CEA /* SPStructured.h in Headers */,
+				40823ABE6443EFD62E88D0516F5F98A3 /* SPSubject.h in Headers */,
+				6760AF35AC08DD84C8059CEC3BC3CFDE /* SPTiming.h in Headers */,
+				17CE28AD1A6259CA25FF97552D029245 /* SPTracker.h in Headers */,
+				C32DE046F563502E06B60661C352EECD /* SPTrackerEvent.h in Headers */,
+				8ADC2453400F286CD49F39A1E8E018CD /* SPUnstructured.h in Headers */,
+				BCC146B2D522388C89340320122BD185 /* SPUtilities.h in Headers */,
+				A8836ABB6EB294E442C9C90F20A053CB /* SPWeakTimerTarget.h in Headers */,
+				FDF37946C94A8595552FD4A5CA15C29C /* UIViewController+SPScreenView_SWIZZLE.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -869,16 +879,16 @@
 		};
 		B261C8EBD659B1E21B1D24B5DA3177EF /* SnowplowTracker-watchOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6C3CE41B4B0537E7F5B89EC121A93AEE /* Build configuration list for PBXNativeTarget "SnowplowTracker-watchOS" */;
+			buildConfigurationList = F669A4B34603581AEFAEB0E0ACF01FE4 /* Build configuration list for PBXNativeTarget "SnowplowTracker-watchOS" */;
 			buildPhases = (
-				A6B357BF07D37205BCAABE4CE80E91FB /* Headers */,
-				C563C91FF1DA17F76727B292D5AD0CAD /* Sources */,
-				827A4258CF9F2764EDBC24F78CB6B8DA /* Frameworks */,
+				282D7607FD5822F5C501D83ACE5B54A1 /* Headers */,
+				4DD94EE7C4CDA92B84A00F406EB15947 /* Sources */,
+				E9B7D18019602DBCC874BFD5A3CF2026 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				61127FA8209F04195C05BD4F8BEBD655 /* PBXTargetDependency */,
+				562A3C717CFAC05E0A9902A3E5CD2ABB /* PBXTargetDependency */,
 			);
 			name = "SnowplowTracker-watchOS";
 			productName = "SnowplowTracker-watchOS";
@@ -887,16 +897,16 @@
 		};
 		E7F6349754F16DE836B7AF669F08095F /* SnowplowTracker-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E6EDF88A95D9E355A587C57CACFE2CF3 /* Build configuration list for PBXNativeTarget "SnowplowTracker-iOS" */;
+			buildConfigurationList = D6EE93C7190BE8E778F4A1BC73A4F2D8 /* Build configuration list for PBXNativeTarget "SnowplowTracker-iOS" */;
 			buildPhases = (
-				4DF67101D931419B630EE24F8987559C /* Headers */,
-				82281E61B1A30E7626085D232A7E6598 /* Sources */,
-				E4A7F600808B8B10EB63FC0A4A4B7840 /* Frameworks */,
+				F796137CCA26B6EB79484061C0563E1E /* Headers */,
+				750BB394062F10AC898B95380651BCC6 /* Sources */,
+				E2894FE00195EAAF2EC0959330F97202 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				4AAB1129EA694A836FBBAF754AA8D0AE /* PBXTargetDependency */,
+				52F1E9B0455B1A29194B117D9E75BA11 /* PBXTargetDependency */,
 			);
 			name = "SnowplowTracker-iOS";
 			productName = "SnowplowTracker-iOS";
@@ -949,47 +959,91 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		82281E61B1A30E7626085D232A7E6598 /* Sources */ = {
+		4DD94EE7C4CDA92B84A00F406EB15947 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				56098A65FF35AB756B78FA9AF8DE6A8A /* OpenIDFA.m in Sources */,
-				FBFF3B9818C00AB5D8FD0C2FC1F37692 /* SNOWError.m in Sources */,
-				E3007ACB08E06ED2D2645EBBF7D2E24D /* Snowplow.m in Sources */,
-				E64706D65115697CD7F98387FF38DB50 /* SnowplowTracker-iOS-dummy.m in Sources */,
-				2A7F38EFA30831CE3A17D6FE9BA258DA /* SNOWReachability.m in Sources */,
-				4CF981D7C586EE5C41969E44D98E6AA8 /* SPBackground.m in Sources */,
-				38BB6FA50E50BD0C939534AA71C25D54 /* SPConsentDocument.m in Sources */,
-				ADFC3E00FFF8B900B9E5751B2D9B72E9 /* SPConsentGranted.m in Sources */,
-				104AB419D000C0C69C1FE24E5AE037E8 /* SPConsentWithdrawn.m in Sources */,
-				C1500EFADDB5CBC36CDD989ED9D0C015 /* SPDevicePlatform.m in Sources */,
-				AEE3982E05D6AB29F66D51A23B87A447 /* SPEcommerce.m in Sources */,
-				8D261F005F84447D6083CF7CBA40A698 /* SPEcommerceItem.m in Sources */,
-				0DFB7A37CCBF2737DFEE1C1EA2513356 /* SPEmitter.m in Sources */,
-				52E08E56C33670213FE4DEB1BED65CB2 /* SPEventBase.m in Sources */,
-				24FF5C083868E9A0DE6A9B602B1D0E46 /* SPEventStore.m in Sources */,
-				02C57B51A10D34471740D1F351BE0A96 /* SPForeground.m in Sources */,
-				10740CC4CA3F1BE3695A883D084F47AA /* SPGlobalContext.m in Sources */,
-				FB2EE06EA74A73F93FE7CB5BCF165042 /* SPInstallTracker.m in Sources */,
-				A499F9291BA8F55D83C23F9BA3E077C5 /* SPPageView.m in Sources */,
-				41A883F77D8F8E84B2B295B307B984CF /* SPPayload.m in Sources */,
-				ACA1544E07C29C319D00603B93F6E472 /* SPPushNotification.m in Sources */,
-				2572D72496791FEDCCC201894864679D /* SPRequestResponse.m in Sources */,
-				77C32A3BC56F986E02B7FCE6C06C7DEC /* SPSchemaRule.m in Sources */,
-				F458236CC48A949994386AA4FAB9B05D /* SPSchemaRuleset.m in Sources */,
-				C0C9F5B69F26892D22A3D90F252AA9EF /* SPScreenState.m in Sources */,
-				C5BA17ED194FCBF55D9839D9E553905B /* SPScreenView.m in Sources */,
-				14DCC754081F15CDC974D6B276C6696E /* SPSelfDescribingJson.m in Sources */,
-				03E368F37601202B2C7D72066E9A0A39 /* SPSession.m in Sources */,
-				4CDC29764D44802F4F2B61FB05079E73 /* SPStructured.m in Sources */,
-				E2104606DCBEF70923AFA0F545E0DF83 /* SPSubject.m in Sources */,
-				9F94CC5D2FB4BA6EB23D2911FA919423 /* SPTiming.m in Sources */,
-				6574C5C44B04835092148EEAE71498DC /* SPTracker.m in Sources */,
-				66AF63941A7B446E85C55D5B6435ADAF /* SPTrackerEvent.m in Sources */,
-				14825D387D34945A94000E4E07A456DA /* SPUnstructured.m in Sources */,
-				4B546680F2EF7079F63B96023DC4D631 /* SPUtilities.m in Sources */,
-				DB63D5241F96625D13A9247D664896C2 /* SPWeakTimerTarget.m in Sources */,
-				85629B6CFF8C85999A257339CA66967A /* UIViewController+SPScreenView_SWIZZLE.m in Sources */,
+				999218F1B26E5010174306A0465FB879 /* OpenIDFA.m in Sources */,
+				EB356B1B84BBB2A0202E419A9F928FFF /* SNOWError.m in Sources */,
+				C71F5E6560B03B9451C5C75A99E7216C /* Snowplow.m in Sources */,
+				537CFCDCE720FD6687A98F6D704491D1 /* SnowplowTracker-watchOS-dummy.m in Sources */,
+				465CA4E77E9441DEECCC2F95839440EF /* SPBackground.m in Sources */,
+				B094716A30DDBBFCF4004EABBC95A156 /* SPConsentDocument.m in Sources */,
+				F43DC99363B7FAA5FCBCEB4D060AE5D4 /* SPConsentGranted.m in Sources */,
+				5DEA56CA21AEF2914C233D6296D64648 /* SPConsentWithdrawn.m in Sources */,
+				FC777AB3EF0DB2B00D3F58A1159CA00F /* SPDevicePlatform.m in Sources */,
+				309E30E0A8304E432B82D4BD1BD73946 /* SPEcommerce.m in Sources */,
+				F28DDE4A0C96B9107F2EB89DA98723CA /* SPEcommerceItem.m in Sources */,
+				6E755CA013B735066171E93D32D8F3DE /* SPEmitter.m in Sources */,
+				26061DD8E8B41043853DEC9F747185F0 /* SPEventBase.m in Sources */,
+				147849EFDF6F68D528363763CE97A0E9 /* SPEventStore.m in Sources */,
+				A326E17D51114EF9BCDF8D30A49D3B74 /* SPForeground.m in Sources */,
+				98C95D21A80C88C2CF44E89E7B5EDAAB /* SPGdprContext.m in Sources */,
+				42EBCA5E5937841BAEB97FEEBB6A08EC /* SPGlobalContext.m in Sources */,
+				C4B76157D4879569BC1DC4186BC1DA4D /* SPInstallTracker.m in Sources */,
+				D457B7C342FB0B72E4A1BF281F42A2DD /* SPPageView.m in Sources */,
+				40B94ABC8B7F398009CC4539F4EE9AED /* SPPayload.m in Sources */,
+				6E12A8D2AA83A32F5E6E4A699B397933 /* SPPushNotification.m in Sources */,
+				3CFF1C3151DDF442B90535CAFF7F0BDB /* SPRequestResponse.m in Sources */,
+				E9A10E88058E878F01B38236CF9CFE80 /* SPSchemaRule.m in Sources */,
+				2E6F07A7A5194C68FE29F87BBAD24470 /* SPSchemaRuleset.m in Sources */,
+				4E414739778DCC9C3600570D7335A5F3 /* SPScreenState.m in Sources */,
+				B297F05E322F395090ECAE4254D051D0 /* SPScreenView.m in Sources */,
+				03880BB0EA934F4281A3991934957F76 /* SPSelfDescribingJson.m in Sources */,
+				39E2BF95DF70177283D2B9C83C2B87F2 /* SPSession.m in Sources */,
+				959E1AA97F6D151112F6711D0ECF8862 /* SPStructured.m in Sources */,
+				B4CB34A4FACF3BAA3E0B066AD31F83F6 /* SPSubject.m in Sources */,
+				F3D445B2E46176B7FE0730010D6D7435 /* SPTiming.m in Sources */,
+				530AE57AD9F2DF3197681CB34580D0CC /* SPTracker.m in Sources */,
+				43D5D423F5A459A1266EAA587BD44FD8 /* SPTrackerEvent.m in Sources */,
+				2732385C42EA171617CC44BB3A14BD04 /* SPUnstructured.m in Sources */,
+				E41B8248A174D5B1483459491027BDC3 /* SPUtilities.m in Sources */,
+				10A4200B86CD34D42FBB6D2C408B8760 /* SPWeakTimerTarget.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		750BB394062F10AC898B95380651BCC6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F5DD1EB9E7B9B112F80AE885C72F194D /* OpenIDFA.m in Sources */,
+				A81B90A652D6C47C908A3A077C92CCA9 /* SNOWError.m in Sources */,
+				2260BB5AF18DD6F00F0102AD10059717 /* Snowplow.m in Sources */,
+				7E144925513FAECA897844553095B4A4 /* SnowplowTracker-iOS-dummy.m in Sources */,
+				0BA275988B9317BC6765342DB53C5239 /* SNOWReachability.m in Sources */,
+				E891E7C5E43AFF37DF7A2B5E9EA58911 /* SPBackground.m in Sources */,
+				6457B7D9BDB4575DD43B3A3C663ADB94 /* SPConsentDocument.m in Sources */,
+				45BD5D72CD7FCCEDC13A8C82D3B5EDDF /* SPConsentGranted.m in Sources */,
+				85ED0DCF67C1FC9C7DD2383E74A8107E /* SPConsentWithdrawn.m in Sources */,
+				9FE29F8364C2DD4BF7435C4F6A01EBE1 /* SPDevicePlatform.m in Sources */,
+				6B624B1628CFA53376D613A1A520E098 /* SPEcommerce.m in Sources */,
+				DB3344AD5A8B680F6E3B7808F5DA8D24 /* SPEcommerceItem.m in Sources */,
+				EC44F6FB47141E3A58027A05D82A988C /* SPEmitter.m in Sources */,
+				74CDAD94C90F0BC6DE50865571631A5F /* SPEventBase.m in Sources */,
+				97A712E88C9B1310F6081A08BC42B3B7 /* SPEventStore.m in Sources */,
+				41343463E50C875C65C86CA4A45A5FA9 /* SPForeground.m in Sources */,
+				629D0821EAD457874CB340B2F4F2BEB0 /* SPGdprContext.m in Sources */,
+				0492EF8D2CDD054A22AF01DA12B48E49 /* SPGlobalContext.m in Sources */,
+				84581985C8C81A1C7D90CC4EA2016010 /* SPInstallTracker.m in Sources */,
+				894EC57FE3B0EBD9D19D40D5262E4281 /* SPPageView.m in Sources */,
+				92874BC359278654A273EF8951147E1C /* SPPayload.m in Sources */,
+				D5BD625EB88F70880CBE5EF0974C401C /* SPPushNotification.m in Sources */,
+				E152F1D6495895E7D009851ED693E8DC /* SPRequestResponse.m in Sources */,
+				717A691330A232415E69480809245039 /* SPSchemaRule.m in Sources */,
+				C60D092192882D3333598D3FC68C93E1 /* SPSchemaRuleset.m in Sources */,
+				F1668AE38EA7718B59360951F03200B7 /* SPScreenState.m in Sources */,
+				785545731EDDD7725F2896DB8AA81968 /* SPScreenView.m in Sources */,
+				BE2573D80C29440309C74ADE0681BCAB /* SPSelfDescribingJson.m in Sources */,
+				887BEB86B8CBD2BF7E2400671B2D4135 /* SPSession.m in Sources */,
+				CD75D364545222D51DC2C4A8BA05E196 /* SPStructured.m in Sources */,
+				8EC9D32271EA5B28197908286500D2B8 /* SPSubject.m in Sources */,
+				6E8698DBB8EA592D5C08AEEBAF7B230A /* SPTiming.m in Sources */,
+				1B1999B71014A817C1593C58115425E5 /* SPTracker.m in Sources */,
+				D20DCC69B03EB63B42DBF7622C1C9023 /* SPTrackerEvent.m in Sources */,
+				409C551E3B8051FBA9E9C57D29E0FD26 /* SPUnstructured.m in Sources */,
+				8683D204FACD5FAAC3CE8A390928F1CA /* SPUtilities.m in Sources */,
+				59DB7BEAF35572802ACCE3620F456F56 /* SPWeakTimerTarget.m in Sources */,
+				1AEEE612C90F6233B4C5D7CB7D77878E /* UIViewController+SPScreenView_SWIZZLE.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -998,48 +1052,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				2E05E556BE848BAB4D986C28E8E9BDDF /* Pods-SnowplowSwiftWatch Extension-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		C563C91FF1DA17F76727B292D5AD0CAD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2CA4BE43FAD7344E1F7F4044F25A0A2F /* OpenIDFA.m in Sources */,
-				3A6007DFF23A3B6EA157DEDE47E9B38A /* SNOWError.m in Sources */,
-				D29802B7F83B72679513CCF051A09626 /* Snowplow.m in Sources */,
-				3F9A8CD951D5B1C284F75B26243DE06C /* SnowplowTracker-watchOS-dummy.m in Sources */,
-				857E218F56C70683EDF32B0FCB987F1B /* SPBackground.m in Sources */,
-				2E2078F99C644B6DCC43BE3006893AF5 /* SPConsentDocument.m in Sources */,
-				F1DDBECB30FD7AF156D7B39F0CF9E479 /* SPConsentGranted.m in Sources */,
-				685E7B8C2B86867AAFDE2E5B3D288C0B /* SPConsentWithdrawn.m in Sources */,
-				B1D5869B75050E6BD309DF84384D0F03 /* SPDevicePlatform.m in Sources */,
-				2A382926E356427588E3870C82BA8468 /* SPEcommerce.m in Sources */,
-				1DC1DEF8AD8DC37D26942B2DE86AA90E /* SPEcommerceItem.m in Sources */,
-				81AC80467309ABAFF87E15F1B4859248 /* SPEmitter.m in Sources */,
-				4C7A91515902DB65623FD1B88D8D49D2 /* SPEventBase.m in Sources */,
-				BC8211D579DD2176C17A64FEB391F95D /* SPEventStore.m in Sources */,
-				789B6C0413A923C6E54CF7A2AC0F6F77 /* SPForeground.m in Sources */,
-				5B67B25AE176286A8B3393F20AEA6C3B /* SPGlobalContext.m in Sources */,
-				EB4DD583E0C1AB33A69396E15B116FE8 /* SPInstallTracker.m in Sources */,
-				6D8374B67DE82F584E049E8C3AD35E13 /* SPPageView.m in Sources */,
-				742453BE8104349D648C244C82AADC4F /* SPPayload.m in Sources */,
-				7B73B37F5833893DAB5365B113439586 /* SPPushNotification.m in Sources */,
-				B46097153E2E3F439231E6AE68994F3B /* SPRequestResponse.m in Sources */,
-				3F618F6ACFB21154593CB39B9040B1D3 /* SPSchemaRule.m in Sources */,
-				F4B6C6ABC456E3CB884C65629ACC0B79 /* SPSchemaRuleset.m in Sources */,
-				D8120049C0AEAE79D8BB3C8A70CC43D7 /* SPScreenState.m in Sources */,
-				561F6FC647479ECF2FDB0ABEFDDA9EDB /* SPScreenView.m in Sources */,
-				B69C37375A1A130F1D5A093AA3A68272 /* SPSelfDescribingJson.m in Sources */,
-				30E0DB6FD2ACE99361D5511B58208562 /* SPSession.m in Sources */,
-				5B3301841B26C90A9C7DB40913523DBA /* SPStructured.m in Sources */,
-				B922D57104F686B9A4983C510CBD02E2 /* SPSubject.m in Sources */,
-				5AA12245F7B55368878B902FE4E4DD22 /* SPTiming.m in Sources */,
-				3D86BC43E6BF41B1437E28DEEC6119D0 /* SPTracker.m in Sources */,
-				83D5CA787370518F536D1AB81F5CF6F2 /* SPTrackerEvent.m in Sources */,
-				1F85204CF3F8178E0CAD35D1E601B971 /* SPUnstructured.m in Sources */,
-				4537983EF37237CE84E6AEA5FA203F98 /* SPUtilities.m in Sources */,
-				52A082B412AB1D6CA34B6BF0E23B60DF /* SPWeakTimerTarget.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1079,17 +1091,17 @@
 			target = 09D8936C24020EE35FD4BBC3796A95DB /* FMDB-watchOS */;
 			targetProxy = 817046EC3996F369C530BDF13C4CA133 /* PBXContainerItemProxy */;
 		};
-		4AAB1129EA694A836FBBAF754AA8D0AE /* PBXTargetDependency */ = {
+		52F1E9B0455B1A29194B117D9E75BA11 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "FMDB-iOS";
 			target = 3FDEFF0D795E620F69126992BD6EFE0C /* FMDB-iOS */;
-			targetProxy = 36C6770EF8562827155BC9B3D790A63C /* PBXContainerItemProxy */;
+			targetProxy = 1EF338902947B4F3B19044861F472122 /* PBXContainerItemProxy */;
 		};
-		61127FA8209F04195C05BD4F8BEBD655 /* PBXTargetDependency */ = {
+		562A3C717CFAC05E0A9902A3E5CD2ABB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "FMDB-watchOS";
 			target = 09D8936C24020EE35FD4BBC3796A95DB /* FMDB-watchOS */;
-			targetProxy = 1634672C88F6D03900F3A248EC3BC48E /* PBXContainerItemProxy */;
+			targetProxy = 03B1384583D93A89EE0A9136455CBBAC /* PBXContainerItemProxy */;
 		};
 		6A6C1D8139E9C846BB985EAC88F9A84B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1219,28 +1231,27 @@
 			};
 			name = Debug;
 		};
-		51960D5509FEF7D2320FDB4224C253C4 /* Debug */ = {
+		70C027AB6DF26C41CEC4268DDBED59EC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D5284D47C6A2D58062C69E95DF3B56BA /* SnowplowTracker-iOS.xcconfig */;
+			baseConfigurationReference = 8AA910C8154FCC2394724FE78EC285DC /* SnowplowTracker-watchOS.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/SnowplowTracker-iOS/SnowplowTracker-iOS-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MODULEMAP_FILE = "Headers/Public/SnowplowTracker/SnowplowTracker-iOS.modulemap";
+				GCC_PREFIX_HEADER = "Target Support Files/SnowplowTracker-watchOS/SnowplowTracker-watchOS-prefix.pch";
+				MODULEMAP_FILE = "Headers/Public/SnowplowTracker/SnowplowTracker-watchOS.modulemap";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_MODULE_NAME = SnowplowTracker;
-				PRODUCT_NAME = "SnowplowTracker-iOS";
+				PRODUCT_NAME = "SnowplowTracker-watchOS";
 				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -1305,9 +1316,30 @@
 			};
 			name = Release;
 		};
-		7D8CC0624E12A7D1B4B663C0B7606A60 /* Release */ = {
+		BAC029CE1CAB0244A51C5AC0CB1751D7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D5284D47C6A2D58062C69E95DF3B56BA /* SnowplowTracker-iOS.xcconfig */;
+			baseConfigurationReference = F2F52BAC24768F73915DD2C2EA957A95 /* Pods-SnowplowSwiftDemo.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACH_O_TYPE = staticlib;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BB645ADF6716BAE89A1062947AD281D5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F775E6AB3889D1DF600E20977AF0124B /* SnowplowTracker-iOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1331,27 +1363,6 @@
 			};
 			name = Release;
 		};
-		BAC029CE1CAB0244A51C5AC0CB1751D7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F2F52BAC24768F73915DD2C2EA957A95 /* Pods-SnowplowSwiftDemo.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACH_O_TYPE = staticlib;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
 		C53D8DE27A304C5241A815FBC85F34EB /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0EE5F41DD3ACCDE1D6EB5031C5810222 /* Pods-SnowplowSwiftWatch Extension.release.xcconfig */;
@@ -1370,6 +1381,31 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VALIDATE_PRODUCT = YES;
 				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Release;
+		};
+		C746D712AE9446DD6597E63DC70972BE /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8AA910C8154FCC2394724FE78EC285DC /* SnowplowTracker-watchOS.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/SnowplowTracker-watchOS/SnowplowTracker-watchOS-prefix.pch";
+				MODULEMAP_FILE = "Headers/Public/SnowplowTracker/SnowplowTracker-watchOS.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = SnowplowTracker;
+				PRODUCT_NAME = "SnowplowTracker-watchOS";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -1397,30 +1433,6 @@
 			};
 			name = Release;
 		};
-		D29C0ABD3F9EC2045B4BD6D3AE7BFA18 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0BD4900F50D91416AC99D51EE4BC03F3 /* SnowplowTracker-watchOS.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/SnowplowTracker-watchOS/SnowplowTracker-watchOS-prefix.pch";
-				MODULEMAP_FILE = "Headers/Public/SnowplowTracker/SnowplowTracker-watchOS.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = SnowplowTracker;
-				PRODUCT_NAME = "SnowplowTracker-watchOS";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Debug;
-		};
 		E00BF1CC285E9C3D905871A3D17E24B6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 987CEC26216D30EFD857D4CA96370E64 /* FMDB-iOS.xcconfig */;
@@ -1447,30 +1459,30 @@
 			};
 			name = Release;
 		};
-		E0256398D97F12FAE0CFA41EF38D8877 /* Release */ = {
+		E8DAA4911F368E0E0D0587064C77B2A5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0BD4900F50D91416AC99D51EE4BC03F3 /* SnowplowTracker-watchOS.xcconfig */;
+			baseConfigurationReference = F775E6AB3889D1DF600E20977AF0124B /* SnowplowTracker-iOS.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/SnowplowTracker-watchOS/SnowplowTracker-watchOS-prefix.pch";
-				MODULEMAP_FILE = "Headers/Public/SnowplowTracker/SnowplowTracker-watchOS.modulemap";
+				GCC_PREFIX_HEADER = "Target Support Files/SnowplowTracker-iOS/SnowplowTracker-iOS-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MODULEMAP_FILE = "Headers/Public/SnowplowTracker/SnowplowTracker-iOS.modulemap";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_MODULE_NAME = SnowplowTracker;
-				PRODUCT_NAME = "SnowplowTracker-watchOS";
+				PRODUCT_NAME = "SnowplowTracker-iOS";
 				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = watchos;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 4;
-				VALIDATE_PRODUCT = YES;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Release;
+			name = Debug;
 		};
 		E94C6D910D59DEFAB509F22B25FE8074 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1526,15 +1538,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6C3CE41B4B0537E7F5B89EC121A93AEE /* Build configuration list for PBXNativeTarget "SnowplowTracker-watchOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D29C0ABD3F9EC2045B4BD6D3AE7BFA18 /* Debug */,
-				E0256398D97F12FAE0CFA41EF38D8877 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		90541EA888E08FE4BA34DCBB958F450D /* Build configuration list for PBXNativeTarget "Pods-SnowplowSwiftDemo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1562,6 +1565,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		D6EE93C7190BE8E778F4A1BC73A4F2D8 /* Build configuration list for PBXNativeTarget "SnowplowTracker-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8DAA4911F368E0E0D0587064C77B2A5 /* Debug */,
+				BB645ADF6716BAE89A1062947AD281D5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DF07D6DE040B61FFF4C25F363C2947E3 /* Build configuration list for PBXNativeTarget "FMDB-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1571,11 +1583,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E6EDF88A95D9E355A587C57CACFE2CF3 /* Build configuration list for PBXNativeTarget "SnowplowTracker-iOS" */ = {
+		F669A4B34603581AEFAEB0E0ACF01FE4 /* Build configuration list for PBXNativeTarget "SnowplowTracker-watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				51960D5509FEF7D2320FDB4224C253C4 /* Debug */,
-				7D8CC0624E12A7D1B4B663C0B7606A60 /* Release */,
+				70C027AB6DF26C41CEC4268DDBED59EC /* Debug */,
+				C746D712AE9446DD6597E63DC70972BE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Snowplow iOSTests/TestGeneratedJsons.m
+++ b/Snowplow iOSTests/TestGeneratedJsons.m
@@ -27,6 +27,7 @@
 #import "SPTracker.h"
 #import "SPSession.h"
 #import "SPSubject.h"
+#import "SPGdprContext.h"
 #import "SPPayload.h"
 #import "SPEvent.h"
 #import "SPSelfDescribingJson.h"
@@ -98,6 +99,14 @@ const NSString* IGLU_PATH = @"http://raw.githubusercontent.com/snowplow/iglu-cen
     NSDictionary * data = [subject getGeoLocationDict];
     NSDictionary * json = [[[SPSelfDescribingJson alloc] initWithSchema:kSPGeoContextSchema andData:data] getAsDictionary];
     XCTAssertTrue([validator validateJson:json]);
+}
+
+- (void)testGdprContextJson {
+    SPGdprContext *gdpr = [[SPGdprContext alloc] initWithBasis:SPGdprProcessingBasisConsent
+                                                    documentId:@"id"
+                                               documentVersion:@"version"
+                                           documentDescription:@"description"];
+    XCTAssertTrue([validator validateJson:[gdpr.context getAsDictionary]]);
 }
 
 - (void)testStructuredEventPayloadJson  {

--- a/Snowplow iOSTests/TestScreenState.m
+++ b/Snowplow iOSTests/TestScreenState.m
@@ -2,8 +2,22 @@
 //  TestScreenState.m
 //  Snowplow-iOSTests
 //
-//  Created by Michael Hadam on 4/1/19.
-//  Copyright © 2019 Snowplow Analytics. All rights reserved.
+//  Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Michael Hadam
+//  Copyright © 2020 Snowplow Analytics. All rights reserved.
+//  License: Apache License Version 2.0
 //
 
 #import <XCTest/XCTest.h>

--- a/Snowplow macOSTests/Snowplow_macOSTests.m
+++ b/Snowplow macOSTests/Snowplow_macOSTests.m
@@ -2,8 +2,22 @@
 //  Snowplow_macOSTests.m
 //  Snowplow macOSTests
 //
-//  Created by Michael Hadam on 12/20/18.
-//  Copyright © 2018 Snowplow Analytics. All rights reserved.
+//  Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Michael Hadam
+//  Copyright © 2020 Snowplow Analytics. All rights reserved.
+//  License: Apache License Version 2.0
 //
 
 #import <XCTest/XCTest.h>

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -304,6 +304,14 @@
 		ED8A3EED2371709100E51827 /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 75264A2F224E5DBC000E0E9B /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ED914EB52431FEE70068DA0A /* TestGlobalContexts.m in Sources */ = {isa = PBXBuildFile; fileRef = ED914EB42431FEE70068DA0A /* TestGlobalContexts.m */; };
 		ED914EB72432081F0068DA0A /* TestSchemaRuleset.m in Sources */ = {isa = PBXBuildFile; fileRef = ED914EB62432081F0068DA0A /* TestSchemaRuleset.m */; };
+		ED914EBA24325AB40068DA0A /* SPGdprContext.h in Headers */ = {isa = PBXBuildFile; fileRef = ED914EB824325AB40068DA0A /* SPGdprContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ED914EBB24325AB40068DA0A /* SPGdprContext.h in Headers */ = {isa = PBXBuildFile; fileRef = ED914EB824325AB40068DA0A /* SPGdprContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ED914EBC24325AB40068DA0A /* SPGdprContext.h in Headers */ = {isa = PBXBuildFile; fileRef = ED914EB824325AB40068DA0A /* SPGdprContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ED914EBD24325AB40068DA0A /* SPGdprContext.h in Headers */ = {isa = PBXBuildFile; fileRef = ED914EB824325AB40068DA0A /* SPGdprContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ED914EBE24325AB40068DA0A /* SPGdprContext.m in Sources */ = {isa = PBXBuildFile; fileRef = ED914EB924325AB40068DA0A /* SPGdprContext.m */; };
+		ED914EBF24325AB40068DA0A /* SPGdprContext.m in Sources */ = {isa = PBXBuildFile; fileRef = ED914EB924325AB40068DA0A /* SPGdprContext.m */; };
+		ED914EC024325AB40068DA0A /* SPGdprContext.m in Sources */ = {isa = PBXBuildFile; fileRef = ED914EB924325AB40068DA0A /* SPGdprContext.m */; };
+		ED914EC124325AB40068DA0A /* SPGdprContext.m in Sources */ = {isa = PBXBuildFile; fileRef = ED914EB924325AB40068DA0A /* SPGdprContext.m */; };
 		ED91CB6C23AA715B0078E75F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED91CB6D23AA715B0078E75F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED91CB6E23AA715B0078E75F /* SPDevicePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -508,6 +516,8 @@
 		ED852B3223A0EEC600F2DF6B /* SNOWReachability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SNOWReachability.h; sourceTree = "<group>"; };
 		ED914EB42431FEE70068DA0A /* TestGlobalContexts.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestGlobalContexts.m; sourceTree = "<group>"; };
 		ED914EB62432081F0068DA0A /* TestSchemaRuleset.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestSchemaRuleset.m; sourceTree = "<group>"; };
+		ED914EB824325AB40068DA0A /* SPGdprContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPGdprContext.h; sourceTree = "<group>"; };
+		ED914EB924325AB40068DA0A /* SPGdprContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPGdprContext.m; sourceTree = "<group>"; };
 		ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDevicePlatform.h; sourceTree = "<group>"; };
 		ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPDevicePlatform.m; sourceTree = "<group>"; };
 		EDD58289242538860040F155 /* SPEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPEvent.h; sourceTree = "<group>"; };
@@ -718,6 +728,8 @@
 				754774CC222756470043B814 /* UIViewController+SPScreenView_SWIZZLE.m */,
 				75264A2F224E5DBC000E0E9B /* SPInstallTracker.h */,
 				75264A31224E5DD2000E0E9B /* SPInstallTracker.m */,
+				ED914EB824325AB40068DA0A /* SPGdprContext.h */,
+				ED914EB924325AB40068DA0A /* SPGdprContext.m */,
 			);
 			path = Snowplow;
 			sourceTree = "<group>";
@@ -838,6 +850,7 @@
 				ED843F4E23F7195D00DB74B5 /* SPPushNotification.h in Headers */,
 				752DAC3B21CC43C70065F874 /* SPRequestResponse.h in Headers */,
 				ED843F0823F70BEA00DB74B5 /* SPConsentWithdrawn.h in Headers */,
+				ED914EBA24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				ED843ED023F5A91300DB74B5 /* SPTrackerEvent.h in Headers */,
 				ED843EE023F6FED000DB74B5 /* SPPageView.h in Headers */,
 				EDE8F0BA242901FE00107F03 /* SPGlobalContext.h in Headers */,
@@ -870,6 +883,7 @@
 				ED843F4F23F7195D00DB74B5 /* SPPushNotification.h in Headers */,
 				EDE8F0CF2429025300107F03 /* SPSchemaRuleset.h in Headers */,
 				EDFEEAC823A7CB2A001E6D03 /* SPInstallTracker.h in Headers */,
+				ED914EBB24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				754774C12225FBB90043B814 /* SPScreenState.h in Headers */,
 				ED843F1323F70C9D00DB74B5 /* SPConsentDocument.h in Headers */,
 				ED843EEB23F7001D00DB74B5 /* SPStructured.h in Headers */,
@@ -914,6 +928,7 @@
 				ED843F5023F7195D00DB74B5 /* SPPushNotification.h in Headers */,
 				EDE8F0D02429025300107F03 /* SPSchemaRuleset.h in Headers */,
 				75CAC43721F2A0CC00271FB3 /* SPRequestCallback.h in Headers */,
+				ED914EBC24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				754774C22225FBB90043B814 /* SPScreenState.h in Headers */,
 				ED843F1423F70C9D00DB74B5 /* SPConsentDocument.h in Headers */,
 				ED843EEC23F7001D00DB74B5 /* SPStructured.h in Headers */,
@@ -972,6 +987,7 @@
 				ED843F5123F7195D00DB74B5 /* SPPushNotification.h in Headers */,
 				75F9C5F021FA35BC00A5B8FC /* SPWeakTimerTarget.h in Headers */,
 				ED843F0B23F70BEA00DB74B5 /* SPConsentWithdrawn.h in Headers */,
+				ED914EBD24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				ED843ED323F5A91300DB74B5 /* SPTrackerEvent.h in Headers */,
 				ED843EE323F6FED000DB74B5 /* SPPageView.h in Headers */,
 				EDE8F0BD242901FE00107F03 /* SPGlobalContext.h in Headers */,
@@ -1194,6 +1210,7 @@
 				ED843EEE23F7001D00DB74B5 /* SPStructured.m in Sources */,
 				ED843EF823F700A000DB74B5 /* SPUnstructured.m in Sources */,
 				ED843F2023F7163500DB74B5 /* SPConsentGranted.m in Sources */,
+				ED914EBE24325AB40068DA0A /* SPGdprContext.m in Sources */,
 				752DAC1921CC42BC0065F874 /* SPTracker.m in Sources */,
 				752DAC1B21CC42BC0065F874 /* SPEmitter.m in Sources */,
 				EDE8F0DE2429025300107F03 /* SPSchemaRule.m in Sources */,
@@ -1257,6 +1274,7 @@
 				75CAC43D21F2A17500271FB3 /* SPSubject.m in Sources */,
 				ED843ED523F5A91300DB74B5 /* SPTrackerEvent.m in Sources */,
 				ED843F2123F7163500DB74B5 /* SPConsentGranted.m in Sources */,
+				ED914EBF24325AB40068DA0A /* SPGdprContext.m in Sources */,
 				75CAC43E21F2A17500271FB3 /* SPSession.m in Sources */,
 				ED843F6723F71A6300DB74B5 /* SPBackground.m in Sources */,
 				75CAC43F21F2A17500271FB3 /* SPPayload.m in Sources */,
@@ -1298,6 +1316,7 @@
 				75CAC44A21F2A19500271FB3 /* SPEmitter.m in Sources */,
 				ED843ED623F5A91300DB74B5 /* SPTrackerEvent.m in Sources */,
 				ED843F2223F7163500DB74B5 /* SPConsentGranted.m in Sources */,
+				ED914EC024325AB40068DA0A /* SPGdprContext.m in Sources */,
 				ED91CB7323AA8AD50078E75F /* SPDevicePlatform.m in Sources */,
 				ED843F6823F71A6300DB74B5 /* SPBackground.m in Sources */,
 				75CAC44B21F2A19500271FB3 /* SPSubject.m in Sources */,
@@ -1350,6 +1369,7 @@
 				ED843EF123F7001D00DB74B5 /* SPStructured.m in Sources */,
 				ED843EFB23F700A000DB74B5 /* SPUnstructured.m in Sources */,
 				ED843F2323F7163500DB74B5 /* SPConsentGranted.m in Sources */,
+				ED914EC124325AB40068DA0A /* SPGdprContext.m in Sources */,
 				75F9C5D521FA357100A5B8FC /* OpenIDFA.m in Sources */,
 				75F9C5D621FA357100A5B8FC /* Snowplow.m in Sources */,
 				EDE8F0E12429025300107F03 /* SPSchemaRule.m in Sources */,

--- a/Snowplow/SPGdprContext.h
+++ b/Snowplow/SPGdprContext.h
@@ -1,5 +1,5 @@
 //
-//  UIViewController+SPScreenView.h
+//  SPGdprContext.h
 //  Snowplow
 //
 //  Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
@@ -15,29 +15,33 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Authors: Michael Hadam
+//  Authors: Alex Benini
 //  Copyright © 2020 Snowplow Analytics. All rights reserved.
 //  License: Apache License Version 2.0
 //
 
-#import <UIKit/UIKit.h>
-
-@class UIViewController;
-typedef NS_ENUM(NSInteger, SPScreenType);
+#import <Foundation/Foundation.h>
+#import "SPTracker.h"
+#import "SPSelfDescribingJson.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface UIViewController (SPScreenView_SWIZZLE)
+@interface SPGdprContext : NSObject
 
-- (void) SP_viewDidAppear:(BOOL)animated;
-- (NSString *) _SP_getViewControllerName:(UIViewController *)viewController;
-- (SPScreenType) _SP_getViewControllerType:(UIViewController *)viewController;
-- (SPScreenType) _SP_getTopViewControllerType;
-- (UIViewController *) _SP_topViewController;
-- (UIViewController *) _SP_topViewController:(UIViewController *)rootViewController;
-- (NSString *) _SP_getViewControllerName;
-- (BOOL) _SP_validateString:(NSString *)string;
-- (NSString *) _SP_getSnowplowId;
+/*!
+ @brief Set a GDPR context for the tracker
+ @param basisForProcessing Enum one of valid legal bases for processing.
+ @param documentId Document ID.
+ @param documentVersion Version of the document.
+ @param documentDescription Description of the document.
+ */
+- (nullable instancetype)initWithBasis:(SPGdprProcessingBasis)basisForProcessing
+                            documentId:(nullable NSString *)documentId
+                       documentVersion:(nullable NSString *)documentVersion
+                   documentDescription:(nullable NSString *)documentDescription;
+
+/// Return context with value stored about GDPR processing.
+- (SPSelfDescribingJson *)context;
 
 @end
 

--- a/Snowplow/SPGdprContext.m
+++ b/Snowplow/SPGdprContext.m
@@ -1,0 +1,84 @@
+//
+//  SPGdprContext.m
+//  Snowplow
+//
+//  Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  Copyright © 2020 Snowplow Analytics. All rights reserved.
+//  License: Apache License Version 2.0
+//
+
+#import "SPGdprContext.h"
+#import "Snowplow.h"
+
+@interface SPGdprContext ()
+
+@property (nonatomic) NSString *basis;
+@property (nonatomic) NSString *documentId;
+@property (nonatomic) NSString *documentVersion;
+@property (nonatomic) NSString *documentDescription;
+
+@end
+
+@implementation SPGdprContext
+
+- (instancetype)initWithBasis:(SPGdprProcessingBasis)basisForProcessing
+                   documentId:(NSString *)documentId
+              documentVersion:(NSString *)documentVersion
+          documentDescription:(NSString *)documentDescription
+{
+    if (self = [super init]) {
+        self.basis = [self stringFromProcessingBasis:basisForProcessing];
+        if (!self.basis) {
+            return nil;
+        }
+        self.documentId = documentId;
+        self.documentVersion = documentVersion;
+        self.documentDescription = documentDescription;
+    }
+    return self;
+}
+
+- (SPSelfDescribingJson *)context {
+    NSMutableDictionary<NSString *, NSString *> *data = [NSMutableDictionary dictionary];
+    [data setValue:self.basis forKey:kSPBasisForProcessing];
+    [data setValue:self.documentId forKey:kSPDocumentId];
+    [data setValue:self.documentVersion forKey:kSPDocumentVersion];
+    [data setValue:self.documentDescription forKey:kSPDocumentDescription];
+    return [[SPSelfDescribingJson alloc] initWithSchema:kSPGdprContextSchema andData:data];
+}
+
+#pragma mark Private methods
+
+- (NSString *)stringFromProcessingBasis:(SPGdprProcessingBasis)basis {
+    switch (basis) {
+        case SPGdprProcessingBasisConsent:
+            return @"consent";
+        case SPGdprProcessingBasisContract:
+            return @"contract";
+        case SPGdprProcessingBasisLegalObligation:
+            return @"legal_obligation";
+        case SPGdprProcessingBasisVitalInterest:
+            return @"vital_interests";
+        case SPGdprProcessingBasisPublicTask:
+            return @"public_task";
+        case SPGdprProcessingBasisLegitimateInterests:
+            return @"legitimate_interests";
+        default:
+            return nil;
+    }
+}
+
+@end

--- a/Snowplow/SPTracker.h
+++ b/Snowplow/SPTracker.h
@@ -52,6 +52,15 @@ void uncaughtExceptionHandler(NSException *exception);
 
 @class SPGlobalContext;
 
+typedef NS_ENUM(NSInteger, SPGdprProcessingBasis) {
+    SPGdprProcessingBasisConsent = 0,
+    SPGdprProcessingBasisContract = 1,
+    SPGdprProcessingBasisLegalObligation = 2,
+    SPGdprProcessingBasisVitalInterest = 3,
+    SPGdprProcessingBasisPublicTask = 4,
+    SPGdprProcessingBasisLegitimateInterests = 5
+};
+
 /*!
  @brief The builder for SPTracker.
  */
@@ -178,6 +187,18 @@ void uncaughtExceptionHandler(NSException *exception);
  */
 - (void)setGlobalContextGenerators:(NSDictionary<NSString *, SPGlobalContext *> *)globalContexts;
 
+/*!
+ @brief Tracker builder method to set a GDPR context for the tracker
+ @param basisForProcessing Enum one of valid legal bases for processing.
+ @param documentId Document ID.
+ @param documentVersion Version of the document.
+ @param documentDescription Description of the document.
+ */
+- (void)setGdprContextWithBasis:(SPGdprProcessingBasis)basisForProcessing
+                     documentId:(NSString *)documentId
+                documentVersion:(NSString *)documentVersion
+            documentDescription:(NSString *)documentDescription;
+
 @end
 
 /*!
@@ -292,6 +313,23 @@ void uncaughtExceptionHandler(NSException *exception);
  @return The global context associated with the tag or `nil` in case of any entry with that string tag.
  */
 - (SPGlobalContext *)removeGlobalContext:(NSString *)tag;
+
+/*!
+ Enables GDPR context to be sent with every event.
+ @param basisForProcessing GDPR Basis for processing.
+ @param documentId ID of a GDPR basis document.
+ @param documentVersion Version of the document.
+ @param documentDescription Description of the document.
+ */
+- (void)enableGdprContextWithBasis:(SPGdprProcessingBasis)basisForProcessing
+                        documentId:(NSString *)documentId
+                   documentVersion:(NSString *)documentVersion
+               documentDescription:(NSString *)documentDescription;
+
+/// Disable GDPR context.
+- (void)disableGdprContext;
+
+#pragma mark - Events tracking methods
 
 /*!
  @brief Tracks a page view event.

--- a/Snowplow/Snowplow.h
+++ b/Snowplow/Snowplow.h
@@ -84,6 +84,7 @@ extern NSString * const kSPBackgroundSchema;
 extern NSString * const kSPForegroundSchema;
 extern NSString * const kSPErrorSchema;
 extern NSString * const kSPApplicationInstallSchema;
+extern NSString * const kSPGdprContextSchema;
 
 // --- Event Keys
 
@@ -282,5 +283,12 @@ extern NSString * const kSPInstalledBefore;
 extern NSString * const kSPInstallTimestamp;
 extern NSString * const kSPPreviousInstallVersion;
 extern NSString * const kSPPreviousInstallBuild;
+
+// --- GDPR Context
+
+extern NSString * const kSPBasisForProcessing;
+extern NSString * const kSPDocumentId;
+extern NSString * const kSPDocumentVersion;
+extern NSString * const kSPDocumentDescription;
 
 @end

--- a/Snowplow/Snowplow.m
+++ b/Snowplow/Snowplow.m
@@ -68,6 +68,7 @@ NSString * const kSPForegroundSchema = @"iglu:com.snowplowanalytics.snowplow/app
 NSString * const kSPBackgroundSchema = @"iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0";
 NSString * const kSPErrorSchema = @"iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-2";
 NSString * const kSPApplicationInstallSchema = @"iglu:com.snowplowanalytics.mobile/application_install/jsonschema/1-0-0";
+NSString * const kSPGdprContextSchema     = @"iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0";
 
 // --- Event Keys
 
@@ -270,5 +271,12 @@ NSString * const kSPInstalledBefore        = @"SPInstalledBefore";
 NSString * const kSPInstallTimestamp       = @"SPInstallTimestamp";
 NSString * const kSPPreviousInstallVersion = @"SPInstallVersion";
 NSString * const kSPPreviousInstallBuild   = @"SPInstallBuild";
+
+// --- GDPR Context
+
+NSString * const kSPBasisForProcessing  = @"basisForProcessing";
+NSString * const kSPDocumentId          = @"documentId";
+NSString * const kSPDocumentVersion     = @"documentVersion";
+NSString * const kSPDocumentDescription = @"documentDescription";
 
 @end

--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.m
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.m
@@ -2,8 +2,22 @@
 //  UIViewController+SPScreenView_SWIZZLE.m
 //  Snowplow
 //
-//  Created by Michael Hadam on 2/27/19.
-//  Copyright © 2019 Snowplow Analytics. All rights reserved.
+//  Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Michael Hadam
+//  Copyright © 2020 Snowplow Analytics. All rights reserved.
+//  License: Apache License Version 2.0
 //
 
 #import "SPTracker.h"


### PR DESCRIPTION
Implementation of GDPR context.

Please review this suggested documentation:

----

The GDPR context attaches a context with the GDPR basis for processing and the details of a related document (eg. a consent document) to all events which are fired after it is set.

It takes the following arguments:

|      **Name** | **Description**             | **Required?** | **Type** |
|--------------:|:----------------------------|:--------------|:---------|
|       `basis` | GDPR Basis for processing | Yes           | Enum String   |
|     `documentId` | ID of a GDPR basis document     | No           | String   |
|        `documentVersion` | Version of the document        | No            | String   |
| `documentDescription` | Description of the document | No            | String   |

The required basisForProcessing accepts only the following literals: `consent`, `contract`, `legal_obligation`, `vital_interests`, `public_task`, `legitimate_interests` - in accordance with the [five legal bases for processing](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/)

The GDPR context is enabled by calling the `setGdprContextWithBasis:documentId:documentVersion:documentDescription:` method of the tracker builder or by calling the `enableGdprContextWithBasis:documentId:documentVersion:documentDescription:` method once the tracker has been initialised.

It is called as follows:

```
SPTracker *tracker = [SPTracker build:^(id<SPTrackerBuilder> builder) {
    [builder setEmitter:emitter];
    ...
    [builder setGdprContextWithBasis:SPGdprProcessingBasisConsent
                          documentId:@"someId"
                     documentVersion:@"0.1.0"
                 documentDescription:@"a demo document description"];
}];
```

Setup on tracker already initialised:

```
[tracker enableGdprContextWithBasis:SPGdprProcessingBasisConsent
                         documentId:@"someId"
                    documentVersion:@"0.1.0"
                documentDescription:@"a demo document description"];
```