### PR TITLE
Set lifecycle tracking off by default (close #587)

### DIFF
--- a/Snowplow/Internal/Configurations/SPTrackerConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPTrackerConfiguration.m
@@ -56,7 +56,7 @@
         self.geoLocationContext = NO;
         self.screenContext = YES;
         self.screenViewAutotracking = YES;
-        self.lifecycleAutotracking = YES;
+        self.lifecycleAutotracking = NO;
         self.installAutotracking = YES;
         self.exceptionAutotracking = YES;
         self.diagnosticAutotracking = NO;

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -99,7 +99,7 @@ NSString * const kFilenameExt = @"dict";
         BOOL result = [fm createDirectoryAtURL:url withIntermediateDirectories:YES attributes:nil error:&error];
         if (!result) {
             SPLogError(@"Unable to create file for sessions: %@", error.localizedDescription);
-            return NO;
+            return nil;
         }
         url = [url URLByAppendingPathComponent:self.sessionFilename];
         self.sessionFileUrl = url;
@@ -281,22 +281,18 @@ NSString * const kFilenameExt = @"dict";
 }
 
 - (void) updateInBackground {
-    if (!_inBackground) {
+    if (!_inBackground && [self.tracker getLifecycleEvents]) {
         _backgroundIndex += 1;
         _inBackground = YES;
-        if ([self.tracker getLifecycleEvents]) {
-            [self sendBackgroundEvent];
-        }
+        [self sendBackgroundEvent];
     }
 }
 
 - (void) updateInForeground {
-    if (_inBackground) {
+    if (_inBackground && [self.tracker getLifecycleEvents]) {
         _foregroundIndex += 1;
         _inBackground = NO;
-        if ([self.tracker getLifecycleEvents]) {
-            [self sendForegroundEvent];
-        }
+        [self sendForegroundEvent];
     }
 }
 


### PR DESCRIPTION
As planned, I set lifecycle optional.
In order to keep the behaviour similar between Android and iOS, I've also disabled the background/foreground index in case the lifecycle tracking is disabled. In that case all the events will be considered in foreground.