### PR TITLE
Fix Session UserID not consistent among tracker instances (close #630)

### DIFF
--- a/Snowplow/Internal/SPTrackerConstants.h
+++ b/Snowplow/Internal/SPTrackerConstants.h
@@ -148,6 +148,8 @@ extern NSString * const kSPApplicationBuild;
 
 // --- Session Context
 
+extern NSString * const kSPInstallationUserId;
+
 extern NSString * const kSPSessionUserId;
 extern NSString * const kSPSessionId;
 extern NSString * const kSPSessionPreviousId;

--- a/Snowplow/Internal/SPTrackerConstants.m
+++ b/Snowplow/Internal/SPTrackerConstants.m
@@ -132,6 +132,8 @@ NSString * const kSPApplicationBuild      = @"build";
 
 // --- Session Context
 
+NSString * const kSPInstallationUserId    = @"SPInstallationUserId";
+
 NSString * const kSPSessionUserId         = @"userId";
 NSString * const kSPSessionId             = @"sessionId";
 NSString * const kSPSessionPreviousId     = @"previousSessionId";


### PR DESCRIPTION
As explained in the issue, we need to keep a unique session userID for all the tracker instances of the same app.

The session userID will be part of the collection of IDs explained in the RFC for the tracker v2: https://discourse.snowplowanalytics.com/t/rfc-mobile-trackers-v2-0/4370
"Installation ID: created by the tracker at first execution (it’s the session_userId that can be tracked even if the session context is turned off). The installation ID will be constant until the app deletion."