### PR TITLE
Support lifecycle reporting for tvOS (close #640)

### DIFF
--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -107,7 +107,7 @@
         [self startChecker];
 
         // Trigger notification for view changes
-        #if SNOWPLOW_TARGET_IOS
+        #if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_TV
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(updateInBackground)
                                                      name:UIApplicationWillResignActiveNotification


### PR DESCRIPTION
This may clash with the refactor in #638 but putting it here for visibility for @AlexBenny 

Allows lifecycle tracking on iOS and tvOS.