### PR TITLE
Release/2.0.1

### DIFF
--- a/Snowplow iOSTests/Configurations/TestTrackerController.m
+++ b/Snowplow iOSTests/Configurations/TestTrackerController.m
@@ -42,4 +42,14 @@
     XCTAssertNil(tracker.session);
 }
 
+- (void)testSubjectUserIdCanBeUpdated {
+    id<SPTrackerController> tracker = [SPSnowplow createTrackerWithNamespace:@"namespace" endpoint:@"https://fake-url" method:SPHttpMethodPost];
+    XCTAssertNotNil(tracker.subject);
+    XCTAssertNil(tracker.subject.userId);
+    tracker.subject.userId = @"fakeUserId";
+    XCTAssertEqualObjects(@"fakeUserId", tracker.subject.userId);
+    tracker.subject.userId = nil;
+    XCTAssertNil(tracker.subject.userId);
+}
+
 @end

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -310,6 +310,14 @@
 		CE4F9D20244B066500968CFC /* SPEcommerce.m in Sources */ = {isa = PBXBuildFile; fileRef = CE4F9C85244B066500968CFC /* SPEcommerce.m */; };
 		CE4F9D21244B066500968CFC /* SPEcommerce.m in Sources */ = {isa = PBXBuildFile; fileRef = CE4F9C85244B066500968CFC /* SPEcommerce.m */; };
 		ED26E6BA23842AB00096AF7C /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED26E6B923842AAF0096AF7C /* AdSupport.framework */; };
+		ED34672A26415C1D0018BA61 /* SPJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = ED34672826415C1D0018BA61 /* SPJSONSerialization.h */; };
+		ED34672B26415C1D0018BA61 /* SPJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = ED34672826415C1D0018BA61 /* SPJSONSerialization.h */; };
+		ED34672C26415C1D0018BA61 /* SPJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = ED34672826415C1D0018BA61 /* SPJSONSerialization.h */; };
+		ED34672D26415C1D0018BA61 /* SPJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = ED34672826415C1D0018BA61 /* SPJSONSerialization.h */; };
+		ED34672E26415C1D0018BA61 /* SPJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = ED34672926415C1D0018BA61 /* SPJSONSerialization.m */; };
+		ED34672F26415C1D0018BA61 /* SPJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = ED34672926415C1D0018BA61 /* SPJSONSerialization.m */; };
+		ED34673026415C1D0018BA61 /* SPJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = ED34672926415C1D0018BA61 /* SPJSONSerialization.m */; };
+		ED34673126415C1D0018BA61 /* SPJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = ED34672926415C1D0018BA61 /* SPJSONSerialization.m */; };
 		ED8122AA25E9578500AE7FE8 /* SPSnowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8122A825E9578500AE7FE8 /* SPSnowplow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED8122AB25E9578600AE7FE8 /* SPSnowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8122A825E9578500AE7FE8 /* SPSnowplow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED8122AC25E9578600AE7FE8 /* SPSnowplow.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8122A825E9578500AE7FE8 /* SPSnowplow.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -724,6 +732,8 @@
 		CE4F9C84244B066500968CFC /* SPEcommerce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPEcommerce.h; sourceTree = "<group>"; };
 		CE4F9C85244B066500968CFC /* SPEcommerce.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPEcommerce.m; sourceTree = "<group>"; };
 		ED26E6B923842AAF0096AF7C /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/AdSupport.framework; sourceTree = DEVELOPER_DIR; };
+		ED34672826415C1D0018BA61 /* SPJSONSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPJSONSerialization.h; sourceTree = "<group>"; };
+		ED34672926415C1D0018BA61 /* SPJSONSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPJSONSerialization.m; sourceTree = "<group>"; };
 		ED6AC5152369D42800A8F8A3 /* ios.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = ios.modulemap; sourceTree = "<group>"; };
 		ED8122A825E9578500AE7FE8 /* SPSnowplow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPSnowplow.h; sourceTree = "<group>"; };
 		ED8122A925E9578500AE7FE8 /* SPSnowplow.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPSnowplow.m; sourceTree = "<group>"; };
@@ -1186,6 +1196,8 @@
 				ABFCC3751922984A00FAE8FE /* SPUtilities.m */,
 				044CA88B1B94791E000EA3B1 /* SPWeakTimerTarget.h */,
 				044CA88C1B94792B000EA3B1 /* SPWeakTimerTarget.m */,
+				ED34672826415C1D0018BA61 /* SPJSONSerialization.h */,
+				ED34672926415C1D0018BA61 /* SPJSONSerialization.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1275,6 +1287,7 @@
 				ED88B5A725792C620048FAD1 /* SPEmitterControllerImpl.h in Headers */,
 				752DAC3321CC43C70065F874 /* SPTracker.h in Headers */,
 				CE4F9D12244B066500968CFC /* SPBackground.h in Headers */,
+				ED34672A26415C1D0018BA61 /* SPJSONSerialization.h in Headers */,
 				ED91CB6C23AA715B0078E75F /* SPDevicePlatform.h in Headers */,
 				CE4F9CA6244B066500968CFC /* SPTiming.h in Headers */,
 				ED87A41C2577AC5B000C54EB /* SPTrackerController.h in Headers */,
