### PR TITLE
Fix updating IDFA during app runtime (close #661)

### DIFF
--- a/Snowplow iOSTests/TestPlatformContext.m
+++ b/Snowplow iOSTests/TestPlatformContext.m
@@ -48,7 +48,7 @@
 }
 
 - (void)testAddsAllMockedInfo {
-    SPDeviceInfoMonitor *deviceInfoMonitor= [[SPMockDeviceInfoMonitor alloc] init];
+    SPDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
     NSDictionary *platformDict = [[context fetchPlatformDict] getAsDictionary];
     XCTAssertTrue([@"appleIdfa" isEqualToString: [platformDict valueForKey:kSPMobileAppleIdfa]]);
@@ -71,7 +71,7 @@
 
 - (void)testUpdatesMobileInfo {
 #if SNOWPLOW_TARGET_IOS
-    SPMockDeviceInfoMonitor *deviceInfoMonitor= [[SPMockDeviceInfoMonitor alloc] init];
+    SPMockDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
@@ -86,7 +86,7 @@
 
 - (void)testDoesntUpdateMobileInfoWithinUpdateWindow {
 #if SNOWPLOW_TARGET_IOS
-    SPMockDeviceInfoMonitor *deviceInfoMonitor= [[SPMockDeviceInfoMonitor alloc] init];
+    SPMockDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:1000 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
@@ -101,7 +101,7 @@
 
 - (void)testUpdatesNetworkInfo {
 #if SNOWPLOW_TARGET_IOS
-    SPMockDeviceInfoMonitor *deviceInfoMonitor= [[SPMockDeviceInfoMonitor alloc] init];
+    SPMockDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:1 networkDictUpdateFrequency:0 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkType"]);
@@ -116,7 +116,7 @@
 
 - (void)testDoesntUpdateNetworkInfoWithinUpdateWindow {
 #if SNOWPLOW_TARGET_IOS
-    SPMockDeviceInfoMonitor *deviceInfoMonitor= [[SPMockDeviceInfoMonitor alloc] init];
+    SPMockDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1000 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkType"]);
@@ -131,7 +131,7 @@
 
 - (void)testDoesntUpdateNonEphemeralInfo {
 #if SNOWPLOW_TARGET_IOS
-    SPMockDeviceInfoMonitor *deviceInfoMonitor= [[SPMockDeviceInfoMonitor alloc] init];
+    SPMockDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:0 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"physicalMemory"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"totalStorage"]);
@@ -143,6 +143,33 @@
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"totalStorage"]);
 #endif
 }
+
+- (void)testDoesntUpdateIdfaAndIdfvIfNotNil {
+#if SNOWPLOW_TARGET_IOS
+    SPMockDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
+    SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
+    XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfa"]);
+    XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfv"]);
+    [context fetchPlatformDict];
+    XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfa"]);
+    XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfv"]);
+#endif
+}
+
+- (void)testUpdatesIdfaAndIdfvIfNil {
+#if SNOWPLOW_TARGET_IOS
+    SPMockDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
+    deviceInfoMonitor.customAppleIdfa = nil;
+    deviceInfoMonitor.customAppleIdfv = nil;
+    SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
+    XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfa"]);
+    XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfv"]);
+    [context fetchPlatformDict];
+    XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"appleIdfa"]);
+    XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"appleIdfv"]);
+#endif
+}
+
 - (void)testPerformanceOfFetchingNetworkDict {
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:1000 networkDictUpdateFrequency:0];
     [self measureBlock:^{

--- a/Snowplow iOSTests/Utils/SPMockDeviceInfoMonitor.h
+++ b/Snowplow iOSTests/Utils/SPMockDeviceInfoMonitor.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (int) accessCount:(NSString *) method;
 
 @property (strong, nonatomic) NSDictionary<NSString *, NSNumber *> *methodAccessCounts;
+@property (strong, nonatomic, nullable) NSString *customAppleIdfa;
+@property (strong, nonatomic, nullable) NSString *customAppleIdfv;
 
 @end
 

--- a/Snowplow iOSTests/Utils/SPMockDeviceInfoMonitor.m
+++ b/Snowplow iOSTests/Utils/SPMockDeviceInfoMonitor.m
@@ -27,18 +27,20 @@
 - (instancetype) init {
     if (self = [super init]) {
         self.methodAccessCounts = [[NSMutableDictionary alloc] init];
+        self.customAppleIdfa = @"appleIdfa";
+        self.customAppleIdfv = @"appleIdfv";
     }
     return self;
 }
 
 - (NSString *) appleIdfa {
     [self increaseMethodAccessCount:@"appleIdfa"];
-    return @"appleIdfa";
+    return self.customAppleIdfa;
 }
 
 - (NSString *) appleIdfv {
     [self increaseMethodAccessCount:@"appleIdfv"];
-    return @"appleIdfv";
+    return self.customAppleIdfv;
 }
 
 - (NSString *) deviceVendor {

--- a/Snowplow/Internal/Subject/SPPlatformContext.m
+++ b/Snowplow/Internal/Subject/SPPlatformContext.m
@@ -90,8 +90,6 @@
 
 - (void) setMobileDict {
     [self.platformDict addValueToPayload:[self.deviceInfoMonitor carrierName]           forKey:kSPMobileCarrier];
-    [self.platformDict addValueToPayload:[self.deviceInfoMonitor appleIdfa]             forKey:kSPMobileAppleIdfa];
-    [self.platformDict addValueToPayload:[self.deviceInfoMonitor appleIdfv]             forKey:kSPMobileAppleIdfv];
     [self.platformDict addNumericValueToPayload:[self.deviceInfoMonitor totalStorage]   forKey:kSPMobileTotalStorage];
     [self.platformDict addNumericValueToPayload:[self.deviceInfoMonitor physicalMemory] forKey:kSPMobilePhysicalMemory];
     
@@ -101,6 +99,14 @@
 
 - (void) setEphemeralMobileDict {
     self.lastUpdatedEphemeralMobileDict = [[NSDate date] timeIntervalSince1970];
+    
+    NSDictionary *currentDict = [self.platformDict getAsDictionary];
+    if ([currentDict valueForKey:kSPMobileAppleIdfa] == nil) {
+        [self.platformDict addValueToPayload:[self.deviceInfoMonitor appleIdfa] forKey:kSPMobileAppleIdfa];
+    }
+    if ([currentDict valueForKey:kSPMobileAppleIdfv] == nil) {
+        [self.platformDict addValueToPayload:[self.deviceInfoMonitor appleIdfv] forKey:kSPMobileAppleIdfv];
+    }
     
     [self.platformDict addNumericValueToPayload:[self.deviceInfoMonitor batteryLevel]          forKey:kSPMobileBatteryLevel];
     [self.platformDict addValueToPayload:[self.deviceInfoMonitor batteryState]                 forKey:kSPMobileBatteryState];


### PR DESCRIPTION
Addresses issue #661 by updating the Apple IDFA and IDFV while they are `nil`. Once a value for them is found, they will no longer be updated.