### PR TITLE
Fix leak on SNOWReachability

### DIFF
--- a/Snowplow/SNOWReachability.m
+++ b/Snowplow/SNOWReachability.m
@@ -123,4 +123,9 @@ static void PrintReachabilityFlags(SCNetworkReachabilityFlags flags, const char*
     return returnValue;
 }
 
+
+- (void)dealloc {
+    CFRelease(_reachabilityRef);
+}
+
 @end


### PR DESCRIPTION
`CFRelease` was only called in the `reachabilityForInternetConnection` method, in case the object failed to be allocated.
In case the object was created, the reachability ref was never released, causing a memory leak.

Reproducible by running Leaks Instrument and tracking an event. SP related stack trace from instruments:
```
   0 libsystem_malloc.dylib _malloc_zone_malloc
   1 CoreFoundation _CFRuntimeCreateInstance
   2 SystemConfiguration __SCNetworkReachabilityCreatePrivate
   3 SystemConfiguration SCNetworkReachabilityCreateWithAddress
   4 MyApp +[SNOWReachability reachabilityForInternetConnection]
   5 MyApp +[SPUtilities getNetworkType]
   6 MyApp -[SPSubject setMobileDict]
   7 MyApp -[SPSubject initWithPlatformContext:andGeoContext:]
```

This PR adds a `CFRelease` in the `dealloc` method. Instruments no longer show a leak.