### PR TITLE
Add session callback (close #664)

### DIFF
--- a/Snowplow iOSTests/TestSession.m
+++ b/Snowplow iOSTests/TestSession.m
@@ -55,7 +55,7 @@
     XCTAssertNil([session getTracker]);
     XCTAssertTrue(![session getInBackground]);
     XCTAssertNotNil([session getSessionDictWithEventId:@"eventid-1"]);
-    XCTAssertTrue([session getSessionIndex] >= 1);
+    XCTAssertTrue(session.state.sessionIndex >= 1);
     XCTAssertEqual([session getForegroundTimeout], 600000);
     XCTAssertEqual([session getBackgroundTimeout], 300000);
 }
@@ -86,7 +86,7 @@
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
     
     NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
-    NSInteger sessionIndex = [session getSessionIndex];
+    NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -96,7 +96,7 @@
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
     
     NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
-    NSInteger sessionIndex = [session getSessionIndex];
+    NSInteger sessionIndex = session.state.sessionIndex;
     NSString *sessionId = [sessionContext objectForKey:kSPSessionId];
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -105,7 +105,7 @@
     [NSThread sleepForTimeInterval:1];
 
     sessionContext = [session getSessionDictWithEventId:@"event_2"];
-    sessionIndex = [session getSessionIndex];
+    sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -114,7 +114,7 @@
     [NSThread sleepForTimeInterval:1];
 
     sessionContext = [session getSessionDictWithEventId:@"event_3"];
-    sessionIndex = [session getSessionIndex];
+    sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -123,7 +123,7 @@
     [NSThread sleepForTimeInterval:3.1];
 
     sessionContext = [session getSessionDictWithEventId:@"event_4"];
-    sessionIndex = [session getSessionIndex];
+    sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(2, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_4", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -147,7 +147,7 @@
     [session updateInBackground];
     
     NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
-    NSInteger sessionIndex = [session getSessionIndex];
+    NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -175,7 +175,7 @@
     NSString *sessionId = session.state.sessionId;
 
     NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
-    NSInteger sessionIndex = [session getSessionIndex];
+    NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(sessionId, [sessionContext objectForKey:kSPSessionId]);
@@ -185,7 +185,7 @@
     [NSThread sleepForTimeInterval:1];
     
     sessionContext = [session getSessionDictWithEventId:@"event_2"];
-    sessionIndex = [session getSessionIndex];
+    sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(sessionId, [sessionContext objectForKey:kSPSessionId]);
@@ -195,7 +195,7 @@
     [NSThread sleepForTimeInterval:1];
     
     sessionContext = [session getSessionDictWithEventId:@"event_3"];
-    sessionIndex = [session getSessionIndex];
+    sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(sessionId, [sessionContext objectForKey:kSPSessionId]);
@@ -205,7 +205,7 @@
     [NSThread sleepForTimeInterval:2.1];
     
     sessionContext = [session getSessionDictWithEventId:@"event_4"];
-    sessionIndex = [session getSessionIndex];
+    sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(2, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_4", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -330,9 +330,9 @@
     [tracker1 track:event];
     [tracker2 track:event];
 
-    NSInteger initialValue1 = [tracker1.session getSessionIndex];
+    NSInteger initialValue1 = tracker1.session.state.sessionIndex;
     NSString *id1 = tracker1.session.state.sessionId;
-    NSInteger initialValue2 = [tracker2.session getSessionIndex];
+    NSInteger initialValue2 = tracker2.session.state.sessionIndex;
     NSString *id2 = tracker2.session.state.sessionId;
 
     // Retrigger session in tracker1
@@ -345,8 +345,8 @@
     id2 = tracker2.session.state.sessionId;
 
     // Check sessions have the correct state
-    XCTAssertEqual(0, [tracker1.session getSessionIndex] - initialValue1); // retriggered
-    XCTAssertEqual(1, [tracker2.session getSessionIndex] - initialValue2); // timed out
+    XCTAssertEqual(0, tracker1.session.state.sessionIndex - initialValue1); // retriggered
+    XCTAssertEqual(1, tracker2.session.state.sessionIndex - initialValue2); // timed out
     
     //Recreate tracker2
     SPTracker *tracker2b = [SPTracker build:^(id<SPTrackerBuilder> _Nonnull builder) {
@@ -357,7 +357,7 @@
         [builder setBackgroundTimeout:5];
     }];
     [tracker2b track:event];
-    NSInteger initialValue2b = [tracker2b.session getSessionIndex];
+    NSInteger initialValue2b = tracker2b.session.state.sessionIndex;
     NSString *previousId2b = tracker2b.session.state.previousSessionId;
 
     // Check the new tracker session gets the data from the old tracker2 session

--- a/Snowplow iOSTests/TestSession.m
+++ b/Snowplow iOSTests/TestSession.m
@@ -172,7 +172,7 @@
     
     [session updateInBackground]; // It sends a background event
 
-    NSString *sessionId = [session getSessionId];
+    NSString *sessionId = session.state.sessionId;
 
     NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
     NSInteger sessionIndex = [session getSessionIndex];
@@ -331,9 +331,9 @@
     [tracker2 track:event];
 
     NSInteger initialValue1 = [tracker1.session getSessionIndex];
-    NSString *id1 = [tracker1.session getSessionId];
+    NSString *id1 = tracker1.session.state.sessionId;
     NSInteger initialValue2 = [tracker2.session getSessionIndex];
-    NSString *id2 = [tracker2.session getSessionId];
+    NSString *id2 = tracker2.session.state.sessionId;
 
     // Retrigger session in tracker1
     [NSThread sleepForTimeInterval:7];
@@ -342,7 +342,7 @@
 
     // Send event to force update of session on tracker2
     [tracker2 track:event];
-    id2 = [tracker2.session getSessionId];
+    id2 = tracker2.session.state.sessionId;
 
     // Check sessions have the correct state
     XCTAssertEqual(0, [tracker1.session getSessionIndex] - initialValue1); // retriggered
@@ -358,7 +358,7 @@
     }];
     [tracker2b track:event];
     NSInteger initialValue2b = [tracker2b.session getSessionIndex];
