### PR TITLE
Renew event ID when event object is reused (close #521)

### DIFF
--- a/Snowplow iOSTests/TestEvent.m
+++ b/Snowplow iOSTests/TestEvent.m
@@ -39,15 +39,17 @@
 }
 
 - (void)testEventBuilderConditions {
+    NSString *presetEventId = [NSUUID UUID].UUIDString;
+    
     // Valid construction
     SPPageView *event = [SPPageView build:^(id<SPPageViewBuilder> builder) {
         [builder setPageUrl:@"DemoPageUrl"];
         [builder setContexts:[self getCustomContext]];
-        [builder setEventId:@"an-event-id-string"];
+        [builder setEventId:presetEventId];
         [builder setTimestamp:@1234567890];
     }];
     XCTAssertNotNil(event);
-    XCTAssertEqualObjects([event getEventId], @"an-event-id-string");
+    XCTAssertEqualObjects([event getEventId], presetEventId);
     XCTAssertEqual([event getTimestamp].longLongValue, @(1234567890).longLongValue);
     event = nil;
     
@@ -76,16 +78,12 @@
     XCTAssertNil(event);
     
     // EventID is nil
-    @try {
-        event = [SPPageView build:^(id<SPPageViewBuilder> builder) {
-            [builder setPageUrl:@"DemoPageUrl"];
-            [builder setEventId:nil];
-        }];
-    }
-    @catch (NSException *exception) {
-        XCTAssertEqualObjects(@"EventID cannot be nil or empty.", exception.reason);
-    }
-    XCTAssertNil(event);
+    event = [SPPageView build:^(id<SPPageViewBuilder> builder) {
+        [builder setPageUrl:@"DemoPageUrl"];
+        [builder setEventId:nil];
+    }];
+    XCTAssertNotNil(event);
+    event = nil;
     
     // EventID is empty
     @try {
@@ -95,7 +93,7 @@
         }];
     }
     @catch (NSException *exception) {
-        XCTAssertEqualObjects(@"EventID cannot be nil or empty.", exception.reason);
+        XCTAssertEqualObjects(@"EventID has to be a valid UUID.", exception.reason);
     }
     XCTAssertNil(event);
 }

--- a/Snowplow iOSTests/TestTracker.m
+++ b/Snowplow iOSTests/TestTracker.m
@@ -174,8 +174,6 @@ NSString *const TEST_SERVER_TRACKER = @"http://www.notarealurl.com";
     XCTAssertEqual(payloadDict[kSPPlatform], SPDevicePlatformToString(SPDevicePlatformGeneral));
     XCTAssertEqual(payloadDict[kSPAppId], @"anAppId");
     XCTAssertEqual(payloadDict[kSPNamespace], @"aNamespace");
-    
-    
 
     // Test setting variables to new values
 
@@ -189,6 +187,19 @@ NSString *const TEST_SERVER_TRACKER = @"http://www.notarealurl.com";
     XCTAssertEqual(payloadDict[kSPPlatform], nil);
     XCTAssertEqual(payloadDict[kSPAppId], @"newAppId");
     XCTAssertEqual(payloadDict[kSPNamespace], @"newNamespace");
+}
+
+- (void)testEventIdNotDuplicated {
+    SPPrimitive *event = [SPStructured build:^(id<SPStructuredBuilder> builder) {
+        [builder setCategory:@"Category"];
+        [builder setAction:@"Action"];
+        [builder setLabel:@"Label"];
+    }];
+    NSUUID *eventId = [[SPTrackerEvent alloc] initWithEvent:event].eventId;
+    XCTAssertNotNil(eventId);
+    NSUUID *newEventId = [[SPTrackerEvent alloc] initWithEvent:event].eventId;
+    XCTAssertNotNil(newEventId);
+    XCTAssertNotEqualObjects(eventId, newEventId);
 }
 
 @end

--- a/Snowplow/SPEcommerce.m
+++ b/Snowplow/SPEcommerce.m
@@ -141,6 +141,9 @@
     return _items;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // to ignore warnings for deprecated methods that we are forced to use until the next major version release
+
 - (void)endProcessingWithTracker:(SPTracker *)tracker {
     // Track each item individually
     NSNumber *timestamp = [self getTimestamp];
@@ -149,5 +152,7 @@
         [tracker track:item];
     }
 }
+
+#pragma GCC diagnostic pop
 
 @end

--- a/Snowplow/SPEventBase.h
+++ b/Snowplow/SPEventBase.h
@@ -67,24 +67,23 @@ NSString * stringWithSPScreenType(SPScreenType screenType);
 
 /*!
  @brief Set the timestamp of the event.
-
  @param timestamp The timestamp of the event in milliseconds (epoch time)
+ @deprecated This method is for internal use only and will be removed in the next major version.
  */
-- (void) setTimestamp:(NSNumber *)timestamp;
+- (void) setTimestamp:(NSNumber *)timestamp __deprecated_msg("The timestamp will be set once the event is processed.");
 
 /*!
  @brief Set the contexts attached to the event.
-
  @param contexts An array of contexts (should be self-describing JSONs).
  */
 - (void) setContexts:(NSMutableArray *)contexts;
 
 /*!
  @brief Set the UUID associated with the event.
-
  @param eventId A UUID for the event.
+ @deprecated This method is for internal use only and will be removed in the next major version.
  */
