### PR TITLE
Check session for background event using foreground timeout (close #667)

### DIFF
--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -221,16 +221,16 @@
 - (void) updateInBackground {
     if (!_inBackground && [self.tracker getLifecycleEvents]) {
         _backgroundIndex += 1;
-        _inBackground = YES;
         [self sendBackgroundEvent];
+        _inBackground = YES;
     }
 }
 
 - (void) updateInForeground {
     if (_inBackground && [self.tracker getLifecycleEvents]) {
         _foregroundIndex += 1;
-        _inBackground = NO;
         [self sendForegroundEvent];
+        _inBackground = NO;
     }
 }
 


### PR DESCRIPTION
Not much to add to what is already described in the related issue (#667).

Suggested documentation:

---

## Session Context

Client session tracking is activated by default but it can be disabled through the TrackerConfiguration as explained above. When enabled the tracker appends a client_session context to each event it sends and it maintains this session information as long as the application is installed on the device.

Sessions correspond to tracked user activity. A session expires when no tracking events have occurred for the amount of time defined in a timeout (by default 30 minutes). The session timeout check is executed for each event tracked. If the gap between two consecutive events is longer than the timeout the session is renewed. There are two timeouts since a session can timeout in the foreground (while the app is visible) or in the background (when the app has been suspended, but not closed).

--added part--

The lifecycle events (`application_foreground` and `application_background` events) have a role in the session expiration. The lifecycle events can be enabled in the [TrackerConfiguration](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/mobile-trackers/mobile-trackers-v3-0/introduction/#TrackerConfiguration) enabling `lifecycleAutotracking` (Note: on Android it requires `androidx.lifecycle:lifecycle-extensions`). Once enabled they will be fired automatically when the app moves from foreground state to background state and vice versa.

When the app moves from foreground to background the `application_background` event is fired. If session tracking is enabled, the session context will be attached to the event checking the session expiration using the foreground timeout.
When the app moves from background to foreground the `application_foreground` event is fired. If session tracking is enabled, the session context will be attached to the event checking the session expiration using the background timeout.

For instance, with this configuration:

```
SessionConfiguration(
    TimeMeasure(360L, TimeUnit.SECONDS),
    TimeMeasure(15L, TimeUnit.SECONDS)
)
```

the session would expire if the app is backgrounded for more than 15 seconds, like in this example:

```
time: 0s - screen_view event - foreground timeout session check - session 1
time: 3s - application_background event - foreground timeout session check (3 < 360) - session 1
time: 30s - application_foreground event - background timeout session check (30 > 15) - session 2
```

In the above example the `application_foreground` event triggers a new session because the time spent on background (without tracked events) is bigger than the background timeout for the session.