-    NSString *previousId2b = [tracker2b.session getPreviousSessionId];
+    NSString *previousId2b = tracker2b.session.state.previousSessionId;
 
     // Check the new tracker session gets the data from the old tracker2 session
     XCTAssertEqual(initialValue2 + 2, initialValue2b);

--- a/Snowplow iOSTests/TestUtils.m
+++ b/Snowplow iOSTests/TestUtils.m
@@ -46,16 +46,7 @@
 }
 
 - (void)testGetLanguage {
-#if TARGET_OS_IPHONE
-    if (SNOWPLOW_iOS_9_OR_LATER) {
-        NSArray *options = [NSArray arrayWithObjects:@"en", @"en-US", nil];
-        XCTAssertTrue([options containsObject:[SPUtilities getLanguage]]);
-    }
-#else
-    XCTAssertEqualObjects([SPUtilities getLanguage],
-                          @"en",
-                          @"Language retrieved is not the same as 'en'");
-#endif
+    XCTAssertNotNil([SPUtilities getLanguage]);
 }
 
 - (void)testGetPlatform {

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -392,6 +392,14 @@
 		ED38D93826EBCEBE002AEC8E /* SPLifecycleState.m in Sources */ = {isa = PBXBuildFile; fileRef = ED38D92A26EBCEBE002AEC8E /* SPLifecycleState.m */; };
 		ED38D93926EBCEBE002AEC8E /* SPLifecycleState.m in Sources */ = {isa = PBXBuildFile; fileRef = ED38D92A26EBCEBE002AEC8E /* SPLifecycleState.m */; };
 		ED38D93A26EBCEBE002AEC8E /* SPLifecycleState.m in Sources */ = {isa = PBXBuildFile; fileRef = ED38D92A26EBCEBE002AEC8E /* SPLifecycleState.m */; };
+		ED49DF3C2757E4F500610843 /* SPSessionState.h in Headers */ = {isa = PBXBuildFile; fileRef = ED49DF3A2757E4F400610843 /* SPSessionState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED49DF3D2757E4F500610843 /* SPSessionState.h in Headers */ = {isa = PBXBuildFile; fileRef = ED49DF3A2757E4F400610843 /* SPSessionState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED49DF3E2757E4F500610843 /* SPSessionState.h in Headers */ = {isa = PBXBuildFile; fileRef = ED49DF3A2757E4F400610843 /* SPSessionState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED49DF3F2757E4F500610843 /* SPSessionState.h in Headers */ = {isa = PBXBuildFile; fileRef = ED49DF3A2757E4F400610843 /* SPSessionState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED49DF402757E4F500610843 /* SPSessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = ED49DF3B2757E4F400610843 /* SPSessionState.m */; };
+		ED49DF412757E4F500610843 /* SPSessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = ED49DF3B2757E4F400610843 /* SPSessionState.m */; };
+		ED49DF422757E4F500610843 /* SPSessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = ED49DF3B2757E4F400610843 /* SPSessionState.m */; };
+		ED49DF432757E4F500610843 /* SPSessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = ED49DF3B2757E4F400610843 /* SPSessionState.m */; };
 		ED6B0329271094D700EFA12B /* SPMessageNotificationAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = ED6B0327271094D700EFA12B /* SPMessageNotificationAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED6B032A271094D700EFA12B /* SPMessageNotificationAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = ED6B0327271094D700EFA12B /* SPMessageNotificationAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED6B032B271094D700EFA12B /* SPMessageNotificationAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = ED6B0327271094D700EFA12B /* SPMessageNotificationAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1032,6 +1040,8 @@
 		ED38D92826EBCEBE002AEC8E /* SPLifecycleStateMachine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPLifecycleStateMachine.m; sourceTree = "<group>"; };
 		ED38D92926EBCEBE002AEC8E /* SPLifecycleStateMachine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPLifecycleStateMachine.h; sourceTree = "<group>"; };
 		ED38D92A26EBCEBE002AEC8E /* SPLifecycleState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPLifecycleState.m; sourceTree = "<group>"; };
+		ED49DF3A2757E4F400610843 /* SPSessionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPSessionState.h; sourceTree = "<group>"; };
+		ED49DF3B2757E4F400610843 /* SPSessionState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPSessionState.m; sourceTree = "<group>"; };
 		ED6AC5152369D42800A8F8A3 /* ios.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = ios.modulemap; sourceTree = "<group>"; };
 		ED6B0327271094D700EFA12B /* SPMessageNotificationAttachment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMessageNotificationAttachment.h; sourceTree = "<group>"; };
 		ED6B0328271094D700EFA12B /* SPMessageNotificationAttachment.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMessageNotificationAttachment.m; sourceTree = "<group>"; };
@@ -1656,6 +1666,8 @@
 				EDDD702E264F25A200259404 /* SPSessionConfigurationUpdate.m */,
 				043EC5DD1B8F048500294081 /* SPSession.h */,
 				043EC5DF1B8F049200294081 /* SPSession.m */,
+				ED49DF3A2757E4F400610843 /* SPSessionState.h */,
+				ED49DF3B2757E4F400610843 /* SPSessionState.m */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -1781,6 +1793,7 @@
 				ED277BD22625F220002C7B6D /* SPConfigurationBundle.h in Headers */,
 				EDDD6FFD264E873B00259404 /* SPController.h in Headers */,
 				CE4F9CF2244B066500968CFC /* SPStructured.h in Headers */,
+				ED49DF3C2757E4F500610843 /* SPSessionState.h in Headers */,
 				EDD8542A24EFEFE600661F6B /* SPNetworkConnection.h in Headers */,
 				ED88B7912587B5620048FAD1 /* SPNetworkControllerImpl.h in Headers */,
 				ED38D93326EBCEBE002AEC8E /* SPLifecycleStateMachine.h in Headers */,
@@ -1947,6 +1960,7 @@
 				EDAB65CF26CBD5150067755F /* SPDeepLinkEntity.h in Headers */,
 				ED88B590257922490048FAD1 /* SPEmitterController.h in Headers */,
 				75CAC46321F2A21B00271FB3 /* SPWeakTimerTarget.h in Headers */,
+				ED49DF3D2757E4F500610843 /* SPSessionState.h in Headers */,
 				ED88B5FC257954370048FAD1 /* SPGDPRController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2002,6 +2016,7 @@
 				ED91CB6E23AA715B0078E75F /* SPDevicePlatform.h in Headers */,
 				EDDD7031264F25A200259404 /* SPSessionConfigurationUpdate.h in Headers */,
 				75CAC43821F2A0CC00271FB3 /* Snowplow-umbrella-header.h in Headers */,
+				ED49DF3E2757E4F500610843 /* SPSessionState.h in Headers */,
 				CE4F9C9C244B066500968CFC /* SPEvent.h in Headers */,
 				EDAB664226D699D90067755F /* SPStateFuture.h in Headers */,
 				CE4F9CB0244B066500968CFC /* SPConsentWithdrawn.h in Headers */,
@@ -2126,6 +2141,7 @@
 				ED277BD52625F220002C7B6D /* SPConfigurationBundle.h in Headers */,
 				EDDD7000264E873B00259404 /* SPController.h in Headers */,
 				CE4F9CF5244B066500968CFC /* SPStructured.h in Headers */,
+				ED49DF3F2757E4F500610843 /* SPSessionState.h in Headers */,
 				EDD8542D24EFEFE600661F6B /* SPNetworkConnection.h in Headers */,
 				ED88B7942587B5620048FAD1 /* SPNetworkControllerImpl.h in Headers */,
 				ED38D93626EBCEBE002AEC8E /* SPLifecycleStateMachine.h in Headers */,
@@ -2513,6 +2529,7 @@
 				752DAC1721CC42BC0065F874 /* SPTrackerConstants.m in Sources */,
 				ED277BE62625F5C5002C7B6D /* SPFetchedConfigurationBundle.m in Sources */,
 				CE4F9C92244B066500968CFC /* SPForeground.m in Sources */,
+				ED49DF402757E4F500610843 /* SPSessionState.m in Sources */,
 				ED91CB7123AA8AD50078E75F /* SPDevicePlatform.m in Sources */,
 				CE4F9CBA244B066500968CFC /* SPSelfDescribing.m in Sources */,
 				ED277BD62625F220002C7B6D /* SPConfigurationBundle.m in Sources */,
@@ -2686,6 +2703,7 @@
 				75CAC44021F2A17500271FB3 /* SPSelfDescribingJson.m in Sources */,
 				CE4F9CCF244B066500968CFC /* SNOWError.m in Sources */,
 				CE4F9C87244B066500968CFC /* SPTiming.m in Sources */,
+				ED49DF412757E4F500610843 /* SPSessionState.m in Sources */,
 				CE4F9D1F244B066500968CFC /* SPEcommerce.m in Sources */,
 				EDDD703E264F27E700259404 /* SPNetworkConfigurationUpdate.m in Sources */,
 				75CAC44121F2A17500271FB3 /* SPSQLiteEventStore.m in Sources */,
@@ -2783,6 +2801,7 @@
 				75CAC44C21F2A19500271FB3 /* SPSession.m in Sources */,
 				CE4F9CD0244B066500968CFC /* SNOWError.m in Sources */,
 				CE4F9C88244B066500968CFC /* SPTiming.m in Sources */,
+				ED49DF422757E4F500610843 /* SPSessionState.m in Sources */,
 				CE4F9D20244B066500968CFC /* SPEcommerce.m in Sources */,
 				EDDD703F264F27E700259404 /* SPNetworkConfigurationUpdate.m in Sources */,
 				75CAC44D21F2A19500271FB3 /* SPPayload.m in Sources */,
@@ -2888,6 +2907,7 @@
 				75F9C5DA21FA357100A5B8FC /* SPSession.m in Sources */,
 				CE4F9CD1244B066500968CFC /* SNOWError.m in Sources */,
 				75F9C5DB21FA357100A5B8FC /* SPPayload.m in Sources */,
+				ED49DF432757E4F500610843 /* SPSessionState.m in Sources */,
 				CE4F9CF1244B066500968CFC /* SPSchemaRule.m in Sources */,
 				EDDD7040264F27E700259404 /* SPNetworkConfigurationUpdate.m in Sources */,
 				CE4F9C91244B066500968CFC /* SPConsentWithdrawn.m in Sources */,

--- a/Snowplow/Internal/Configurations/SPSessionConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPSessionConfiguration.h
@@ -22,8 +22,11 @@
 
 #import <Foundation/Foundation.h>
 #import "SPConfiguration.h"
+#import "SPSessionState.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^OnSessionUpdate)(SPSessionState * _Nonnull sessionState);
 
 NS_SWIFT_NAME(SessionConfigurationProtocol)
 @protocol SPSessionConfigurationProtocol
@@ -53,6 +56,11 @@ NS_SWIFT_NAME(SessionConfigurationProtocol)
  * background.
  */
 @property NSMeasurement<NSUnitDuration *> *backgroundTimeout API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0));
