### PR TITLE
Current session id access (closes #508)

### DIFF
--- a/Snowplow/SPSession.h
+++ b/Snowplow/SPSession.h
@@ -145,4 +145,10 @@
  */
 - (NSString*) getUserId;
 
+/**
+ * Returns the current session's id
+ * @return the current session's id
+ */
+- (NSString*) getSessionId;
+
 @end

--- a/Snowplow/SPSession.m
+++ b/Snowplow/SPSession.m
@@ -182,6 +182,10 @@ NSString * const kSessionSavePath = @"session.dict";
     return _userId;
 }
 
+- (NSString *)getSessionId {
+    return _currentSessionId;
+}
+
 - (NSInteger) getBackgroundIndex {
     return _backgroundIndex;
 }

--- a/Snowplow/SPTracker.h
+++ b/Snowplow/SPTracker.h
@@ -279,6 +279,13 @@ typedef NS_ENUM(NSInteger, SPGdprProcessingBasis) {
 - (NSString*) getSessionUserId;
 
 /*!
+ @brief Returns the current session's id.
+
+ @return UUID of the session.
+ */
+- (NSString*) getSessionId;
+
+/*!
  @brief Returns whether lifecyle events is enabled.
 
  @return Whether background and foreground events are sent.

--- a/Snowplow/SPTracker.m
+++ b/Snowplow/SPTracker.m
@@ -395,6 +395,10 @@ void uncaughtExceptionHandler(NSException *exception) {
     return [_session getUserId];
 }
 
+- (NSString*) getSessionId {
+    return [_session getSessionId];
+}
+
 - (BOOL) getLifecycleEvents {
     return _lifecycleEvents;
 }


### PR DESCRIPTION
Adds public access to an `SPTracker`'s current session id. Closes #508