### PR TITLE
Issue/525 fix url percent escaping

### DIFF
--- a/Snowplow iOSTests/TestEvent.m
+++ b/Snowplow iOSTests/TestEvent.m
@@ -200,7 +200,7 @@
     XCTAssertNil(event);
 }
 
-- (void)testUnstructuredBuilderConditions {
+- (void)testUnstructuredBuilderEmptyCondition {
     // Valid construction
     NSMutableDictionary * data = [[NSMutableDictionary alloc] init];
     [data setObject:[NSNumber numberWithInt:23] forKey:@"level"];
@@ -219,6 +219,25 @@
     }
     @catch (NSException *exception) {
         XCTAssertEqualObjects(@"EventData cannot be nil.", exception.reason);
+    }
+    XCTAssertNil(event);
+}
+
+- (void)testUnstructuredBuilderWrongDataCondition {
+    // Invalid dictionary
+    NSMutableDictionary * data = [[NSMutableDictionary alloc] init];
+    [data setObject:[NSNumber numberWithInt:12] forKey:[NSNumber numberWithInt:12]];
+    SPSelfDescribingJson * sdj = [[SPSelfDescribingJson alloc] initWithSchema:@"iglu:com.acme_company/demo_ios_event/jsonschema/1-0-0"
+                                                                      andData:data];
+    // Data is wrong
+    SPUnstructured *event;
+    @try {
+        event = [SPUnstructured build:^(id<SPUnstructuredBuilder> builder) {
+            [builder setEventData:sdj];
+        }];
+    }
+    @catch (NSException *exception) {
+        XCTAssertEqualObjects(@"EventData has to be JSON serializable.", exception.reason);
     }
     XCTAssertNil(event);
 }

--- a/Snowplow iOSTests/TestUtils.m
+++ b/Snowplow iOSTests/TestUtils.m
@@ -176,6 +176,20 @@
     XCTAssertEqualObjects([SPUtilities urlEncodeDictionary:encodedValues], @"a=%20&c=%3D");
 }
 
+- (void)testEscapedQueryString {
+    id testValues = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                     [NSNull null], @"null_value_key",
+                     @"Not null", @"string_value_key",
+                     @"|!\" £$%&/()=?^ì§°ç*éùàò+{}◊∞Ç±¿≈ ⁄›‰¢’”»ıè¶#@][ˆ¡≠`´÷‹~~¥‘“«`", @"characters_key",
+                     nil];
+    NSString *now = [SPUtilities urlEncodeDictionary:testValues];
+    NSString *then = @"string_value_key=Not%20null&characters_key=%7C%21%22%20%C2%A3%24%25%26%2F%28%29%3D%3F%5E%C3%AC%C2%A7%C2%B0%C3%A7%2A%C3%A9%C3%B9%C3%A0%C3%B2%2B%7B%7D%E2%97%8A%E2%88%9E%C3%87%C2%B1%C2%BF%E2%89%88%20%EF%A3%BF%E2%81%84%E2%80%BA%E2%80%B0%C2%A2%E2%80%99%E2%80%9D%C2%BB%C4%B1%C3%A8%C2%B6%23%40%5D%5B%CB%86%C2%A1%E2%89%A0%60%C2%B4%C3%B7%E2%80%B9~~%C2%A5%E2%80%98%E2%80%9C%C2%AB%60&null_value_key=%3Cnull%3E";
+    XCTAssertEqualObjects(now, then);
+    NSString *urlString = [NSString stringWithFormat:@"%@?%@", @"http://www.snowplow.com", now];
+    NSURL *url = [NSURL URLWithString:urlString];
+    XCTAssertNotNil(url);
+}
+
 - (void)testCheckArgument {
     @try {
         [SPUtilities checkArgument:NO withMessage:@"This will throw an exception."];

--- a/Snowplow/SPSession.m
+++ b/Snowplow/SPSession.m
@@ -33,11 +33,16 @@
 #import <UIKit/UIKit.h>
 #endif
 
+@interface SPSession ()
+
+@property (atomic) NSNumber *accessedLast;
+
+@end
+
 @implementation SPSession {
     NSInteger   _foregroundTimeout;
     NSInteger   _backgroundTimeout;
     NSInteger   _checkInterval;
-    NSNumber *  _accessedLast;
     BOOL        _inBackground;
     NSString *  _userId;
     NSString *  _currentSessionId;
@@ -239,7 +244,7 @@ NSString * const kSessionSavePath = @"session.dict";
             range = strongSelf->_foregroundTimeout;
         }
         
-        if (![strongSelf isTimeInRangeWithStartTime:strongSelf->_accessedLast.longLongValue andCheckTime:checkTime.longLongValue andRange:range]) {
+        if (![strongSelf isTimeInRangeWithStartTime:strongSelf.accessedLast.longLongValue andCheckTime:checkTime.longLongValue andRange:range]) {
             [strongSelf updateSession];
             [strongSelf updateAccessedLast];
             [strongSelf updateSessionDict];
@@ -256,7 +261,7 @@ NSString * const kSessionSavePath = @"session.dict";
 }
 
 - (void) updateAccessedLast {
-    _accessedLast = [SPUtilities getTimestamp];
+    self.accessedLast = [SPUtilities getTimestamp];
 }
 
 - (void) updateSessionDict {

--- a/Snowplow/SPTrackerEvent.m
+++ b/Snowplow/SPTrackerEvent.m
@@ -41,8 +41,8 @@
             self.timestamp = [[[NSDate alloc] init] timeIntervalSince1970];
         }
         self.trueTimestamp = event.trueTimestamp;
-        self.contexts = event.contexts;
-        self.payload = event.payload;
+        self.contexts = [event.contexts mutableCopy];
+        self.payload = [event.payload mutableCopy];
 
         if ([event isKindOfClass:SPPrimitive.class]) {
             self.eventName = [(SPPrimitive *)event name];

--- a/Snowplow/SPUnstructured.m
+++ b/Snowplow/SPUnstructured.m
@@ -45,6 +45,7 @@
 
 - (void) preconditions {
     [SPUtilities checkArgument:(_eventData != nil) withMessage:@"EventData cannot be nil."];
+    [SPUtilities checkArgument:[NSJSONSerialization isValidJSONObject:_eventData.data] withMessage:@"EventData has to be JSON serializable."];
     [self basePreconditions];
 }
 

--- a/Snowplow/SPUtilities.m
+++ b/Snowplow/SPUtilities.m
@@ -310,7 +310,8 @@
     if (!string) {
         return @"";   
     }
-    NSCharacterSet *allowedCharSet = [NSCharacterSet characterSetWithCharactersInString:@"{}!*'\\\"();:@&=+$,/?%#[]% "].invertedSet;
+    NSMutableCharacterSet *allowedCharSet = [NSCharacterSet URLQueryAllowedCharacterSet].mutableCopy;
+    [allowedCharSet removeCharactersInString:@"!*'\"();:@&=+$,/?%#[]% "];
     return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharSet];
 }
 


### PR DESCRIPTION
This PR contains three different bugfixes and improvements:

- Fix contexts duplication (#524)
- Fix url percent escaping (#525)
- Validate EventData in Unstructured events (#526)

The latter is an improvement needed to spot issues at event generation rather than later during the event processing, which generates a crash with an error hard to understand. 