+
+/**
+ * The callback called everytime the session is updated.
+ */
+@property (nullable) OnSessionUpdate onSessionUpdate;
 
 @end
 
@@ -86,6 +94,11 @@ NS_SWIFT_NAME(SessionConfiguration)
 - (instancetype)initWithForegroundTimeout:(NSMeasurement<NSUnitDuration *> *)foregroundTimeout
                         backgroundTimeout:(NSMeasurement<NSUnitDuration *> *)backgroundTimeout
 API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0));
+
+/**
+ * The callback called everytime the session is updated.
+ */
+SP_BUILDER_DECLARE_NULLABLE(OnSessionUpdate, onSessionUpdate)
 
 @end
 

--- a/Snowplow/Internal/Configurations/SPSessionConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPSessionConfiguration.h
@@ -26,7 +26,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^OnSessionUpdate)(SPSessionState * _Nonnull sessionState);
+typedef void(^OnSessionStateUpdate)(SPSessionState * _Nonnull sessionState);
 
 NS_SWIFT_NAME(SessionConfigurationProtocol)
 @protocol SPSessionConfigurationProtocol
@@ -60,7 +60,7 @@ NS_SWIFT_NAME(SessionConfigurationProtocol)
 /**
  * The callback called everytime the session is updated.
  */
-@property (nullable) OnSessionUpdate onSessionUpdate;
+@property (nullable) OnSessionStateUpdate onSessionStateUpdate;
 
 @end
 
