### PR TITLE
Add missing references to SPConsentDocument.h (closes #507)

### DIFF
--- a/Snowplow/SPEvent.h
+++ b/Snowplow/SPEvent.h
@@ -28,6 +28,7 @@
 #import "SPUnstructured.h"
 #import "SPScreenView.h"
 #import "SPConsentWithdrawn.h"
+#import "SPConsentDocument.h"
 #import "SPConsentGranted.h"
 #import "SPTiming.h"
 #import "SPEcommerce.h"

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -49,6 +49,7 @@ Pod::Spec.new do |s|
     'Snowplow/SPUnstructured.h',
     'Snowplow/SPScreenView.h',
     'Snowplow/SPConsentWithdrawn.h',
+    'Snowplow/SPConsentDocument.h',
     'Snowplow/SPConsentGranted.h',
     'Snowplow/SPTiming.h',
     'Snowplow/SPEcommerce.h',


### PR DESCRIPTION
Fixes a regression in v1.3.0 by adding missing references to the public `SPConsentDocument.h` header.