### PR TITLE
Enable Xcode 12 support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 DerivedData
+.derivedData
 *.xcuserstate
 *.gcda
 *.gcno
@@ -39,3 +40,6 @@ Frameworks/
 
 # Documentation
 /docs/html/
+
+# Swift Package Manager
+.swiftpm

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "FMDB",
+        "repositoryURL": "https://github.com/ccgus/fmdb",
+        "state": {
+          "branch": null,
+          "revision": "61e51fde7f7aab6554f30ab061cc588b28a97d04",
+          "version": "2.7.7"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "SnowplowTracker",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v9)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "SnowplowTracker",
-    platforms: [
-        .iOS(.v9)
-    ],
     products: [
         .library(
             name: "SnowplowTracker",


### PR DESCRIPTION
Since Xcode 12 is released and the minimum deployment target handling was updated for the Swift Package Manager, the current situation with `snowplow-objc-tracker` and its dependency `FMDB` does not meet the requirements anymore.

Because the minimum deployment target of `FMDB` is `v9` and the one from `snowplow-objc-tracker` is `v8`, Xcode complains that `v8` is too small. In other words, a dependency needs to fulfil the minimum deployment target version of the host (snowplow).