@@ -98,7 +98,7 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0));
 /**
  * The callback called everytime the session is updated.
  */
-SP_BUILDER_DECLARE_NULLABLE(OnSessionUpdate, onSessionUpdate)
+SP_BUILDER_DECLARE_NULLABLE(OnSessionStateUpdate, onSessionUpdate)
 
 @end
 

--- a/Snowplow/Internal/Configurations/SPSessionConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPSessionConfiguration.h
@@ -98,7 +98,7 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0));
 /**
  * The callback called everytime the session is updated.
  */
-SP_BUILDER_DECLARE_NULLABLE(OnSessionStateUpdate, onSessionUpdate)
+SP_BUILDER_DECLARE_NULLABLE(OnSessionStateUpdate, onSessionStateUpdate)
 
 @end
 

--- a/Snowplow/Internal/Configurations/SPSessionConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPSessionConfiguration.m
@@ -27,7 +27,7 @@
 
 @synthesize foregroundTimeoutInSeconds;
 @synthesize backgroundTimeoutInSeconds;
-@synthesize onSessionUpdate;
+@synthesize onSessionStateUpdate;
 
 - (instancetype)init {
     return [self initWithForegroundTimeoutInSeconds:1800 backgroundTimeoutInSeconds:1800];
@@ -83,7 +83,7 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
 
 // MARK: - Builders
 
-SP_BUILDER_METHOD(OnSessionUpdate, onSessionUpdate)
+SP_BUILDER_METHOD(OnSessionStateUpdate, onSessionStateUpdate)
 
 // MARK: - NSCopying
 

--- a/Snowplow/Internal/Configurations/SPSessionConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPSessionConfiguration.m
@@ -91,6 +91,7 @@ SP_BUILDER_METHOD(OnSessionStateUpdate, onSessionStateUpdate)
     SPSessionConfiguration *copy = [[SPSessionConfiguration allocWithZone:zone] init];
     copy.backgroundTimeoutInSeconds = self.backgroundTimeoutInSeconds;
     copy.foregroundTimeoutInSeconds = self.foregroundTimeoutInSeconds;
+    copy.onSessionStateUpdate = self.onSessionStateUpdate;
     return copy;
 }
 

--- a/Snowplow/Internal/Configurations/SPSessionConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPSessionConfiguration.m
@@ -27,6 +27,7 @@
 
 @synthesize foregroundTimeoutInSeconds;
 @synthesize backgroundTimeoutInSeconds;
+@synthesize onSessionUpdate;
 
 - (instancetype)init {
     return [self initWithForegroundTimeoutInSeconds:1800 backgroundTimeoutInSeconds:1800];
@@ -79,6 +80,10 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
 {
     return [[NSMeasurement alloc] initWithDoubleValue:self.backgroundTimeoutInSeconds unit:NSUnitDuration.seconds];
 }
+
+// MARK: - Builders
+
+SP_BUILDER_METHOD(OnSessionUpdate, onSessionUpdate)
 
 // MARK: - NSCopying
 

--- a/Snowplow/Internal/Session/SPSession.h
+++ b/Snowplow/Internal/Session/SPSession.h
@@ -26,6 +26,9 @@
 NS_SWIFT_NAME(Session)
 @interface SPSession : NSObject
 
+/// Callback to be called when the session is updated
+@property OnSessionUpdate onSessionUpdate;
+
 /**
  * Initializes a newly allocated SnowplowSession
  * @return a SnowplowSession

--- a/Snowplow/Internal/Session/SPSession.h
+++ b/Snowplow/Internal/Session/SPSession.h
@@ -112,12 +112,6 @@ NS_SWIFT_NAME(Session)
 - (NSDictionary *) getSessionDictWithEventId:(NSString *)firstEventId;
 
 /**
- * Returns the current session index count
- * @return a count of sessions
- */
-- (NSInteger) getSessionIndex;
-
-/**
  * Returns the foreground index count
  * @return a count of foregrounds
  */

--- a/Snowplow/Internal/Session/SPSession.h
+++ b/Snowplow/Internal/Session/SPSession.h
@@ -22,12 +22,16 @@
 
 #import <Foundation/Foundation.h>
 #import "SPTracker.h"
+#import "SPSessionState.h"
 
 NS_SWIFT_NAME(Session)
 @interface SPSession : NSObject
 
 /// Callback to be called when the session is updated
-@property OnSessionUpdate onSessionUpdate;
+@property OnSessionStateUpdate onSessionStateUpdate;
+
+/// Returns the current session state
+@property (readonly) SPSessionState *state;
 
 /**
  * Initializes a newly allocated SnowplowSession
@@ -136,17 +140,5 @@ NS_SWIFT_NAME(Session)
  * @return the session's userId
  */
 - (NSString*) getUserId;
-
-/**
- * Returns the current session's id
- * @return the current session's id
- */
-- (NSString*) getSessionId;
-
-/**
- * Returns the current session's id
- * @return the previous session's id
- */
-- (NSString*) getPreviousSessionId;
 
 @end

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -144,8 +144,9 @@
             if ([self shouldUpdateSession]) {
                 [self updateSessionWithEventId:eventId];
                 if (self.onSessionStateUpdate) {
-                    //$ Add here callback in separate thread
-                    self.onSessionStateUpdate(_state);
+                    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                        self.onSessionStateUpdate(self.state);
+                    });
                 }
             }
             self.lastSessionCheck = [SPUtilities getTimestamp];

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -152,7 +152,9 @@
         @synchronized (self) {
             if ([self shouldUpdateSession]) {
                 SPSessionState *state = [self updateSessionWithEventId:eventId];
-                self.onSessionUpdate(state);
+                if (self.onSessionUpdate) {
+                    self.onSessionUpdate(state);
+                }
             }
             self.lastSessionCheck = [SPUtilities getTimestamp];
             result = [_sessionDict mutableCopy];

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -164,10 +164,6 @@
     return _backgroundTimeout;
 }
 