@@ -1396,6 +1409,7 @@
 				ED88B56A2578F8820048FAD1 /* SPEmitterConfiguration.h in Headers */,
 				CE4F9CF3244B066500968CFC /* SPStructured.h in Headers */,
 				EDD8542124EFEFB900661F6B /* SPDefaultNetworkConnection.h in Headers */,
+				ED34672B26415C1D0018BA61 /* SPJSONSerialization.h in Headers */,
 				ED8866FF25715DD600DB53BB /* SPConfiguration.h in Headers */,
 				ED88B5A825792C620048FAD1 /* SPEmitterControllerImpl.h in Headers */,
 				75CAC46021F2A21B00271FB3 /* SPSQLiteEventStore.h in Headers */,
@@ -1437,6 +1451,7 @@
 				CE4F9CB8244B066500968CFC /* SPSelfDescribing.h in Headers */,
 				75CAC43321F2A0CC00271FB3 /* SPUtilities.h in Headers */,
 				75CAC43721F2A0CC00271FB3 /* SPRequestCallback.h in Headers */,
+				ED34672C26415C1D0018BA61 /* SPJSONSerialization.h in Headers */,
 				ED914EBC24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				ED8866C025711EC000DB53BB /* SPLoggerDelegate.h in Headers */,
 				ED88B6DD2583DFC90048FAD1 /* SPServiceProvider.h in Headers */,
@@ -1509,6 +1524,7 @@
 				ED88B5AA25792C620048FAD1 /* SPEmitterControllerImpl.h in Headers */,
 				75F9C5E621FA35BC00A5B8FC /* SPTrackerConstants.h in Headers */,
 				CE4F9D15244B066500968CFC /* SPBackground.h in Headers */,
+				ED34672D26415C1D0018BA61 /* SPJSONSerialization.h in Headers */,
 				ED91CB6F23AA715B0078E75F /* SPDevicePlatform.h in Headers */,
 				CE4F9CA9244B066500968CFC /* SPTiming.h in Headers */,
 				ED87A41F2577AC5B000C54EB /* SPTrackerController.h in Headers */,
@@ -1880,6 +1896,7 @@
 				CE4F9CC6244B066500968CFC /* SPSchemaRuleset.m in Sources */,
 				754774D0222756470043B814 /* UIViewController+SPScreenView_SWIZZLE.m in Sources */,
 				CE4F9CDA244B066500968CFC /* SPPageView.m in Sources */,
+				ED34672E26415C1D0018BA61 /* SPJSONSerialization.m in Sources */,
 				ED88B7952587B5620048FAD1 /* SPNetworkControllerImpl.m in Sources */,
 				EDF2A1BE264032F9009032AB /* SPSubjectControllerImpl.m in Sources */,
 				ED88670225715DD600DB53BB /* SPConfiguration.m in Sources */,
@@ -2006,6 +2023,7 @@
 				CE4F9CC7244B066500968CFC /* SPSchemaRuleset.m in Sources */,
 				CE4F9C8B244B066500968CFC /* SPConsentDocument.m in Sources */,
 				EDD8541B24EEC25100661F6B /* SPEmitterEvent.m in Sources */,
+				ED34672F26415C1D0018BA61 /* SPJSONSerialization.m in Sources */,
 				75CAC44021F2A17500271FB3 /* SPSelfDescribingJson.m in Sources */,
 				CE4F9CCF244B066500968CFC /* SNOWError.m in Sources */,
 				CE4F9C87244B066500968CFC /* SPTiming.m in Sources */,
@@ -2070,6 +2088,7 @@
 				CE4F9CC8244B066500968CFC /* SPSchemaRuleset.m in Sources */,
 				CE4F9C8C244B066500968CFC /* SPConsentDocument.m in Sources */,
 				EDD8541C24EEC25100661F6B /* SPEmitterEvent.m in Sources */,
+				ED34673026415C1D0018BA61 /* SPJSONSerialization.m in Sources */,
 				75CAC44C21F2A19500271FB3 /* SPSession.m in Sources */,
 				CE4F9CD0244B066500968CFC /* SNOWError.m in Sources */,
 				CE4F9C88244B066500968CFC /* SPTiming.m in Sources */,
@@ -2109,6 +2128,7 @@
 				CE4F9CC9244B066500968CFC /* SPSchemaRuleset.m in Sources */,
 				7534D20122569BED00904EE5 /* SPScreenState.m in Sources */,
 				CE4F9CDD244B066500968CFC /* SPPageView.m in Sources */,
+				ED34673126415C1D0018BA61 /* SPJSONSerialization.m in Sources */,
 				ED88B7982587B5620048FAD1 /* SPNetworkControllerImpl.m in Sources */,
 				EDF2A1C1264032F9009032AB /* SPSubjectControllerImpl.m in Sources */,
 				ED88670525715DD600DB53BB /* SPConfiguration.m in Sources */,

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -550,6 +550,18 @@
 		EDEE836024BE0944000B8530 /* SPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EDEE835924BE0944000B8530 /* SPLogger.m */; };
 		EDEE836124BE0944000B8530 /* SPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EDEE835924BE0944000B8530 /* SPLogger.m */; };
 		EDEE836324C0C318000B8530 /* TestLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EDEE836224C0C317000B8530 /* TestLogger.m */; };
