### PR TITLE
TrueTimestamp has to be set in seconds (close #532)

### DIFF
--- a/Snowplow iOSTests/TestEvent.m
+++ b/Snowplow iOSTests/TestEvent.m
@@ -108,11 +108,14 @@
     XCTAssertNil([event getTrueTimestamp]);
 
     // Set trueTimestamp
+    NSNumber *testDate = @([[NSDate date] timeIntervalSince1970]);
     event = [SPPageView build:^(id<SPPageViewBuilder> builder) {
         [builder setPageUrl:@"DemoPageUrl"];
-        [builder setTrueTimestamp:@(1234567890)];
+        [builder setTrueTimestamp:testDate];
     }];
-    XCTAssertEqualObjects([event getTrueTimestamp], @(1234567890));
+    long long expected = (long long)(testDate.doubleValue * 1000);
+    long long testing = (long long)([event getTrueTimestamp].doubleValue * 1000);
+    XCTAssertEqual(testing, expected);
 }
 
 - (void)testPageViewBuilderConditions {

--- a/Snowplow/SPEventBase.h
+++ b/Snowplow/SPEventBase.h
@@ -74,7 +74,7 @@ NSString * stringWithSPScreenType(SPScreenType screenType);
 
 /*!
  @brief Set the optional timestamp of the event.
- @param timestamp The timestamp of the event in milliseconds (epoch time)
+ @param timestamp The timestamp of the event in seconds (epoch time)
  */
 - (void)setTrueTimestamp:(NSNumber *)timestamp;
 
@@ -123,14 +123,14 @@ NSString * stringWithSPScreenType(SPScreenType screenType);
 - (NSMutableArray *) getContexts;
 
 /*!
- @brief Get the timestamp of the event.
+ @brief Get the timestamp of the event in milliseconds (epoch time).
  @note If the timestamp is not set, it sets one as a side effect.
  @deprecated This method is for internal use only and will be removed in the next major version.
 */
 - (NSNumber *) getTimestamp __deprecated_msg("The timestamp is set only when the event is processed.");
 
 /*!
- @brief Get the user timestamp of the event if it has been set.
+ @brief Get the user timestamp of the event in seconds (epoch time) if it has been set.
 */
 - (NSNumber *)getTrueTimestamp;
 

--- a/Snowplow/SPEventBase.m
+++ b/Snowplow/SPEventBase.m
@@ -61,7 +61,8 @@ NSString * stringWithSPScreenType(SPScreenType screenType) {
 }
 
 - (void)setTrueTimestamp:(NSNumber *)trueTimestamp {
-    _trueTimestamp = trueTimestamp;
+    long long tt = trueTimestamp.doubleValue * 1000;
+    _trueTimestamp = @(tt);
 }
 
 - (void) setContexts:(NSMutableArray *)contexts {
@@ -90,7 +91,10 @@ NSString * stringWithSPScreenType(SPScreenType screenType) {
 }
 
 - (NSNumber *)getTrueTimestamp {
-    return _trueTimestamp;
+    if (!_trueTimestamp) {
+        return nil;
+    }
+    return @(_trueTimestamp.longLongValue / (double)1000);
 }
 
 - (NSString *) getEventId {

--- a/Snowplow/SPTracker.m
+++ b/Snowplow/SPTracker.m
@@ -554,9 +554,9 @@ void uncaughtExceptionHandler(NSException *exception) {
 
 - (void)addBasicPropertiesToPayload:(SPPayload *)payload event:(SPTrackerEvent *)event {
     [payload addValueToPayload:event.eventId.UUIDString forKey:kSPEid];
-    [payload addValueToPayload:[NSString stringWithFormat:@"%lld", (long long)(event.timestamp * 1000)] forKey:kSPTimestamp];
+    [payload addValueToPayload:[NSString stringWithFormat:@"%lld", event.timestamp] forKey:kSPTimestamp];
     if (event.trueTimestamp) {
-        [payload addValueToPayload:[NSString stringWithFormat:@"%lld", (long long)(event.trueTimestamp.doubleValue * 1000)] forKey:kSPTrueTimestamp];
+        [payload addValueToPayload:[NSString stringWithFormat:@"%lld", event.trueTimestamp.longLongValue] forKey:kSPTrueTimestamp];
     }
     [payload addDictionaryToPayload:_trackerData];
     if (_subject != nil) {

--- a/Snowplow/SPTrackerEvent.h
+++ b/Snowplow/SPTrackerEvent.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSString *schema;
 @property (nonatomic) NSString *eventName;
 @property (nonatomic) NSUUID *eventId;
-@property (nonatomic) NSTimeInterval timestamp;
+@property (nonatomic) long long timestamp;
 @property (nonatomic) NSNumber *trueTimestamp;
 @property (nonatomic) NSMutableArray<SPSelfDescribingJson *> *contexts;
 

--- a/Snowplow/SPTrackerEvent.m
+++ b/Snowplow/SPTrackerEvent.m
@@ -36,9 +36,9 @@
             self.eventId = [NSUUID UUID];
         }
         if (event.timestamp) {
-            self.timestamp = event.timestamp.doubleValue / 1000;
+            self.timestamp = event.timestamp.longLongValue;
         } else {
-            self.timestamp = [[[NSDate alloc] init] timeIntervalSince1970];
+            self.timestamp = (long long)([[[NSDate alloc] init] timeIntervalSince1970] * 1000);
         }
         self.trueTimestamp = event.trueTimestamp;
         self.contexts = [event.contexts mutableCopy];


### PR DESCRIPTION
@paulboocock This should be a comment fix of the trueTimestamp methods, but meanwhile I noticed that some type conversions and math operations can cause minor precision loss in the decimals, so I think it's worth to be a patch for the just released trueTimestamp feature.