-- (NSInteger) getSessionIndex {
-    return _sessionIndex;
-}
-
 - (BOOL) getInBackground {
     return _inBackground;
 }

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -176,11 +176,13 @@
 
 - (NSString *)retrieveUserIdWithState:(SPSessionState *)state {
     NSString *userId = state.userId ?: [SPUtilities getUUIDString];
-    // With v2 we designed a new identifier: Installation ID.
-    // It should be created by the tracker at first execution and it should be constant until the app deletion.
-    // It behaves as the SessionUserID but it should be available even if the session context is disabled.
-    // At the moment we store it separately from the session in order to fully implement it in one of the
-    // future versions.
+    // Session_UserID is available only if the session context is enabled.
+    // In a future version we would like to make it available even if the session context is disabled.
+    // For this reason, we store the Session_UserID in a separate storage (decoupled by session values)
+    // calling it Installation_UserID in order to remark that it isn't related to the session context.
+    // Although, for legacy, we need to copy its value in the Session_UserID of the session context
+    // as the session context schema (and related data modelling) requires it.
+    // For further details: https://discourse.snowplowanalytics.com/t/rfc-mobile-trackers-v2-0
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     NSString *storedUserId = [userDefaults stringForKey:kSPInstallationUserId];
     if (storedUserId) {

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -204,7 +204,15 @@
     _isNewSession = NO;
     _sessionIndex++;
     _state = [[SPSessionState alloc] initWithFirstEventId:eventId currentSessionId:[SPUtilities getUUIDString] previousSessionId:_state.sessionId sessionIndex:_sessionIndex userId:_userId storage:@"LOCAL_STORAGE"];
-    self.dataPersistence.session = _state.sessionContext;
+    NSDictionary<NSString *,NSObject *> *sessionToPersist = _state.sessionContext;
+    // Remove previousSessionId if nil because dictionaries with nil values aren't plist serializable
+    // and can't be stored with SPDataPersistence.
+    if (!_state.previousSessionId) {
+        NSMutableDictionary<NSString *,NSObject *> *sessionCopy = [sessionToPersist mutableCopy];
+        [sessionCopy removeObjectForKey:kSPSessionPreviousId];
+        sessionToPersist = sessionCopy;
+    }
+    self.dataPersistence.session = sessionToPersist;
 }
 
 - (void) updateInBackground {

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -151,7 +151,8 @@
     } else {
         @synchronized (self) {
             if ([self shouldUpdateSession]) {
-                [self updateSessionWithEventId:eventId];
+                SPSessionState *state = [self updateSessionWithEventId:eventId];
+                self.onSessionUpdate(state);
             }
             self.lastSessionCheck = [SPUtilities getTimestamp];
             result = [_sessionDict mutableCopy];
@@ -221,7 +222,7 @@
     return now < lastAccess || now - lastAccess > timeout;
 }
 
-- (void)updateSessionWithEventId:(NSString *)eventId {
+- (SPSessionState *)updateSessionWithEventId:(NSString *)eventId {
     _isNewSession = NO;
     _firstEventId = eventId;
     _previousSessionId = _currentSessionId;
@@ -238,8 +239,12 @@
     [newSessionDict setObject:[NSNumber numberWithInt:(int)_sessionIndex] forKey:kSPSessionIndex];
     [newSessionDict setObject:_sessionStorage forKey:kSPSessionStorage];
     _sessionDict = [newSessionDict copy];
-
+    
     [self writeSessionToFile];
+
+    // Create SessionState
+    SPSessionState *sessionState = [[SPSessionState alloc] init];
+    return sessionState;
 }
 
 - (void) updateInBackground {

--- a/Snowplow/Internal/Session/SPSessionConfigurationUpdate.h
+++ b/Snowplow/Internal/Session/SPSessionConfigurationUpdate.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SP_DIRTYFLAG(foregroundTimeoutInSeconds)
 SP_DIRTYFLAG(backgroundTimeoutInSeconds)
+SP_DIRTYFLAG(onSessionUpdate)
 
 @end
 

--- a/Snowplow/Internal/Session/SPSessionConfigurationUpdate.h
+++ b/Snowplow/Internal/Session/SPSessionConfigurationUpdate.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SP_DIRTYFLAG(foregroundTimeoutInSeconds)
 SP_DIRTYFLAG(backgroundTimeoutInSeconds)
-SP_DIRTYFLAG(onSessionUpdate)
+SP_DIRTYFLAG(onSessionStateUpdate)
 
 @end
 

--- a/Snowplow/Internal/Session/SPSessionConfigurationUpdate.m
+++ b/Snowplow/Internal/Session/SPSessionConfigurationUpdate.m
@@ -26,5 +26,6 @@
 
 SP_DIRTY_GETTER(NSInteger, foregroundTimeoutInSeconds);
 SP_DIRTY_GETTER(NSInteger, backgroundTimeoutInSeconds);
+SP_DIRTY_GETTER(OnSessionUpdate, onSessionUpdate)
 
 @end

--- a/Snowplow/Internal/Session/SPSessionConfigurationUpdate.m
+++ b/Snowplow/Internal/Session/SPSessionConfigurationUpdate.m
@@ -26,6 +26,6 @@
 
 SP_DIRTY_GETTER(NSInteger, foregroundTimeoutInSeconds);
 SP_DIRTY_GETTER(NSInteger, backgroundTimeoutInSeconds);
-SP_DIRTY_GETTER(OnSessionUpdate, onSessionUpdate)
+SP_DIRTY_GETTER(OnSessionStateUpdate, onSessionStateUpdate)
 
 @end

--- a/Snowplow/Internal/Session/SPSessionControllerImpl.m
+++ b/Snowplow/Internal/Session/SPSessionControllerImpl.m
@@ -76,10 +76,10 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
     [self.session setBackgroundTimeout:backgroundTimeoutInSeconds * 1000];
 }
 
-- (void)setOnSessionUpdate:(OnSessionUpdate)onSessionUpdate {
-    self.dirtyConfig.onSessionUpdate = onSessionUpdate;
-    self.dirtyConfig.onSessionUpdateUpdated = YES;
-    self.session.onSessionUpdate = onSessionUpdate;
+- (void)setOnSessionStateUpdate:(OnSessionStateUpdate)onSessionUpdate {
+    self.dirtyConfig.onSessionStateUpdate = onSessionUpdate;
+    self.dirtyConfig.onSessionStateUpdateUpdated = YES;
+    self.session.onSessionStateUpdate = onSessionUpdate;
 }
 
 - (NSMeasurement<NSUnitDuration *> *)foregroundTimeout
@@ -110,12 +110,12 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
     return floor([self.session getBackgroundTimeout] / 1000);
 }
 
-- (OnSessionUpdate)onSessionUpdate {
+- (OnSessionStateUpdate)onSessionStateUpdate {
     if (!self.isEnabled) {
         SPLogTrack(nil, @"Attempt to access SessionController fields when disabled");
         return nil;
     }
-    return self.session.onSessionUpdate;
+    return self.session.onSessionStateUpdate;
 }
 
 - (NSInteger)sessionIndex {
@@ -131,7 +131,7 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
         SPLogTrack(nil, @"Attempt to access SessionController fields when disabled");
         return nil;
     }
-    return self.session.getSessionId;
+    return self.session.state.sessionId;
 }
 
 - (NSString *)userId {

--- a/Snowplow/Internal/Session/SPSessionControllerImpl.m
+++ b/Snowplow/Internal/Session/SPSessionControllerImpl.m
@@ -76,6 +76,12 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
     [self.session setBackgroundTimeout:backgroundTimeoutInSeconds * 1000];
 }
 
+- (void)setOnSessionUpdate:(OnSessionUpdate)onSessionUpdate {
+    self.dirtyConfig.onSessionUpdate = onSessionUpdate;
+    self.dirtyConfig.onSessionUpdateUpdated = YES;
+    self.session.onSessionUpdate = onSessionUpdate;
+}
+
 - (NSMeasurement<NSUnitDuration *> *)foregroundTimeout
 API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
 {
@@ -102,6 +108,14 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
         return -1;
     }
     return floor([self.session getBackgroundTimeout] / 1000);
+}
+
+- (OnSessionUpdate)onSessionUpdate {
+    if (!self.isEnabled) {
+        SPLogTrack(nil, @"Attempt to access SessionController fields when disabled");
+        return nil;
+    }
+    return self.session.onSessionUpdate;
 }
 
 - (NSInteger)sessionIndex {

--- a/Snowplow/Internal/Session/SPSessionControllerImpl.m
+++ b/Snowplow/Internal/Session/SPSessionControllerImpl.m
@@ -123,7 +123,7 @@ API_AVAILABLE(ios(10), macosx(10.12), tvos(10.0), watchos(3.0))
         SPLogTrack(nil, @"Attempt to access SessionController fields when disabled");
         return -1;
     }
-    return self.session.getSessionIndex;
+    return self.session.state.sessionIndex;
 }
 
 - (NSString *)sessionId {

--- a/Snowplow/Internal/Session/SPSessionState.h
+++ b/Snowplow/Internal/Session/SPSessionState.h
@@ -1,0 +1,19 @@
+//
+//  SPSessionState.h
+//  Snowplow
+//
+//  Created by Alex Benini on 01/12/21.
+//  Copyright © 2021 Snowplow Analytics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SPState.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPSessionState : NSObject <SPState>
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snowplow/Internal/Session/SPSessionState.h
+++ b/Snowplow/Internal/Session/SPSessionState.h
@@ -13,6 +13,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPSessionState : NSObject <SPState>
 
+@property (nonatomic, nonnull, readonly) NSString *firstEventId;
+@property (nonatomic, nullable, readonly) NSString *previousSessionId;
+@property (nonatomic, nonnull, readonly) NSString *sessionId;
+@property (nonatomic, readonly) NSInteger sessionIndex;
+@property (nonatomic, nonnull, readonly) NSString *storage;
+@property (nonatomic, nonnull) NSString *userId;
+
+@property (nonatomic, nonnull, readonly) NSMutableDictionary<NSString *, NSObject *> *sessionContext;
+
+- (instancetype)initWithFirstEventId:(NSString *)firstEventId currentSessionId:(NSString *)currentSessionId previousSessionId:(nullable NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage;
+
+- (instancetype)initWithStoredState:(NSDictionary<NSString *, NSObject *> *)storedState;
 
 @end
 

--- a/Snowplow/Internal/Session/SPSessionState.h
+++ b/Snowplow/Internal/Session/SPSessionState.h
@@ -2,8 +2,21 @@
 //  SPSessionState.h
 //  Snowplow
 //
-//  Created by Alex Benini on 01/12/21.
-//  Copyright © 2021 Snowplow Analytics. All rights reserved.
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  License: Apache License Version 2.0
 //
 
 #import <Foundation/Foundation.h>

--- a/Snowplow/Internal/Session/SPSessionState.m
+++ b/Snowplow/Internal/Session/SPSessionState.m
@@ -34,9 +34,11 @@
         self.storage = storage;
         
         NSMutableDictionary *sessionDictionary = [NSMutableDictionary new];
-        [sessionDictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
+        if (previousSessionId) {
+            [sessionDictionary setObject:previousSessionId forKey:kSPSessionPreviousId];
+        }
         [sessionDictionary setObject:currentSessionId forKey:kSPSessionId];
-        [sessionDictionary setObject:(previousSessionId ?: [NSNull null]) forKey:kSPSessionPreviousId];
+        [sessionDictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
         [sessionDictionary setObject:[NSNumber numberWithInteger:sessionIndex] forKey:kSPSessionIndex];
         [sessionDictionary setObject:storage forKey:kSPSessionStorage];
         [sessionDictionary setObject:userId forKey:kSPSessionUserId];

--- a/Snowplow/Internal/Session/SPSessionState.m
+++ b/Snowplow/Internal/Session/SPSessionState.m
@@ -1,0 +1,13 @@
+//
+//  SPSessionState.m
+//  Snowplow
+//
+//  Created by Alex Benini on 01/12/21.
+//  Copyright © 2021 Snowplow Analytics. All rights reserved.
+//
+
+#import "SPSessionState.h"
+
+@implementation SPSessionState
+
+@end

--- a/Snowplow/Internal/Session/SPSessionState.m
+++ b/Snowplow/Internal/Session/SPSessionState.m
@@ -7,7 +7,72 @@
 //
 
 #import "SPSessionState.h"
+#import "SPTrackerConstants.h"
+#import "NSDictionary+SP_TypeMethods.h"
+
+@interface SPSessionState ()
+
+@property (nonatomic, nonnull, readwrite) NSString *firstEventId;
+@property (nonatomic, nullable, readwrite) NSString *previousSessionId;
+@property (nonatomic, nonnull, readwrite) NSString *sessionId;
+@property (nonatomic, readwrite) NSInteger sessionIndex;
+@property (nonatomic, nonnull, readwrite) NSString *storage;
+
+@property (nonatomic, nonnull, readwrite) NSMutableDictionary<NSString *, NSObject *> *sessionContext;
+
+@end
 
 @implementation SPSessionState
+
+- (instancetype)initWithFirstEventId:(NSString *)firstEventId currentSessionId:(NSString *)currentSessionId previousSessionId:(NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage {
+    if (self = [super init]) {
+        self.firstEventId = firstEventId;
+        self.sessionId = currentSessionId;
+        self.previousSessionId = previousSessionId;
+        self.sessionIndex = sessionIndex;
+        self.userId = userId;
+        self.storage = storage;
+        
+        NSMutableDictionary *sessionDictionary = [NSMutableDictionary new];
+        [sessionDictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
+        [sessionDictionary setObject:currentSessionId forKey:kSPSessionId];
+        [sessionDictionary setObject:(previousSessionId ?: [NSNull null]) forKey:kSPSessionPreviousId];
+        [sessionDictionary setObject:[NSNumber numberWithInteger:sessionIndex] forKey:kSPSessionIndex];
+        [sessionDictionary setObject:storage forKey:kSPSessionStorage];
+        [sessionDictionary setObject:userId forKey:kSPSessionUserId];
+        self.sessionContext = sessionDictionary;
+    }
+    return self;
+}
+
+- (instancetype)initWithStoredState:(NSDictionary<NSString *,NSObject *> *)storedState {
+    if (self = [super init]) {
+        self.sessionContext = [storedState mutableCopy];
+        
+        self.firstEventId = [self.sessionContext sp_stringForKey:kSPSessionFirstEventId defaultValue:nil];
+        if (!self.firstEventId) return nil;
+        
+        self.sessionId = [self.sessionContext sp_stringForKey:kSPSessionId defaultValue:nil];
+        if (!self.sessionId) return nil;
+        
+        self.previousSessionId = [self.sessionContext sp_stringForKey:kSPSessionPreviousId defaultValue:nil];
+        
+        NSNumber *sessionIndexNumber = [self.sessionContext sp_numberForKey:kSPSessionIndex defaultValue:nil];
+        if (!sessionIndexNumber) return nil;
+        self.sessionIndex = sessionIndexNumber.integerValue;
+        
+        self.userId = [self.sessionContext sp_stringForKey:kSPSessionUserId defaultValue:nil];
+        if (!self.userId) return nil;
+        
+        self.storage = [self.sessionContext sp_stringForKey:kSPSessionStorage defaultValue:nil];
+        if (!self.storage) return nil;
+    }
+    return self;
+}
+
+- (void)setUserId:(NSString *)userId {
+    _userId = userId;
+    [self.sessionContext setObject:userId forKey:kSPSessionUserId];
+}
 
 @end

--- a/Snowplow/Internal/Session/SPSessionState.m
+++ b/Snowplow/Internal/Session/SPSessionState.m
@@ -18,7 +18,7 @@
 @property (nonatomic, readwrite) NSInteger sessionIndex;
 @property (nonatomic, nonnull, readwrite) NSString *storage;
 
-@property (nonatomic, nonnull, readwrite) NSMutableDictionary<NSString *, NSObject *> *sessionContext;
+@property (nonatomic, nonnull) NSMutableDictionary<NSString *, NSObject *> *sessionDictionary;
 
 @end
 
@@ -33,40 +33,38 @@
         self.userId = userId;
         self.storage = storage;
         
-        NSMutableDictionary *sessionDictionary = [NSMutableDictionary new];
-        if (previousSessionId) {
-            [sessionDictionary setObject:previousSessionId forKey:kSPSessionPreviousId];
-        }
-        [sessionDictionary setObject:currentSessionId forKey:kSPSessionId];
-        [sessionDictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
-        [sessionDictionary setObject:[NSNumber numberWithInteger:sessionIndex] forKey:kSPSessionIndex];
-        [sessionDictionary setObject:storage forKey:kSPSessionStorage];
-        [sessionDictionary setObject:userId forKey:kSPSessionUserId];
-        self.sessionContext = sessionDictionary;
+        NSMutableDictionary *dictionary = [NSMutableDictionary new];
+        [dictionary setObject:previousSessionId ?: [NSNull null] forKey:kSPSessionPreviousId];
+        [dictionary setObject:currentSessionId forKey:kSPSessionId];
+        [dictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
+        [dictionary setObject:[NSNumber numberWithInteger:sessionIndex] forKey:kSPSessionIndex];
+        [dictionary setObject:storage forKey:kSPSessionStorage];
+        [dictionary setObject:userId forKey:kSPSessionUserId];
+        self.sessionDictionary = dictionary;
     }
     return self;
 }
 
 - (instancetype)initWithStoredState:(NSDictionary<NSString *,NSObject *> *)storedState {
     if (self = [super init]) {
-        self.sessionContext = [storedState mutableCopy];
+        self.sessionDictionary = [storedState mutableCopy];
         
-        self.firstEventId = [self.sessionContext sp_stringForKey:kSPSessionFirstEventId defaultValue:nil];
+        self.firstEventId = [self.sessionDictionary sp_stringForKey:kSPSessionFirstEventId defaultValue:nil];
         if (!self.firstEventId) return nil;
         
-        self.sessionId = [self.sessionContext sp_stringForKey:kSPSessionId defaultValue:nil];
+        self.sessionId = [self.sessionDictionary sp_stringForKey:kSPSessionId defaultValue:nil];
         if (!self.sessionId) return nil;
         
-        self.previousSessionId = [self.sessionContext sp_stringForKey:kSPSessionPreviousId defaultValue:nil];
+        self.previousSessionId = [self.sessionDictionary sp_stringForKey:kSPSessionPreviousId defaultValue:nil];
         
-        NSNumber *sessionIndexNumber = [self.sessionContext sp_numberForKey:kSPSessionIndex defaultValue:nil];
+        NSNumber *sessionIndexNumber = [self.sessionDictionary sp_numberForKey:kSPSessionIndex defaultValue:nil];
         if (!sessionIndexNumber) return nil;
         self.sessionIndex = sessionIndexNumber.integerValue;
         
-        self.userId = [self.sessionContext sp_stringForKey:kSPSessionUserId defaultValue:nil];
+        self.userId = [self.sessionDictionary sp_stringForKey:kSPSessionUserId defaultValue:nil];
         if (!self.userId) return nil;
         
-        self.storage = [self.sessionContext sp_stringForKey:kSPSessionStorage defaultValue:nil];
+        self.storage = [self.sessionDictionary sp_stringForKey:kSPSessionStorage defaultValue:nil];
         if (!self.storage) return nil;
     }
     return self;
@@ -74,7 +72,11 @@
 
 - (void)setUserId:(NSString *)userId {
     _userId = userId;
-    [self.sessionContext setObject:userId forKey:kSPSessionUserId];
+    [self.sessionDictionary setObject:userId forKey:kSPSessionUserId];
+}
+
+- (NSDictionary<NSString *,NSObject *> *)sessionContext {
+    return [self.sessionDictionary mutableCopy];
 }
 
 @end

--- a/Snowplow/Internal/Session/SPSessionState.m
+++ b/Snowplow/Internal/Session/SPSessionState.m
@@ -2,8 +2,21 @@
 //  SPSessionState.m
 //  Snowplow
 //
-//  Created by Alex Benini on 01/12/21.
-//  Copyright © 2021 Snowplow Analytics. All rights reserved.
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  License: Apache License Version 2.0
 //
 
 #import "SPSessionState.h"

--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -331,8 +331,13 @@
     if (self.trackerConfigurationUpdate.isPaused) {
         [tracker pauseEventTracking];
     }
-    if (self.sessionConfigurationUpdate.isPaused) {
-        [tracker.session stopChecker];
+    if (tracker.session) {
+        if (self.sessionConfigurationUpdate.isPaused) {
+            [tracker.session stopChecker];
+        }
+        if (self.sessionConfigurationUpdate.onSessionStateUpdate) {
+            tracker.session.onSessionStateUpdate = self.sessionConfigurationUpdate.onSessionStateUpdate;
+        }
     }
     return tracker;
 }

--- a/Snowplow/Internal/Utils/SPDataPersistence.m
+++ b/Snowplow/Internal/Utils/SPDataPersistence.m
@@ -99,9 +99,13 @@ NSString *sessionKey = @"session";
             // Initialise
             result = [NSMutableDictionary new];
             // Migrate legacy session data
-            NSDictionary *sessionDict = [self sessionDictionaryFromLegacyTrackerV2_2]
-                ?: [self sessionDictionaryFromLegacyTrackerV1]
-                ?: [NSDictionary new];
+            NSMutableDictionary *sessionDict = [self sessionDictionaryFromLegacyTrackerV2_2].mutableCopy
+                ?: [self sessionDictionaryFromLegacyTrackerV1].mutableCopy
+                ?: [NSMutableDictionary new];
+            // Add missing fields
+            [sessionDict setObject:@"" forKey:kSPSessionFirstEventId];
+            [sessionDict setObject:@"LOCAL_STORAGE" forKey:kSPSessionStorage];
+            // Wrap up
             [result setObject:sessionDict forKey:sessionKey];
             [self storeDictionary:result fileURL:self.fileUrl];
         }

--- a/Snowplow/Snowplow-umbrella-header.h
+++ b/Snowplow/Snowplow-umbrella-header.h
@@ -71,3 +71,4 @@
 #import "SPSchemaRule.h"
 #import "SPTrackerStateSnapshot.h"
 #import "SPState.h"
+#import "SPSessionState.h"

--- a/Snowplow/include/SPSessionState.h
+++ b/Snowplow/include/SPSessionState.h
@@ -1,0 +1,1 @@
+../Internal/Session/SPSessionState.h

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -80,7 +80,8 @@ Pod::Spec.new do |s|
     'Snowplow/Internal/**/SPSchemaRuleset.h',
     'Snowplow/Internal/**/SPSchemaRule.h',
     'Snowplow/Internal/**/SPTrackerStateSnapshot.h',
-    'Snowplow/Internal/**/SPState.h'
+    'Snowplow/Internal/**/SPState.h',
+    'Snowplow/Internal/**/SPSessionState.h'
   ]
 
   s.osx.exclude_files = 'Snowplow/**/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.*'


### PR DESCRIPTION
The proposed session callback makes use of the SessionState which contains all the information normally available in the session context.
The current implementation is tailor-made on the specific problem of getting session information but in a further enhancement it could be generalised as callback that return information about any internal tracker state currently kept private (e.g: ScreenState, LifecycleState, etc.).

Little demo example here: https://github.com/snowplow-incubator/snowplow-objc-tracker-examples/pull/16

Proposed documentation:

--

## Session Context

Client session tracking is activated by default but it can be disabled through the TrackerConfiguration as explained above. When enabled the tracker appends a [client_session](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1) context to each event it sends and it maintains this session information as long as the application is installed on the device.

Sessions correspond to tracked user activity. A session expires when no tracking events have occurred for the amount of time defined in a timeout (by default 30 minutes). The session timeout check is executed for each event tracked. If the gap between two consecutive events is longer than the timeout the session is renewed. There are two timeouts since a session can timeout in the foreground (while the app is visible) or in the background (when the app has been suspended, but not closed).

### Session callback

(Available from v3.1)

The tracker allows the configuration of a callback to inform the app everytime a new session is created (in correspondence of a session timeout check). 
This can be configured in the `SessionConfiguration` and it provides the `SessionState` where can be accessed all the info already tracked in the `SessionContext`.

Below an example of where the session callback is used to print out the values of session every time a new session is generated by the tracker:

```
...
let sessionConfig = SessionConfiguration()
    .onSessionStateUpdate { session in
        print("SessionState: id: \(session.sessionId) - index: \(session.sessionIndex) - userID: \(session.userId) - firstEventID: \(session.firstEventId)")
    }
...
let tracker = Snowplow.createTracker(namespace: kNamespace, network: networkConfig, configurations: [sessionConfig])
```