+		EDF2A1B426402D53009032AB /* SPSubjectController.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B326402D52009032AB /* SPSubjectController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDF2A1B526402D53009032AB /* SPSubjectController.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B326402D52009032AB /* SPSubjectController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDF2A1B626402D53009032AB /* SPSubjectController.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B326402D52009032AB /* SPSubjectController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDF2A1B726402D53009032AB /* SPSubjectController.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B326402D52009032AB /* SPSubjectController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EDF2A1BA264032F9009032AB /* SPSubjectControllerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B8264032F9009032AB /* SPSubjectControllerImpl.h */; };
+		EDF2A1BB264032F9009032AB /* SPSubjectControllerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B8264032F9009032AB /* SPSubjectControllerImpl.h */; };
+		EDF2A1BC264032F9009032AB /* SPSubjectControllerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B8264032F9009032AB /* SPSubjectControllerImpl.h */; };
+		EDF2A1BD264032F9009032AB /* SPSubjectControllerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF2A1B8264032F9009032AB /* SPSubjectControllerImpl.h */; };
+		EDF2A1BE264032F9009032AB /* SPSubjectControllerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF2A1B9264032F9009032AB /* SPSubjectControllerImpl.m */; };
+		EDF2A1BF264032F9009032AB /* SPSubjectControllerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF2A1B9264032F9009032AB /* SPSubjectControllerImpl.m */; };
+		EDF2A1C0264032F9009032AB /* SPSubjectControllerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF2A1B9264032F9009032AB /* SPSubjectControllerImpl.m */; };
+		EDF2A1C1264032F9009032AB /* SPSubjectControllerImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF2A1B9264032F9009032AB /* SPSubjectControllerImpl.m */; };
 		EDFEEAC823A7CB2A001E6D03 /* SPInstallTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 75264A2F224E5DBC000E0E9B /* SPInstallTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EDFEEAC923A7CB3C001E6D03 /* SPInstallTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 75264A31224E5DD2000E0E9B /* SPInstallTracker.m */; };
 /* End PBXBuildFile section */
@@ -779,6 +791,9 @@
 		EDEE835824BE0944000B8530 /* SPLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPLogger.h; sourceTree = "<group>"; };
 		EDEE835924BE0944000B8530 /* SPLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPLogger.m; sourceTree = "<group>"; };
 		EDEE836224C0C317000B8530 /* TestLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestLogger.m; sourceTree = "<group>"; };
+		EDF2A1B326402D52009032AB /* SPSubjectController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPSubjectController.h; sourceTree = "<group>"; };
+		EDF2A1B8264032F9009032AB /* SPSubjectControllerImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPSubjectControllerImpl.h; sourceTree = "<group>"; };
+		EDF2A1B9264032F9009032AB /* SPSubjectControllerImpl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPSubjectControllerImpl.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1165,8 +1180,6 @@
 		EDC9B35A255C3B9700F4136D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				AB39617019530E850002F235 /* OpenIDFA.h */,
-				AB39617119530E850002F235 /* OpenIDFA.m */,
 				ED852B3223A0EEC600F2DF6B /* SNOWReachability.h */,
 				ED852B2E23A0E90E00F2DF6B /* SNOWReachability.m */,
 				ABFCC3741922984A00FAE8FE /* SPUtilities.h */,
