### PR TITLE
Do not allow multiple state machines with the same ID (close #658)

### DIFF
--- a/Snowplow iOSTests/TestStateManager.m
+++ b/Snowplow iOSTests/TestStateManager.m
@@ -83,6 +83,16 @@
 
 @end
 
+@interface MockStateMachine1 : MockStateMachine
+@end
+@implementation MockStateMachine1
+@end
+
+@interface MockStateMachine2 : MockStateMachine
+@end
+@implementation MockStateMachine2
+@end
+
 // MARK: - Test
 
 @interface TestStateManager : XCTestCase
@@ -173,5 +183,26 @@
     XCTAssertEqual(1, entities.count);
 }
 
-@end
+- (void)testReplacingStateMachineDoesntResetTrackerState {
+    SPStateManager *stateManager = [SPStateManager new];
+    [stateManager addOrReplaceStateMachine:[MockStateMachine new] identifier:@"identifier"];
+    id<SPTrackerStateSnapshot> trackerState1 = [stateManager trackerStateForProcessedEvent:[[SPSelfDescribing alloc] initWithSchema:@"inc" payload:@{@"value": @1}]];
+    XCTAssertEqual(1, [(MockState *)[trackerState1 stateWithIdentifier:@"identifier"] value]);
+    
+    [stateManager addOrReplaceStateMachine:[MockStateMachine new] identifier:@"identifier"];
+    id<SPTrackerStateSnapshot> trackerState2 = [stateManager trackerStateForProcessedEvent:[[SPStructured alloc] initWithCategory:@"category" action:@"action"]];
+    XCTAssertEqual(1, [(MockState *)[trackerState2 stateWithIdentifier:@"identifier"] value]);
+}
 
+- (void)testReplacingStateMachineWithDifferentOneResetsTrackerState {
+    SPStateManager *stateManager = [SPStateManager new];
+    [stateManager addOrReplaceStateMachine:[MockStateMachine1 new] identifier:@"identifier"];
+    id<SPTrackerStateSnapshot> trackerState1 = [stateManager trackerStateForProcessedEvent:[[SPSelfDescribing alloc] initWithSchema:@"inc" payload:@{@"value": @1}]];
+    XCTAssertEqual(1, [(MockState *)[trackerState1 stateWithIdentifier:@"identifier"] value]);
+    
+    [stateManager addOrReplaceStateMachine:[MockStateMachine2 new] identifier:@"identifier"];
+    id<SPTrackerStateSnapshot> trackerState2 = [stateManager trackerStateForProcessedEvent:[[SPStructured alloc] initWithCategory:@"category" action:@"action"]];
+    XCTAssertEqual(0, [(MockState *)[trackerState2 stateWithIdentifier:@"identifier"] value]);
+}
+
+@end

--- a/Snowplow/Internal/Tracker/SPStateManager.h
+++ b/Snowplow/Internal/Tracker/SPStateManager.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPStateManager : NSObject
 
-- (void)addStateMachine:(id<SPStateMachineProtocol>)stateMachine identifier:(NSString *)stateMachineIdentifier;
+- (void)addOrReplaceStateMachine:(id<SPStateMachineProtocol>)stateMachine identifier:(NSString *)stateMachineIdentifier;
 - (BOOL)removeStateMachine:(NSString *)stateMachineIdentifier;
 
 - (id<SPTrackerStateSnapshot>)trackerStateForProcessedEvent:(SPEvent *)event;

--- a/Snowplow/Internal/Tracker/SPStateManager.m
+++ b/Snowplow/Internal/Tracker/SPStateManager.m
@@ -49,7 +49,11 @@
 
 - (void)addOrReplaceStateMachine:(id<SPStateMachineProtocol>)stateMachine identifier:(NSString *)stateMachineIdentifier {
     @synchronized (self) {
-        if ([self.identifierToStateMachine objectForKey:stateMachineIdentifier]) {
+        id<SPStateMachineProtocol> previousStateMachine = [self.identifierToStateMachine objectForKey:stateMachineIdentifier];
+        if (previousStateMachine) {
+            if ([stateMachine isMemberOfClass:[previousStateMachine class]]) {
+                return;
+            }
             [self removeStateMachine:stateMachineIdentifier];
         }
         self.identifierToStateMachine[stateMachineIdentifier] = stateMachine;

--- a/Snowplow/Internal/Tracker/SPStateManager.m
+++ b/Snowplow/Internal/Tracker/SPStateManager.m
@@ -47,8 +47,11 @@
     return self;
 }
 
-- (void)addStateMachine:(id<SPStateMachineProtocol>)stateMachine identifier:(NSString *)stateMachineIdentifier {
+- (void)addOrReplaceStateMachine:(id<SPStateMachineProtocol>)stateMachine identifier:(NSString *)stateMachineIdentifier {
     @synchronized (self) {
+        if ([self.identifierToStateMachine objectForKey:stateMachineIdentifier]) {
+            [self removeStateMachine:stateMachineIdentifier];
+        }
         self.identifierToStateMachine[stateMachineIdentifier] = stateMachine;
         [self.stateMachineToIdentifier setObject:stateMachineIdentifier forKey:stateMachine];
         [self addToSchemaRegistry:self.eventSchemaToStateMachine

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -330,7 +330,7 @@ void uncaughtExceptionHandler(NSException *exception) {
     @synchronized (self) {
         _deepLinkContext = deepLinkContext;
         if (deepLinkContext) {
-            [self.stateManager addStateMachine:[SPDeepLinkStateMachine new] identifier:@"SPDeepLinkContext"];
+            [self.stateManager addOrReplaceStateMachine:[SPDeepLinkStateMachine new] identifier:@"SPDeepLinkContext"];
         } else {
             [self.stateManager removeStateMachine:@"SPDeepLinkContext"];
         }
@@ -341,7 +341,7 @@ void uncaughtExceptionHandler(NSException *exception) {
     @synchronized (self) {
         _screenContext = screenContext;
         if (screenContext) {
-            [self.stateManager addStateMachine:[SPScreenStateMachine new] identifier:@"SPScreenContext"];
+            [self.stateManager addOrReplaceStateMachine:[SPScreenStateMachine new] identifier:@"SPScreenContext"];
         } else {
             [self.stateManager removeStateMachine:@"SPScreenContext"];
         }
@@ -374,7 +374,7 @@ void uncaughtExceptionHandler(NSException *exception) {
     @synchronized (self) {
         _lifecycleEvents = lifecycleEvents;
         if (lifecycleEvents) {
-            [self.stateManager addStateMachine:[SPLifecycleStateMachine new] identifier:@"SPLifecycle"];
+            [self.stateManager addOrReplaceStateMachine:[SPLifecycleStateMachine new] identifier:@"SPLifecycle"];
         } else {
             [self.stateManager removeStateMachine:@"SPLifecycle"];
         }


### PR DESCRIPTION
Addresses issue #658 

The change automatically removes previous state machine (if any) with the same identifier when adding a new one. This prevents multiple of the same context being added to events in case the same state machine is registered multiple times.