### PR TITLE
Fix missing method decorations when using Swift Package Manager on Xcode 12.5

### DIFF
--- a/Snowplow/Internal/Utils/SPUtilities.h
+++ b/Snowplow/Internal/Utils/SPUtilities.h
@@ -27,10 +27,8 @@
 @class SPPayload;
 @class SPSelfDescribingJson;
 @class SPScreenState;
-
-#if SNOWPLOW_TARGET_IOS
-#import <UserNotifications/UserNotifications.h>
-#endif
+@class UNNotificationAttachment;
+@class UNNotificationTrigger;
 
 /*!
  @class SPUtilities
@@ -230,19 +228,14 @@
 
  @return A string describing the type of trigger.
  */
-#if SNOWPLOW_TARGET_IOS
-+ (NSString *) getTriggerType:(UNNotificationTrigger *)trigger NS_AVAILABLE_IOS(10.0);
-#endif
++ (NSString *) getTriggerType:(UNNotificationTrigger *)trigger API_AVAILABLE(ios(10.0), macosx(10.14));
 
 /*!
  @brief Converts a UNNotificationAttachment array into an array of string dictionaries.
  @param attachments An array of UNNotificationAttachment.
  @return An array of string dictionaries.
  */
-
-#if SNOWPLOW_TARGET_IOS
-+ (NSArray<NSDictionary *> *) convertAttachments:(NSArray<UNNotificationAttachment *> *)attachments NS_AVAILABLE_IOS(10.0);
-#endif
++ (NSArray<NSDictionary *> *) convertAttachments:(NSArray<UNNotificationAttachment *> *)attachments API_AVAILABLE(ios(10.0), macosx(10.14));
 
 /*!
  @brief Converts a kebab-case string keys into a camel-case string keys.

--- a/Snowplow/Internal/Utils/SPUtilities.m
+++ b/Snowplow/Internal/Utils/SPUtilities.m
@@ -35,12 +35,14 @@
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <SystemConfiguration/SystemConfiguration.h>
+#import <UserNotifications/UserNotifications.h>
 #import "SNOWReachability.h"
 
 #elif SNOWPLOW_TARGET_OSX
 
 #import <AppKit/AppKit.h>
 #import <Carbon/Carbon.h>
+#import <UserNotifications/UserNotifications.h>
 #import "SNOWReachability.h"
 
 #elif SNOWPLOW_TARGET_TV


### PR DESCRIPTION
Closes issue #589 
Replaces a custom macro condition with standard availability macros. Fixes compatibility with the Swift Package Manager on [Xcode 12.5](https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-release-notes)

**Before:**
<img width="987" alt="Before" src="https://user-images.githubusercontent.com/915431/116156426-4e166200-a6a0-11eb-8a13-e258181664e1.png">

**After:**
<img width="977" alt="After" src="https://user-images.githubusercontent.com/915431/116156407-48208100-a6a0-11eb-8f24-0318bb5ad9c6.png">