-- (void) setEventId:(NSString *)eventId;
+- (void) setEventId:(NSString *)eventId __deprecated_msg("The eventId will be set once the event is processed.");
 @end
 
 /*!
@@ -108,9 +107,26 @@ NSString * stringWithSPScreenType(SPScreenType screenType);
 @property (nonatomic, readonly) NSDictionary<NSString *, NSObject *> *payload;
 
 - (void) basePreconditions;
+
+/*!
+ @brief Get the copy of the context list associated with the event.
+*/
 - (NSMutableArray *) getContexts;
-- (NSNumber *) getTimestamp;
-- (NSString *) getEventId;
+
+/*!
+ @brief Set the timestamp of the event.
+ @note If the timestamp is not set, it sets one as a side effect.
+ @deprecated This method is for internal use only and will be removed in the next major version.
+*/
+- (NSNumber *) getTimestamp __deprecated_msg("The timestamp is set only when the event is processed.");
+
+/*!
+ @brief Get the UUID associated with the event.
+ @note If the eventId is not set, it sets one as a side effect.
+ @deprecated This method is for internal use only and will be removed in the next major version.
+*/
+- (NSString *) getEventId __deprecated_msg("The eventId is set only when the event is processed.");
+
 - (SPPayload *) addDefaultParamsToPayload:(SPPayload *)pb __deprecated_msg("The payload can be updated only by the tracker.");
 
 /**

--- a/Snowplow/SPEventBase.m
+++ b/Snowplow/SPEventBase.m
@@ -49,9 +49,7 @@ NSString * stringWithSPScreenType(SPScreenType screenType) {
 - (id) init {
     self = [super init];
     if (self) {
-        _timestamp = [SPUtilities getTimestamp];
         _contexts = [[NSMutableArray alloc] init];
-        _eventId = [SPUtilities getUUIDString];
     }
     return self;
 }
@@ -81,10 +79,16 @@ NSString * stringWithSPScreenType(SPScreenType screenType) {
 }
 
 - (NSNumber *) getTimestamp {
+    if (!_timestamp) {
+        _timestamp = [SPUtilities getTimestamp];
+    }
     return _timestamp;
 }
 
 - (NSString *) getEventId {
+    if (!_eventId) {
+        _eventId = [SPUtilities getUUIDString];
+    }
     return _eventId;
 }
 
@@ -102,7 +106,9 @@ NSString * stringWithSPScreenType(SPScreenType screenType) {
 
 - (void) basePreconditions {
     [SPUtilities checkArgument:(_contexts != nil) withMessage:@"Contexts cannot be nil."];
-    [SPUtilities checkArgument:([_eventId length] != 0) withMessage:@"EventID cannot be nil or empty."];
+    if (_eventId) {
+        [SPUtilities checkArgument:([[NSUUID alloc] initWithUUIDString:_eventId] != nil) withMessage:@"EventID has to be a valid UUID."];
+    }
 }
 
 - (void)beginProcessingWithTracker:(SPTracker *)tracker {}

--- a/Snowplow/SPTracker.m
+++ b/Snowplow/SPTracker.m
@@ -192,6 +192,9 @@ void uncaughtExceptionHandler(NSException *exception) {
     _builderFinished = YES;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // to ignore warnings for deprecated methods that we are forced to use until the next major version release
+
 - (void) checkInstall {
     SPInstallTracker * installTracker = [[SPInstallTracker alloc] init];
     NSNumber * previousTimestamp = [installTracker getPreviousInstallTimestamp];
@@ -216,6 +219,8 @@ void uncaughtExceptionHandler(NSException *exception) {
         }
     }
 }
+
+#pragma GCC diagnostic pop
 
 - (void) setTrackerData {
     _trackerData = [NSMutableDictionary dictionaryWithObjectsAndKeys:

--- a/Snowplow/SPTrackerEvent.m
+++ b/Snowplow/SPTrackerEvent.m
@@ -30,9 +30,17 @@
 
 - (instancetype)initWithEvent:(SPEvent *)event {
     if (self = [super init]) {
-        self.eventId = [[NSUUID alloc] initWithUUIDString:event.eventId]; // it has to be set in the TrackerEvent
-        self.contexts = event.contexts; // it has to be set in the TrackerEvent
-        self.timestamp = event.timestamp.doubleValue / 1000; // it has to be set in the TrackerEvent
+        if (event.eventId) {
+            self.eventId = [[NSUUID alloc] initWithUUIDString:event.eventId];
+        } else {
+            self.eventId = [NSUUID UUID];
+        }
+        if (event.timestamp) {
+            self.timestamp = event.timestamp.doubleValue / 1000;
+        } else {
+            self.timestamp = [[[NSDate alloc] init] timeIntervalSince1970];
+        }
+        self.contexts = event.contexts;
         self.payload = event.payload;
 
         if ([event isKindOfClass:SPPrimitive.class]) {


### PR DESCRIPTION
The event ID is set in the event constructor. We want the event ID set when the event is tracked. Unless the user has set it programmatically.