### PR TITLE
Specifcy FMDB version instead of commit in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
-        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", .revision("d68317fc0d7a986872ebf389f8d09b870fc88a7d"))
+        .package(name: "FMDB", url: "https://github.com/ccgus/fmdb", from: "2.7.6")
     ],
     targets: [
         .target(


### PR DESCRIPTION
When support for Swift Package Manager was added to the snowplow-objc-tracker, its FMDB dependency was updated with SPM support, but not yet properly tagged with a new version. I believe that's why the dependency was added pointing to a specific commit. 

This was giving me the following error when I added the snowplow tracker through SPM, pointing to version 1.3.0: `package snowplow-objc-tracker is required using a version-based requirement and it depends on unversion package fmdb`. The workaround for this is to either add the snowplow tracker pointing to a specific commit as well, or use master (which could result in uncontrolled updates with breaking changes)

Since then the FMDB update with support for SPM has been tagged as version 2.7.6. This means that, once we add that version to the snowplow Package.swift, versioning works as expected.