### PR TITLE
Fix SPDataPersistence crash at SDK init (close #655)

### DIFF
--- a/Snowplow iOSTests/TestDataPersistence.m
+++ b/Snowplow iOSTests/TestDataPersistence.m
@@ -59,7 +59,15 @@
 }
 
 - (void)testDataIsCorrectlyStored {
-    SPDataPersistence *dp = [SPDataPersistence dataPersistenceForNamespace:@"namespace"];
+    [self commonTestDataIsCorrectlyStoredOnFile:YES];
+}
+
+- (void)testDataIsCorrectlyStoredWhenNotStoredOnFile {
+    [self commonTestDataIsCorrectlyStoredOnFile:NO];
+}
+
+- (void)commonTestDataIsCorrectlyStoredOnFile:(BOOL)isStoredOnFile {
+    SPDataPersistence *dp = [SPDataPersistence dataPersistenceForNamespace:@"namespace" storedOnFile:isStoredOnFile];
     NSDictionary<NSString *, NSObject *> *session = @{@"key": @"value"};
     dp.session = session;
     XCTAssertEqualObjects(session, dp.session);
@@ -72,8 +80,16 @@
 }
 
 - (void)testDataIsStoredWithoutInterference {
-    SPDataPersistence *dp1 = [SPDataPersistence dataPersistenceForNamespace:@"namespace1"];
-    SPDataPersistence *dp2 = [SPDataPersistence dataPersistenceForNamespace:@"namespace2"];
+    [self commonTestDataIsStoredWithoutInterferenceStoredOnFile:YES];
+}
+
+- (void)testDataIsStoredWithoutInterferenceWhenNotStoredOnFile {
+    [self commonTestDataIsStoredWithoutInterferenceStoredOnFile:NO];
+}
+
+- (void)commonTestDataIsStoredWithoutInterferenceStoredOnFile:(BOOL)isStoredOnFile {
+    SPDataPersistence *dp1 = [SPDataPersistence dataPersistenceForNamespace:@"namespace1" storedOnFile:isStoredOnFile];
+    SPDataPersistence *dp2 = [SPDataPersistence dataPersistenceForNamespace:@"namespace2" storedOnFile:isStoredOnFile];
     NSDictionary<NSString *, NSObject *> *session = @{@"key": @"value"};
     dp1.session = session;
     // Check dp1

--- a/Snowplow/Internal/Utils/SPDataPersistence.h
+++ b/Snowplow/Internal/Utils/SPDataPersistence.h
@@ -28,8 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSDictionary<NSString *, NSDictionary<NSString *, NSObject *> *> *data;
 @property (nonatomic) NSDictionary<NSString *, NSObject *> *session;
+@property (readonly) BOOL isStoredOnFile;
+
++ (instancetype) new NS_UNAVAILABLE;
+- (instancetype) init NS_UNAVAILABLE;
 
 + (SPDataPersistence *)dataPersistenceForNamespace:(NSString *)namespace;
++ (SPDataPersistence *)dataPersistenceForNamespace:(NSString *)namespace storedOnFile:(BOOL)isStoredOnFile;
 + (BOOL)removeDataPersistenceWithNamespace:(NSString *)namespace;
 
 + (NSString *)stringFromNamespace:(NSString *)namespace;


### PR DESCRIPTION
The user reports some crashes starting from SPDataPersistence for some devices. Unfortunately, the crash is not fixable restarting the app or restarting the device.

I suspect the issue is related to the permission when SPDataPersistence tries to create the destination directory.
In that case it would be useful to avoid the directory creation and use an alternative solution (e.g.: UserDefaults)

In SPDataPersistence we use UserDefaults to store the session data when the platform is tvOS or watchOS, because on those the filesystem is not accessible as in iOS.
We can adopt the same solution when there are issues on iOS in order to avoid the crash.