@@ -1203,6 +1216,9 @@
 		EDC9B37B255C3DC600F4136D /* Subject */ = {
 			isa = PBXGroup;
 			children = (
+				EDF2A1B326402D52009032AB /* SPSubjectController.h */,
+				EDF2A1B8264032F9009032AB /* SPSubjectControllerImpl.h */,
+				EDF2A1B9264032F9009032AB /* SPSubjectControllerImpl.m */,
 				ED91CB6B23AA715B0078E75F /* SPDevicePlatform.h */,
 				ED91CB7023AA8AD50078E75F /* SPDevicePlatform.m */,
 				04062D741B8390710019B8D1 /* SPSubject.h */,
@@ -1248,6 +1264,7 @@
 				CE4F9CBE244B066500968CFC /* SPForeground.h in Headers */,
 				ED88B629257A3FE60048FAD1 /* SPGlobalContextsConfiguration.h in Headers */,
 				ED88B7342587777B0048FAD1 /* SPEmitterEventProcessing.h in Headers */,
+				EDF2A1B426402D53009032AB /* SPSubjectController.h in Headers */,
 				ED88B64A257A57F80048FAD1 /* SPGlobalContextsController.h in Headers */,
 				CE4F9D02244B066500968CFC /* SPEcommerceItem.h in Headers */,
 				EDD8541624EEC25100661F6B /* SPEmitterEvent.h in Headers */,
@@ -1306,6 +1323,7 @@
 				752DAC3B21CC43C70065F874 /* SPRequestResult.h in Headers */,
 				ED914EBA24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				752DAC3C21CC43C70065F874 /* SPWeakTimerTarget.h in Headers */,
+				EDF2A1BA264032F9009032AB /* SPSubjectControllerImpl.h in Headers */,
 				CE4F9CA2244B066500968CFC /* SPPageView.h in Headers */,
 				EDEE835A24BE0944000B8530 /* SPLogger.h in Headers */,
 				CE4F9C9E244B066500968CFC /* SPSchemaRule.h in Headers */,
@@ -1383,8 +1401,10 @@
 				75CAC46021F2A21B00271FB3 /* SPSQLiteEventStore.h in Headers */,
 				ED87A3DA25765DAE000C54EB /* SPSessionController.h in Headers */,
 				ED88672C2573C1F100DB53BB /* SPSessionConfiguration.h in Headers */,
+				EDF2A1B526402D53009032AB /* SPSubjectController.h in Headers */,
 				75CAC46221F2A21B00271FB3 /* SPRequestResult.h in Headers */,
 				ED8122AB25E9578600AE7FE8 /* SPSnowplow.h in Headers */,
+				EDF2A1BB264032F9009032AB /* SPSubjectControllerImpl.h in Headers */,
 				ED88B590257922490048FAD1 /* SPEmitterController.h in Headers */,
 				75CAC46321F2A21B00271FB3 /* SPWeakTimerTarget.h in Headers */,
 				ED88B5FC257954370048FAD1 /* SPGDPRController.h in Headers */,
@@ -1432,6 +1452,7 @@
 				75CAC43821F2A0CC00271FB3 /* Snowplow-umbrella-header.h in Headers */,
 				CE4F9C9C244B066500968CFC /* SPEvent.h in Headers */,
 				CE4F9CB0244B066500968CFC /* SPConsentWithdrawn.h in Headers */,
+				EDF2A1BC264032F9009032AB /* SPSubjectControllerImpl.h in Headers */,
 				ED88B5E1257950210048FAD1 /* SPGDPRConfiguration.h in Headers */,
 				CE4F9D14244B066500968CFC /* SPBackground.h in Headers */,
 				75CAC42F21F2A0CC00271FB3 /* SPSession.h in Headers */,
@@ -1455,6 +1476,7 @@
 				CE4F9CF4244B066500968CFC /* SPStructured.h in Headers */,
 				EDD8542224EFEFB900661F6B /* SPDefaultNetworkConnection.h in Headers */,
 				ED88670025715DD600DB53BB /* SPConfiguration.h in Headers */,
+				EDF2A1B626402D53009032AB /* SPSubjectController.h in Headers */,
 				ED88B5A925792C620048FAD1 /* SPEmitterControllerImpl.h in Headers */,
 				75CAC43421F2A0CC00271FB3 /* SPRequestResult.h in Headers */,
 				ED87A3DB25765DAE000C54EB /* SPSessionController.h in Headers */,
@@ -1476,6 +1498,7 @@
 				CE4F9CC1244B066500968CFC /* SPForeground.h in Headers */,
 				ED88B62C257A3FE60048FAD1 /* SPGlobalContextsConfiguration.h in Headers */,
 				ED88B7372587777B0048FAD1 /* SPEmitterEventProcessing.h in Headers */,
+				EDF2A1B726402D53009032AB /* SPSubjectController.h in Headers */,
 				ED88B64D257A57F80048FAD1 /* SPGlobalContextsController.h in Headers */,
 				CE4F9D05244B066500968CFC /* SPEcommerceItem.h in Headers */,
 				EDD8541924EEC25100661F6B /* SPEmitterEvent.h in Headers */,
@@ -1534,6 +1557,7 @@
 				75F9C5F021FA35BC00A5B8FC /* SPWeakTimerTarget.h in Headers */,
 				ED914EBD24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				75F9C5EA21FA35BC00A5B8FC /* SPSession.h in Headers */,
+				EDF2A1BD264032F9009032AB /* SPSubjectControllerImpl.h in Headers */,
 				CE4F9CA5244B066500968CFC /* SPPageView.h in Headers */,
 				EDEE835D24BE0944000B8530 /* SPLogger.h in Headers */,
 				CE4F9CA1244B066500968CFC /* SPSchemaRule.h in Headers */,
@@ -1857,6 +1881,7 @@
 				754774D0222756470043B814 /* UIViewController+SPScreenView_SWIZZLE.m in Sources */,
 				CE4F9CDA244B066500968CFC /* SPPageView.m in Sources */,
 				ED88B7952587B5620048FAD1 /* SPNetworkControllerImpl.m in Sources */,
+				EDF2A1BE264032F9009032AB /* SPSubjectControllerImpl.m in Sources */,
 				ED88670225715DD600DB53BB /* SPConfiguration.m in Sources */,
 				ED88B6DF2583DFC90048FAD1 /* SPServiceProvider.m in Sources */,
 				CE4F9C96244B066500968CFC /* SPEcommerceItem.m in Sources */,
@@ -1996,6 +2021,7 @@
 				EDFEEAC923A7CB3C001E6D03 /* SPInstallTracker.m in Sources */,
 				75CAC44421F2A17500271FB3 /* SPWeakTimerTarget.m in Sources */,
 				CE4F9CD3244B066500968CFC /* SPTrackerEvent.m in Sources */,
+				EDF2A1BF264032F9009032AB /* SPSubjectControllerImpl.m in Sources */,
 				ED91CB7223AA8AD50078E75F /* SPDevicePlatform.m in Sources */,
 				CE4F9C97244B066500968CFC /* SPEcommerceItem.m in Sources */,
 				ED88B62E257A3FE60048FAD1 /* SPGlobalContextsConfiguration.m in Sources */,
@@ -2059,6 +2085,7 @@
 				75CAC45021F2A19500271FB3 /* SPUtilities.m in Sources */,
 				75CAC45121F2A19500271FB3 /* SPRequestResult.m in Sources */,
 				CE4F9CD4244B066500968CFC /* SPTrackerEvent.m in Sources */,
+				EDF2A1C0264032F9009032AB /* SPSubjectControllerImpl.m in Sources */,
 				ED852B3023A0E90E00F2DF6B /* SNOWReachability.m in Sources */,
 				CE4F9C98244B066500968CFC /* SPEcommerceItem.m in Sources */,
 				ED88B62F257A3FE60048FAD1 /* SPGlobalContextsConfiguration.m in Sources */,
@@ -2083,6 +2110,7 @@
 				7534D20122569BED00904EE5 /* SPScreenState.m in Sources */,
 				CE4F9CDD244B066500968CFC /* SPPageView.m in Sources */,
 				ED88B7982587B5620048FAD1 /* SPNetworkControllerImpl.m in Sources */,
+				EDF2A1C1264032F9009032AB /* SPSubjectControllerImpl.m in Sources */,
 				ED88670525715DD600DB53BB /* SPConfiguration.m in Sources */,
 				ED88B6E22583DFC90048FAD1 /* SPServiceProvider.m in Sources */,
 				CE4F9C99244B066500968CFC /* SPEcommerceItem.m in Sources */,

--- a/Snowplow/Internal/Payload/SPPayload.m
+++ b/Snowplow/Internal/Payload/SPPayload.m
@@ -50,12 +50,16 @@
 
 - (void) addValueToPayload:(NSString *)value forKey:(NSString *)key {
     if ([value length] == 0) {
-        if ([_payload valueForKey:key] != nil) {
-            [_payload removeObjectForKey:key];
+        @synchronized (self) {
+            if ([_payload valueForKey:key] != nil) {
+                [_payload removeObjectForKey:key];
+            }
         }
         return;
     }
-    [_payload setObject:value forKey:key];
+    @synchronized (self) {
+        [_payload setObject:value forKey:key];
+    }
 }
 
 - (void)addDictionaryToPayload:(NSDictionary<NSString *, NSObject *> *)dictionary {
@@ -133,14 +137,19 @@
 }
 
 - (NSDictionary<NSString *, NSObject *> *) getAsDictionary {
-    return _payload;
+    @synchronized (self) {
+        return _payload;
+    }
 }
 
 - (NSUInteger)byteSize {
     if (!_payload) {
         return 0;
     }
-    NSData *data = [NSJSONSerialization dataWithJSONObject:_payload options:0 error:nil];
+    NSData *data = nil;
+    @synchronized (self) {
+        data = [NSJSONSerialization dataWithJSONObject:_payload options:0 error:nil];
+    }
     return data.length;
 }
 

--- a/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.h
+++ b/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.h
@@ -20,6 +20,9 @@
 //  License: Apache License Version 2.0
 //
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
 
 @class UIViewController;
@@ -42,3 +45,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.m
+++ b/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.m
@@ -20,6 +20,10 @@
 //  License: Apache License Version 2.0
 //
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_OSX
+
 #import "SPTracker.h"
 #import "SPEventBase.h"
 #import "SPSelfDescribingJson.h"
@@ -182,3 +186,5 @@
 }
 
 @end
+
+#endif

--- a/Snowplow/Internal/Storage/SPSQLiteEventStore.m
+++ b/Snowplow/Internal/Storage/SPSQLiteEventStore.m
@@ -24,6 +24,7 @@
 #import "SPSQLiteEventStore.h"
 #import "SPPayload.h"
 #import "SPUtilities.h"
+#import "SPJSONSerialization.h"
 #import "SPLogger.h"
 
 #if SWIFT_PACKAGE
@@ -202,7 +203,10 @@ static NSString * const _queryDeleteAll   = @"DELETE FROM 'events'";
     }
     [self.queue inDatabase:^(FMDatabase *db) {
         if ([db open]) {
-            NSData *data = [NSJSONSerialization dataWithJSONObject:dict options:0 error:nil];
+            NSData *data = [SPJSONSerialization serializeDictionary:dict];
+            if (!data) {
+                return;
+            }
             [db executeUpdate:_queryInsertEvent, data];
             res = (long long int) [db lastInsertRowId];
         }
@@ -216,8 +220,11 @@ static NSString * const _queryDeleteAll   = @"DELETE FROM 'events'";
         if ([db open]) {
             FMResultSet *s = [db executeQuery:_querySelectId, [NSNumber numberWithLongLong:id_]];
             while ([s next]) {
-                NSData * data = [s dataForColumn:@"eventData"];
-                NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:0];
+                NSData *data = [s dataForColumn:@"eventData"];
+                NSDictionary *dict = [SPJSONSerialization deserializeData:data];
+                if (!dict) {
+                    continue;
+                }
                 SPPayload *payload = [[SPPayload alloc] initWithNSDictionary:dict];
                 event = [[SPEmitterEvent alloc] initWithPayload:payload storeId:id_];
             }
@@ -244,7 +251,10 @@ static NSString * const _queryDeleteAll   = @"DELETE FROM 'events'";
             while ([s next]) {
                 long long int index = [s longLongIntForColumn:@"ID"];
                 NSData *data = [s dataForColumn:@"eventData"];
-                NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:0];
+                NSDictionary *dict = [SPJSONSerialization deserializeData:data];
+                if (!dict) {
+                    continue;
+                }
                 SPPayload *payload = [[SPPayload alloc] initWithNSDictionary:dict];
                 SPEmitterEvent *event = [[SPEmitterEvent alloc] initWithPayload:payload storeId:index];
                 [res addObject:event];

--- a/Snowplow/Internal/Subject/SPSubject.h
+++ b/Snowplow/Internal/Subject/SPSubject.h
@@ -38,6 +38,18 @@ NS_SWIFT_NAME(Subject)
 @property (nonatomic) BOOL platformContext;
 @property (nonatomic) BOOL geoLocationContext;
 
+@property (nonatomic) NSString *userId;
+@property (nonatomic) NSString *networkUserId;
+@property (nonatomic) NSString *domainUserId;
+@property (nonatomic) NSString *useragent;
+@property (nonatomic) NSString *ipAddress;
+@property (nonatomic) NSString *timezone;
+@property (nonatomic) NSString *language;
+@property (nonatomic) SPSize *screenResolution;
+@property (nonatomic) SPSize *screenViewPort;
+@property (nonatomic) NSInteger colorDepth;
+
+
 /*!
  @brief Initializes a newly allocated SPSubject object.
  @return A new SPSubject.
@@ -56,7 +68,7 @@ NS_SWIFT_NAME(Subject)
 /*!
  @warning Internal method - do not use in production
  */
-- (instancetype)initWithPlatformContext:(BOOL)platformContext geoLocationContext:(BOOL)geoContext subjectConfiguration:(SPSubjectConfiguration *)configuration __deprecated_msg("Subject will be removed in the next major version. Use `Snowplow.setup(...)` instead.");
+- (instancetype)initWithPlatformContext:(BOOL)platformContext geoLocationContext:(BOOL)geoContext subjectConfiguration:(SPSubjectConfiguration *)configuration __deprecated_msg("Subject will be removed in the next major version. Use `Snowplow.createTracker(...)` instead.");
 
 /*!
  @brief Gets all standard dictionary pairs to decorate the event with.

--- a/Snowplow/Internal/Subject/SPSubject.m
+++ b/Snowplow/Internal/Subject/SPSubject.m
@@ -106,6 +106,7 @@
 }
 
 - (void) setUserId:(NSString *)uid {
+    _userId = uid;
     [_standardDict addValueToPayload:uid forKey:kSPUid];
 }
 
@@ -114,41 +115,50 @@
 }
 
 - (void) setResolutionWithWidth:(NSInteger)width andHeight:(NSInteger)height {
+    _screenResolution = [[SPSize alloc] initWithWidth:width height:height];
     NSString * res = [NSString stringWithFormat:@"%@x%@", [@(width) stringValue], [@(height) stringValue]];
     [_standardDict addValueToPayload:res forKey:kSPResolution];
 }
 
 - (void) setViewPortWithWidth:(NSInteger)width andHeight:(NSInteger)height {
+    _screenViewPort = [[SPSize alloc] initWithWidth:width height:height];
     NSString * res = [NSString stringWithFormat:@"%@x%@", [@(width) stringValue], [@(height) stringValue]];
     [_standardDict addValueToPayload:res forKey:kSPViewPort];
 }
 
 - (void) setColorDepth:(NSInteger)depth {
+    _colorDepth = depth;
     NSString * res = [NSString stringWithFormat:@"%@", [@(depth) stringValue]];
     [_standardDict addValueToPayload:res forKey:kSPColorDepth];
 }
 
 - (void) setTimezone:(NSString *)timezone {
+    _timezone = timezone;
     [_standardDict addValueToPayload:timezone forKey:kSPTimezone];
 }
 
 - (void) setLanguage:(NSString *)lang {
+    _language = lang;
     [_standardDict addValueToPayload:lang forKey:kSPLanguage];
 }
 
 - (void) setIpAddress:(NSString *)ip {
+    _ipAddress = ip;
     [_standardDict addValueToPayload:ip forKey:kSPIpAddress];
 }
 
 - (void) setUseragent:(NSString *)useragent {
+    _useragent = useragent;
     [_standardDict addValueToPayload:useragent forKey:kSPUseragent];
 }
 
 - (void) setNetworkUserId:(NSString *)nuid {
+    _networkUserId = nuid;
     [_standardDict addValueToPayload:nuid forKey:kSPNetworkUid];
 }
 
 - (void) setDomainUserId:(NSString *)duid {
+    _domainUserId = duid;
     [_standardDict addValueToPayload:duid forKey:kSPDomainUid];
 }
 

--- a/Snowplow/Internal/Subject/SPSubjectController.h
+++ b/Snowplow/Internal/Subject/SPSubjectController.h
@@ -1,0 +1,33 @@
+//
+//  SPSubjectController.h
+//  Snowplow
+//
+//  Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  Copyright: Copyright (c) 2013-2021 Snowplow Analytics Ltd
+//  License: Apache License Version 2.0
+//
+
+#import <Foundation/Foundation.h>
+#import "SPSubjectConfiguration.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(SubjectController)
+@protocol SPSubjectController <SPSubjectConfigurationProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snowplow/Internal/Subject/SPSubjectControllerImpl.h
+++ b/Snowplow/Internal/Subject/SPSubjectControllerImpl.h
@@ -1,0 +1,35 @@
+//
+//  SPSubjectControllerImpl.h
+//  Snowplow
+//
+//  Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  Copyright: Copyright (c) 2013-2021 Snowplow Analytics Ltd
+//  License: Apache License Version 2.0
+//
+
+#import <Foundation/Foundation.h>
+#import "SPSubjectController.h"
+#import "SPSubject.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPSubjectControllerImpl : NSObject <SPSubjectController>
+
+- (instancetype)initWithSubject:(SPSubject *)subject;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snowplow/Internal/Subject/SPSubjectControllerImpl.m
+++ b/Snowplow/Internal/Subject/SPSubjectControllerImpl.m
@@ -1,0 +1,136 @@
+//
+//  SPSubjectControllerImpl.m
+//  Snowplow
+//
+//  Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  Copyright: Copyright (c) 2013-2021 Snowplow Analytics Ltd
+//  License: Apache License Version 2.0
+//
+
+#import "SPSubjectControllerImpl.h"
+#import "SPPayload.h"
+
+
+@interface SPSubjectControllerImpl ()
+
+@property (nonatomic, weak) SPSubject *subject;
+
+@end
+
+
+@implementation SPSubjectControllerImpl
+@synthesize userId;
+@synthesize networkUserId;
+@synthesize domainUserId;
+@synthesize useragent;
+@synthesize ipAddress;
+@synthesize timezone;
+@synthesize language;
+@synthesize screenResolution;
+@synthesize screenViewPort;
+@synthesize colorDepth;
+
+- (instancetype)initWithSubject:(SPSubject *)subject {
+    if (self = [super init]) {
+        self.subject = subject;
+    }
+    return self;
+}
+
+// MARK: - Properties
+
+- (void)setUserId:(NSString *)userId {
+    [self.subject setUserId:userId];
+}
+
+- (NSString *)userId {
+    return self.subject.userId;
+}
+
+- (void)setNetworkUserId:(NSString *)networkUserId {
+    [self.subject setNetworkUserId:networkUserId];
+}
+
+- (NSString *)networkUserId {
+    return [self.subject networkUserId];
+}
+
+- (void)setDomainUserId:(NSString *)domainUserId {
+    [self.subject setDomainUserId:domainUserId];
+}
+
+- (NSString *)domainUserId {
+    return [self.subject domainUserId];
+}
+
+- (void)setUseragent:(NSString *)useragent {
+    [self.subject setUseragent:useragent];
+}
+
+- (NSString *)useragent {
+    return [self.subject useragent];
+}
+
+- (void)setIpAddress:(NSString *)ipAddress {
+    [self.subject setIpAddress:ipAddress];
+}
+
+- (NSString *)ipAddress {
+    return [self.subject ipAddress];
+}
+
+- (void)setTimezone:(NSString *)timezone {
+    [self.subject setTimezone:timezone];
+}
+
+- (NSString *)timezone {
+    return [self.subject timezone];
+}
+
+- (void)setLanguage:(NSString *)language {
+    [self.subject setLanguage:language];
+}
+
+- (NSString *)language {
+    return [self.subject language];
+}
+
+- (void)setScreenResolution:(SPSize *)screenResolution {
+    [self.subject setResolutionWithWidth:screenResolution.width andHeight:screenResolution.height];
+}
+
+- (SPSize *)screenResolution {
+    return [self.subject screenResolution];
+}
+
+- (void)setScreenViewPort:(SPSize *)screenViewPort {
+    [self.subject setViewPortWithWidth:screenResolution.width andHeight:screenResolution.height];
+}
+
+- (SPSize *)screenViewPort {
+    return [self.subject screenViewPort];
+}
+
+- (void)setColorDepth:(NSNumber *)colorDepth {
+    [self.subject setColorDepth:colorDepth.intValue];
+}
+
+- (NSNumber *)colorDepth {
+    return @([self.subject colorDepth]);
+}
+
+@end
+

--- a/Snowplow/Internal/Tracker/SPInstallTracker.m
+++ b/Snowplow/Internal/Tracker/SPInstallTracker.m
@@ -46,7 +46,16 @@
 
 - (NSDate *)previousInstallTimestamp {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    return [userDefaults objectForKey:kSPInstallTimestamp];
+    id value = [userDefaults objectForKey:kSPInstallTimestamp];
+    if (!value) {
+        return nil;
+    } else if ([value isKindOfClass:NSDate.class]) {  // v2.0 format
+        return (NSDate *)value;
+    } else if ([value isKindOfClass:NSNumber.class]) { // v1.7 format
+        NSTimeInterval timeInterval = ((NSNumber *)value).doubleValue / 1000;
+        return [[NSDate alloc] initWithTimeIntervalSince1970:timeInterval];
+    }
+    return nil;
 }
 
 - (void)clearPreviousInstallTimestamp {

--- a/Snowplow/Internal/Tracker/SPTrackerController.h
+++ b/Snowplow/Internal/Tracker/SPTrackerController.h
@@ -24,6 +24,7 @@
 #import "SPTrackerConfiguration.h"
 #import "SPNetworkConfiguration.h"
 
+#import "SPSubjectController.h"
 #import "SPSessionController.h"
 #import "SPEmitterController.h"
 #import "SPNetworkController.h"
@@ -50,6 +51,11 @@ NS_SWIFT_NAME(TrackerController)
  */
 @property (readonly, nonatomic) NSString *namespace;
 
+/**
+ * SubjectController.
+ * @apiNote Don't retain the reference. It may change on tracker reconfiguration.
+ */
+@property (readonly, nonatomic, nullable) id<SPSubjectController> subject;
 /**
  * SessionController.
  * @apiNote Don't retain the reference. It may change on tracker reconfiguration.

--- a/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
+++ b/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
@@ -25,6 +25,7 @@
 #import "SPNetworkControllerImpl.h"
 #import "SPGDPRControllerImpl.h"
 #import "SPGlobalContextsControllerImpl.h"
+#import "SPSubjectControllerImpl.h"
 #import "SPSessionControllerImpl.h"
 
 #import "SPSubjectConfiguration.h"
@@ -43,6 +44,7 @@
 @property (readwrite, nonatomic) id<SPEmitterController> emitter;
 @property (readwrite, nonatomic) id<SPGDPRController> gdpr;
 @property (readwrite, nonatomic) id<SPGlobalContextsController> globalContexts;
+@property (readwrite, nonatomic) id<SPSubjectController> subject;
 
 @property (nonatomic) SPSessionControllerImpl *sessionController;
 
@@ -59,6 +61,7 @@
     self.emitter = [[SPEmitterControllerImpl alloc] initWithEmitter:tracker.emitter];
     self.gdpr = [[SPGDPRControllerImpl alloc] initWithTracker:tracker];
     self.globalContexts = [[SPGlobalContextsControllerImpl alloc] initWithTracker:tracker];
+    self.subject = [[SPSubjectControllerImpl alloc] initWithSubject:tracker.subject];
     if (!tracker.emitter.networkConnection || [tracker.emitter.networkConnection isKindOfClass:SPDefaultNetworkConnection.class]) {
         self.network = [[SPNetworkControllerImpl alloc] initWithEmitter:tracker.emitter];
     }

--- a/Snowplow/Internal/Utils/SPJSONSerialization.h
+++ b/Snowplow/Internal/Utils/SPJSONSerialization.h
@@ -1,0 +1,20 @@
+//
+//  SPJSONSerialization.h
+//  Snowplow
+//
+//  Created by Alex Benini on 04/05/21.
+//  Copyright © 2021 Snowplow Analytics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPJSONSerialization : NSObject
+
++ (nullable NSData *)serializeDictionary:(nonnull NSDictionary *)dictionary;
++ (nullable NSDictionary *)deserializeData:(nonnull NSData *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snowplow/Internal/Utils/SPJSONSerialization.m
+++ b/Snowplow/Internal/Utils/SPJSONSerialization.m
@@ -1,0 +1,52 @@
+//
+//  SPJSONSerialization.m
+//  Snowplow
+//
+//  Created by Alex Benini on 04/05/21.
+//  Copyright © 2021 Snowplow Analytics. All rights reserved.
+//
+
+#import "SPJSONSerialization.h"
+#import "SPLogger.h"
+
+@implementation SPJSONSerialization
+
++ (NSData *)serializeDictionary:(NSDictionary *)dictionary {
+    NSError *error = nil;
+    NSData *data;
+    @try {
+        data = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&error];
+    }
+    @catch (NSException *exception) {
+        SPLogError(@"Dictionary to Data Exception, %@", exception.name);
+        return nil;
+    }
+    if (error) {
+        SPLogError(@"Dictionary to Data Error, %@", error);
+        return nil;
+    }
+    return data;
+}
+
++ (NSDictionary *)deserializeData:(NSData *)data {
+    NSError *error = nil;
+    NSDictionary *dictionary;
+    @try {
+        dictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    }
+    @catch (NSException *exception) {
+        SPLogError(@"Data to Dictionary Exception, %@", exception.name);
+        return nil;
+    }
+    if (error) {
+        SPLogError(@"Data to Dictionary Error, %@", error);
+        return nil;
+    }
+    if (![dictionary isKindOfClass:NSDictionary.class]) {
+        SPLogError(@"Serialized json isn't a Dictionary type");
+        return nil;
+    }
+    return dictionary;
+}
+
+@end

--- a/Snowplow/include/SPSubjectController.h
+++ b/Snowplow/include/SPSubjectController.h
@@ -1,0 +1,1 @@
+../Internal/Subject/SPSubjectController.h


### PR DESCRIPTION
This release introduces the ability of update the userID in the SubjectController.
The version 2.0 allowed the configuration of the userID but it was impossible to update it at runtime.

There are also community contributions and improvements to the reliability of the tracker:
- SPM can be used with the macOS target
- Fix for the exception caused by a wrong migration of install events
- Fix for crashes due to wrong conversion of data to json format and viceversa

### CHANGELOG

**Enhancement:**
- Add SubjectController to update userId (#595)

**Bug fixes:**
- Fix crash if data from Database is corrupted (#596) (Contribution of @glukhanyk)
- Fix NSInvalidArgumentException on first run with v2.0 (#592)
- Fix macOS target for SPM (#593) (Contribution of @Juraldinio)
