### PR TITLE
Fix for CaseSensitive file systems (close #622)

### DIFF
--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -22,7 +22,7 @@
 
 #import "SPServiceProvider.h"
 #import "SPDefaultNetworkConnection.h"
-#import "SPGDPRContext.h"
+#import "SPGdprContext.h"
 
 #import "SPEmitter.h"
 #import "SPSubject.h"


### PR DESCRIPTION
Build on CaseSensitive file systems failed because can't find header file.