### PR TITLE
Fix macOS target for SPM (close #593)

### DIFF
--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.h
@@ -20,6 +20,9 @@
 //  License: Apache License Version 2.0
 //
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
 
 @class UIViewController;
@@ -42,3 +45,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Snowplow/UIViewController+SPScreenView_SWIZZLE.m
+++ b/Snowplow/UIViewController+SPScreenView_SWIZZLE.m
@@ -20,6 +20,10 @@
 //  License: Apache License Version 2.0
 //
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_OSX
+
 #import "SPTracker.h"
 #import "SPEventBase.h"
 #import "SPSelfDescribingJson.h"
@@ -182,3 +186,5 @@
 }
 
 @end
+
+#endif


### PR DESCRIPTION
When I try integrate library to macOS target via SPM I get error, because UIKit does not exists.
I just add precompile checks, because spm does not allow add exceptions for file.