### PR TITLE
Add pause and resume to EmitterController (close #672)

### DIFF
--- a/Snowplow iOSTests/Configurations/TestEmitterConfiguration.m
+++ b/Snowplow iOSTests/Configurations/TestEmitterConfiguration.m
@@ -1,0 +1,77 @@
+//
+//  TestEmitterConfiguration.m
+//  Snowplow-iOSTests
+//
+//  Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini, Matus Tomlein
+//  Copyright: Copyright (c) 2013-2022 Snowplow Analytics Ltd
+//  License: Apache License Version 2.0
+//
+
+#import <XCTest/XCTest.h>
+#import "SPSnowplow.h"
+#import "SPNetworkConfiguration.h"
+#import "SPTrackerConfiguration.h"
+#import "SPSession.h"
+#import "SPMockEventStore.h"
+#import "SPDataPersistence.h"
+#import "SPMockNetworkConnection.h"
+#import "SPLogger.h"
+
+
+@interface TestEmitterConfiguration : XCTestCase
+
+@end
+
+@implementation TestEmitterConfiguration
+
+- (void)setUp {
+    [super setUp];
+    [SPLogger setLogLevel:SPLogLevelVerbose];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testPauseEmitter {
+    SPMockNetworkConnection *networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost successfulConnection:YES];
+    SPEmitterConfiguration *emitterConfig = [[SPEmitterConfiguration alloc] init];
+    emitterConfig.eventStore = [SPMockEventStore new];
+    emitterConfig.bufferOption = SPBufferOptionSingle;
+    SPNetworkConfiguration *networkConfig = [[SPNetworkConfiguration alloc] initWithEndpoint:@"" method:SPHttpMethodPost];
+    networkConfig.networkConnection = networkConnection;
+    
+    SPTrackerConfiguration *trackerConfig = [[SPTrackerConfiguration new] appId:@"appid"];
+    trackerConfig.installAutotracking = false;
+    trackerConfig.screenViewAutotracking = false;
+    trackerConfig.lifecycleAutotracking = false;
+    id<SPTrackerController> tracker = [SPSnowplow createTrackerWithNamespace:@"namespace" network:networkConfig configurations:@[trackerConfig, emitterConfig]];
+    XCTAssertNotNil(tracker);
+    
+    [tracker.emitter pause];
+    [tracker track:[[SPStructured alloc] initWithCategory:@"cat" action:@"act"]];
+    [NSThread sleepForTimeInterval:3];
+    XCTAssertEqual(1, [[tracker emitter] dbCount]);
+    XCTAssertEqual(0, networkConnection.previousResults.count);
+
+    [tracker.emitter resume];
+    [NSThread sleepForTimeInterval:3];
+    XCTAssertEqual(1, networkConnection.previousResults.count);
+    XCTAssertEqual(0, [[tracker emitter] dbCount]);
+}
+
+
+@end

--- a/Snowplow iOSTests/Legacy Tests/LegacyTestEmitter.m
+++ b/Snowplow iOSTests/Legacy Tests/LegacyTestEmitter.m
@@ -25,6 +25,7 @@
 #import "SPEmitter.h"
 #import "SPLogger.h"
 #import "SPMockEventStore.h"
+#import "SPMockNetworkConnection.h"
 
 
 @interface SPBrokenNetworkConnection : NSObject <SPNetworkConnection>
@@ -45,52 +46,6 @@
 - (SPHttpMethod)httpMethod {
     [NSException raise:@"BrokenNetworkConnection" format:@"Fake exception on network connection."];
     return SPHttpMethodGet;
-}
-
-@end
-
-
-@interface SPMockNetworkConnection : NSObject <SPNetworkConnection>
-
-@property (nonatomic) BOOL successfulConnection;
-@property (nonatomic) SPHttpMethod httpMethod;
-@property (nonatomic) NSMutableArray<NSMutableArray<SPRequestResult *> *> *previousResults;
-
-@end
-
-@implementation SPMockNetworkConnection
-
-- initWithRequestOption:(SPHttpMethod)httpMethod successfulConnection:(BOOL)successfulConnection {
-    if (self = [super init]) {
-        self.httpMethod = httpMethod;
-        self.successfulConnection = successfulConnection;
-        self.previousResults = [NSMutableArray new];
-    }
-    return self;
-}
-
-- (nonnull NSArray<SPRequestResult *> *)sendRequests:(nonnull NSArray<SPRequest *> *)requests {
-    NSMutableArray<SPRequestResult *> *requestResults = [NSMutableArray new];
-    for (SPRequest *request in requests) {
-        BOOL isSuccessful = request.oversize || self.successfulConnection;
-        SPRequestResult *result = [[SPRequestResult alloc] initWithSuccess:isSuccessful storeIds:request.emitterEventIds];
-        SPLogVerbose(@"Sent %@ with success %@", request.emitterEventIds, isSuccessful ? @"YES" : @"NO");
-        [requestResults addObject:result];
-    }
-    [self.previousResults addObject:requestResults];
-    return requestResults;
-}
-
-- (SPHttpMethod)httpMethod {
-    return _httpMethod;
-}
-
-- (nonnull NSURL *)url {
-    return [NSURL URLWithString:@"http://fake-url.com"];
-}
-
-- (NSUInteger)sendingCount {
-    return self.previousResults.count;
 }
 
 @end
@@ -179,7 +134,7 @@ NSString *const TEST_SERVER_EMITTER = @"www.notarealurl.com";
     
     // Allow timer to be set
     [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
-    [emitter resume];
+    [emitter resumeTimer];
 }
 
 // MARK: - Emitting tests

--- a/Snowplow iOSTests/Utils/SPMockNetworkConnection.h
+++ b/Snowplow iOSTests/Utils/SPMockNetworkConnection.h
@@ -1,5 +1,5 @@
 //
-//  SPEmitterEventProcessing.h
+//  SPMockNetworkConnection.h
 //  Snowplow
 //
 //  Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
@@ -15,23 +15,26 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Authors: Alex Benini
-//  Copyright: Copyright (c) 2013-2021 Snowplow Analytics Ltd
+//  Authors: Alex Benini, Matus Tomlein
+//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
 //  License: Apache License Version 2.0
 //
 
 #import <Foundation/Foundation.h>
+#import "SPEmitter.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_SWIFT_NAME(EmitterEventProcessing)
-@protocol SPEmitterEventProcessing
+@interface SPMockNetworkConnection : NSObject <SPNetworkConnection>
 
-- (void)addPayloadToBuffer:(SPPayload *)eventPayload;
-- (void)pauseTimer;
-- (void)resumeTimer;
-- (void)flush;
+- (instancetype)initWithRequestOption:(SPHttpMethod)httpMethod successfulConnection:(BOOL)successfulConnection;
+
+@property (nonatomic) BOOL successfulConnection;
+@property (nonatomic) SPHttpMethod httpMethod;
+@property (nonatomic) NSMutableArray<NSMutableArray<SPRequestResult *> *> *previousResults;
+@property (nonatomic) NSUInteger sendingCount;
 
 @end
+
 
 NS_ASSUME_NONNULL_END

--- a/Snowplow iOSTests/Utils/SPMockNetworkConnection.m
+++ b/Snowplow iOSTests/Utils/SPMockNetworkConnection.m
@@ -1,0 +1,61 @@
+//
+//  SPMockNetworkConnection.m
+//  Snowplow
+//
+//  Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini, Matus Tomlein
+//  Copyright: Copyright (c) 2022 Snowplow Analytics Ltd
+//  License: Apache License Version 2.0
+//
+
+#import "SPMockNetworkConnection.h"
+#import "SPLogger.h"
+
+@implementation SPMockNetworkConnection
+
+- initWithRequestOption:(SPHttpMethod)httpMethod successfulConnection:(BOOL)successfulConnection {
+    if (self = [super init]) {
+        self.httpMethod = httpMethod;
+        self.successfulConnection = successfulConnection;
+        self.previousResults = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (nonnull NSArray<SPRequestResult *> *)sendRequests:(nonnull NSArray<SPRequest *> *)requests {
+    NSMutableArray<SPRequestResult *> *requestResults = [NSMutableArray new];
+    for (SPRequest *request in requests) {
+        BOOL isSuccessful = request.oversize || self.successfulConnection;
+        SPRequestResult *result = [[SPRequestResult alloc] initWithSuccess:isSuccessful storeIds:request.emitterEventIds];
+        SPLogVerbose(@"Sent %@ with success %@", request.emitterEventIds, isSuccessful ? @"YES" : @"NO");
+        [requestResults addObject:result];
+    }
+    [self.previousResults addObject:requestResults];
+    return requestResults;
+}
+
+- (SPHttpMethod)httpMethod {
+    return _httpMethod;
+}
+
+- (nonnull NSURL *)url {
+    return [NSURL URLWithString:@"http://fake-url.com"];
+}
+
+- (NSUInteger)sendingCount {
+    return self.previousResults.count;
+}
+
+@end

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		23DFEC802362FAD500BD19C4 /* FMDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 752DAC0C21CC3EEA0065F874 /* FMDB.framework */; };
 		23DFEC822362FAED00BD19C4 /* SnowplowIgluClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75CAC3B921F28BD600271FB3 /* SnowplowIgluClient.framework */; };
 		23DFEC832362FAF800BD19C4 /* VVJSONSchemaValidation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75CAC3C021F2930100271FB3 /* VVJSONSchemaValidation.framework */; };
+		6B4B77D227C64F6000F4E878 /* TestServiceProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B4B77D127C64F6000F4E878 /* TestServiceProvider.m */; };
 		6B871F6127C3913300BCF742 /* TestEmitterConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */; };
 		6B871F6427C3928900BCF742 /* SPMockNetworkConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */; };
 		6B871F6627C3976B00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
@@ -928,6 +929,7 @@
 		0485CA141BAC658500214BC5 /* SPSelfDescribingJson.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPSelfDescribingJson.h; sourceTree = "<group>"; };
 		0485CA151BAC65A300214BC5 /* SPSelfDescribingJson.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPSelfDescribingJson.m; sourceTree = "<group>"; };
 		049B2BDA1B7A203200BD82FC /* SPRequestCallback.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPRequestCallback.h; sourceTree = "<group>"; };
+		6B4B77D127C64F6000F4E878 /* TestServiceProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestServiceProvider.m; sourceTree = SOURCE_ROOT; };
 		6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestEmitterConfiguration.m; sourceTree = "<group>"; };
 		6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockNetworkConnection.h; sourceTree = "<group>"; };
 		6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMockNetworkConnection.m; sourceTree = "<group>"; };
@@ -1271,6 +1273,7 @@
 				EDAB664826D69A160067755F /* TestStateManager.m */,
 				6BF15D0B2702ECD70048F376 /* TestPlatformContext.m */,
 				6BF15D1227035A480048F376 /* TestSubject.m */,
+				6B4B77D127C64F6000F4E878 /* TestServiceProvider.m */,
 			);
 			path = "Snowplow iOSTests";
 			sourceTree = "<group>";
@@ -2627,6 +2630,7 @@
 				75CAC41221F2955100271FB3 /* TestRequest.m in Sources */,
 				75CAC40621F2955100271FB3 /* TestSQLiteEventStore.m in Sources */,
 				ED914EB72432081F0068DA0A /* TestSchemaRuleset.m in Sources */,
+				6B4B77D227C64F6000F4E878 /* TestServiceProvider.m in Sources */,
 				75CAC41121F2955100271FB3 /* LegacyTestTracker.m in Sources */,
 				75CAC40D21F2955100271FB3 /* LegacyTestEmitter.m in Sources */,
 				75CAC40721F2955100271FB3 /* TestPayload.m in Sources */,

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		23DFEC802362FAD500BD19C4 /* FMDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 752DAC0C21CC3EEA0065F874 /* FMDB.framework */; };
 		23DFEC822362FAED00BD19C4 /* SnowplowIgluClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75CAC3B921F28BD600271FB3 /* SnowplowIgluClient.framework */; };
 		23DFEC832362FAF800BD19C4 /* VVJSONSchemaValidation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75CAC3C021F2930100271FB3 /* VVJSONSchemaValidation.framework */; };
+		6B871F6127C3913300BCF742 /* TestEmitterConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */; };
+		6B871F6427C3928900BCF742 /* SPMockNetworkConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */; };
+		6B871F6627C3976B00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
+		6B871F6727C3976C00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
+		6B871F6827C3976C00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
+		6B871F6927C3976D00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
 		6BABC50E270B40450043BB5C /* TestSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BF15D1227035A480048F376 /* TestSubject.m */; };
 		6BBDCD4227019AF4001B547F /* SPPlatformContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BBDCD4027019AF4001B547F /* SPPlatformContext.h */; };
 		6BBDCD4327019AF4001B547F /* SPPlatformContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BBDCD4027019AF4001B547F /* SPPlatformContext.h */; };
@@ -922,6 +928,9 @@
 		0485CA141BAC658500214BC5 /* SPSelfDescribingJson.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPSelfDescribingJson.h; sourceTree = "<group>"; };
 		0485CA151BAC65A300214BC5 /* SPSelfDescribingJson.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPSelfDescribingJson.m; sourceTree = "<group>"; };
 		049B2BDA1B7A203200BD82FC /* SPRequestCallback.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPRequestCallback.h; sourceTree = "<group>"; };
+		6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestEmitterConfiguration.m; sourceTree = "<group>"; };
+		6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockNetworkConnection.h; sourceTree = "<group>"; };
+		6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMockNetworkConnection.m; sourceTree = "<group>"; };
 		6BBDCD4027019AF4001B547F /* SPPlatformContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPPlatformContext.h; path = Snowplow/Internal/Subject/SPPlatformContext.h; sourceTree = SOURCE_ROOT; };
 		6BBDCD4127019AF4001B547F /* SPPlatformContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPPlatformContext.m; path = Snowplow/Internal/Subject/SPPlatformContext.m; sourceTree = SOURCE_ROOT; };
 		6BF08DA4270DEED6009C7E2B /* SPDeviceInfoMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDeviceInfoMonitor.h; sourceTree = "<group>"; };
@@ -1428,6 +1437,7 @@
 				ED87A43C2577E440000C54EB /* TestTrackerController.m */,
 				EDE54F4725EFA38D0073947D /* TestMultipleInstances.m */,
 				ED7F080526190B5F005D377E /* TestRemoteConfiguration.m */,
+				6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */,
 			);
 			path = Configurations;
 			sourceTree = "<group>";
@@ -1448,6 +1458,8 @@
 				EDA06FB52664CD2F007FA773 /* SPMockEventStore.m */,
 				6BF08DAE270DF2E8009C7E2B /* SPMockDeviceInfoMonitor.h */,
 				6BF08DAF270DF2E8009C7E2B /* SPMockDeviceInfoMonitor.m */,
+				6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */,
+				6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1841,6 +1853,7 @@
 				CE4F9C9E244B066500968CFC /* SPSchemaRule.h in Headers */,
 				752DAC3921CC43C70065F874 /* SPSQLiteEventStore.h in Headers */,
 				CE4F9D1A244B066500968CFC /* SPEcommerce.h in Headers */,
+				6B871F6627C3976B00BCF742 /* SPMockNetworkConnection.h in Headers */,
 				EDDD7043264F2A8800259404 /* SPEmitterConfigurationUpdate.h in Headers */,
 				ED98972626287F7A00145157 /* SPConfigurationCache.h in Headers */,
 				ED9081B52703747C00EE9421 /* SPMessageNotification.h in Headers */,
@@ -1890,6 +1903,7 @@
 				ED9081B62703747C00EE9421 /* SPMessageNotification.h in Headers */,
 				ED8866BF25711EC000DB53BB /* SPLoggerDelegate.h in Headers */,
 				ED88B6DC2583DFC80048FAD1 /* SPServiceProvider.h in Headers */,
+				6B871F6727C3976C00BCF742 /* SPMockNetworkConnection.h in Headers */,
 				ED277BD32625F220002C7B6D /* SPConfigurationBundle.h in Headers */,
 				EDD8542B24EFEFE600661F6B /* SPNetworkConnection.h in Headers */,
 				EDAB666126D6ACCB0067755F /* SPDeepLinkState.h in Headers */,
@@ -2001,6 +2015,7 @@
 				ED34672C26415C1D0018BA61 /* SPJSONSerialization.h in Headers */,
 				ED914EBC24325AB40068DA0A /* SPGdprContext.h in Headers */,
 				ED38D92D26EBCEBE002AEC8E /* SPLifecycleState.h in Headers */,
+				6B871F6827C3976C00BCF742 /* SPMockNetworkConnection.h in Headers */,
 				ED7CE16726DE39530035C323 /* SPScreenStateMachine.h in Headers */,
 				ED8866C025711EC000DB53BB /* SPLoggerDelegate.h in Headers */,
 				ED88B6DD2583DFC90048FAD1 /* SPServiceProvider.h in Headers */,
@@ -2189,6 +2204,7 @@
 				CE4F9CA1244B066500968CFC /* SPSchemaRule.h in Headers */,
 				75F9C5EF21FA35BC00A5B8FC /* SPRequestResult.h in Headers */,
 				CE4F9D1D244B066500968CFC /* SPEcommerce.h in Headers */,
+				6B871F6927C3976D00BCF742 /* SPMockNetworkConnection.h in Headers */,
 				EDDD7046264F2A8800259404 /* SPEmitterConfigurationUpdate.h in Headers */,
 				ED98972926287F7A00145157 /* SPConfigurationCache.h in Headers */,
 				ED9081B82703747C00EE9421 /* SPMessageNotification.h in Headers */,
@@ -2616,11 +2632,13 @@
 				75CAC40721F2955100271FB3 /* TestPayload.m in Sources */,
 				75CAC40A21F2955100271FB3 /* TestGeneratedJsons.m in Sources */,
 				7534D20822569F3400904EE5 /* TestScreenState.m in Sources */,
+				6B871F6127C3913300BCF742 /* TestEmitterConfiguration.m in Sources */,
 				ED914EB52431FEE70068DA0A /* TestGlobalContexts.m in Sources */,
 				EDCBD0D824F5084900D39DD2 /* TestNetworkConnection.m in Sources */,
 				ED88B6B3258253F20048FAD1 /* TestEvents.m in Sources */,
 				EDA06FB62664CD2F007FA773 /* SPMockEventStore.m in Sources */,
 				75CAC40921F2955100271FB3 /* TestSelfDescribingJson.m in Sources */,
+				6B871F6427C3928900BCF742 /* SPMockNetworkConnection.m in Sources */,
 				ED87A43D2577E441000C54EB /* TestTrackerController.m in Sources */,
 				EDEE836324C0C318000B8530 /* TestLogger.m in Sources */,
 				EDB6940326B83BF300B76A79 /* TestMemoryEventStore.m in Sources */,

--- a/Snowplow/Internal/Emitter/SPEmitter.h
+++ b/Snowplow/Internal/Emitter/SPEmitter.h
@@ -171,14 +171,24 @@ NS_SWIFT_NAME(Emitter)
 - (void)flush;
 
 /*!
- @brief Allowes sending of events to collector.
+ @brief Starts timer for periodically sending events to collector.
  */
-- (void)resume;
+- (void)resumeTimer;
 
 /*!
- @brief Suspends sending of events to collector.
+ @brief Suspends timer for periodically sending events to collector.
  */
-- (void)pause;
+- (void)pauseTimer;
+
+/*!
+ @brief Allows sending events to collector.
+ */
+- (void)resumeEmit;
+
+/*!
+ @brief Suspends sending events to collector.
+ */
+- (void)pauseEmit;
 
 /*!
  @brief Returns the number of events in the DB.

--- a/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.h
+++ b/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable) SPEmitterConfiguration *sourceConfig;
 
+@property (nonatomic) BOOL isPaused;
+
 SP_DIRTYFLAG(bufferOption)
 SP_DIRTYFLAG(byteLimitGet)
 SP_DIRTYFLAG(byteLimitPost)

--- a/Snowplow/Internal/Emitter/SPEmitterController.h
+++ b/Snowplow/Internal/Emitter/SPEmitterController.h
@@ -40,6 +40,19 @@ NS_SWIFT_NAME(EmitterController)
 
 - (void)flush;
 
+/**
+ * Pause emitting events.
+ * Emitting events will be suspended until resumed again.
+ * Suitable for low bandwidth situations.
+ */
+- (void)pause;
+
+/**
+ * Resume emitting events if previously paused.
+ * The emitter will resume emitting events again.
+ */
+- (void)resume;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Snowplow/Internal/Emitter/SPEmitterControllerImpl.m
+++ b/Snowplow/Internal/Emitter/SPEmitterControllerImpl.m
@@ -111,6 +111,16 @@
     return [self.emitter getSendingStatus];
 }
 
+- (void)pause {
+    self.dirtyConfig.isPaused = YES;
+    [self.emitter pauseEmit];
+}
+
+- (void)resume {
+    self.dirtyConfig.isPaused = NO;
+    [self.emitter resumeEmit];
+}
+
 // MARK: - Private methods
 
 - (SPEmitter *)emitter {

--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -339,6 +339,9 @@
             tracker.session.onSessionStateUpdate = self.sessionConfigurationUpdate.onSessionStateUpdate;
         }
     }
+    if (self.emitterConfigurationUpdate.isPaused) {
+        [emitter pauseEmit];
+    }
     return tracker;
 }
 

--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -269,7 +269,7 @@
 - (SPEmitter *)makeEmitter {
     SPNetworkConfigurationUpdate *networkConfig = self.networkConfigurationUpdate;
     SPEmitterConfigurationUpdate *emitterConfig = self.emitterConfigurationUpdate;
-    return [SPEmitter build:^(id<SPEmitterBuilder> builder) {
+    SPEmitter *emitter = [SPEmitter build:^(id<SPEmitterBuilder> builder) {
         if (networkConfig.networkConnection) {
             [builder setNetworkConnection:networkConfig.networkConnection];
         } else {
@@ -289,6 +289,10 @@
             [builder setCallback:emitterConfig.requestCallback];
         }
     }];
+    if (emitterConfig && emitterConfig.isPaused) {
+        [emitter pauseEmit];
+    }
+    return emitter;
 }
 
 - (SPTracker *)makeTracker {
@@ -338,9 +342,6 @@
         if (self.sessionConfigurationUpdate.onSessionStateUpdate) {
             tracker.session.onSessionStateUpdate = self.sessionConfigurationUpdate.onSessionStateUpdate;
         }
-    }
-    if (self.emitterConfigurationUpdate.isPaused) {
-        [emitter pauseEmit];
     }
     return tracker;
 }

--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -155,7 +155,7 @@
 }
 
 - (void)stopServices {
-    [_emitter pause];
+    [_emitter pauseTimer];
 }
 
 - (void)resetServices {

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -451,13 +451,13 @@ void uncaughtExceptionHandler(NSException *exception) {
 
 - (void) pauseEventTracking {
     _dataCollection = NO;
-    [_emitter pause];
+    [_emitter pauseTimer];
     [_session stopChecker];
 }
 
 - (void) resumeEventTracking {
     _dataCollection = YES;
-    [_emitter resume];
+    [_emitter resumeTimer];
     [_session startChecker];
 }
 

--- a/TestServiceProvider.m
+++ b/TestServiceProvider.m
@@ -1,0 +1,87 @@
+//
+//  TestServiceProvider.m
+//  Snowplow-iOSTests
+//
+//  Copyright (c) 2013-2021 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini, Matus Tomlein
+//  Copyright: Copyright (c) 2013-2022 Snowplow Analytics Ltd
+//  License: Apache License Version 2.0
+//
+
+#import <XCTest/XCTest.h>
+#import "SPSnowplow.h"
+#import "SPNetworkConfiguration.h"
+#import "SPTrackerConfiguration.h"
+#import "SPSession.h"
+#import "SPMockEventStore.h"
+#import "SPDataPersistence.h"
+#import "SPMockNetworkConnection.h"
+#import "SPLogger.h"
+#import "SPServiceProvider.h"
+#import "SPEmitterControllerImpl.h"
+#import "SPEmitterConfigurationUpdate.h"
+#import "SPTrackerController.h"
+
+
+@interface TestServiceProvider : XCTestCase
+
+@end
+
+@implementation TestServiceProvider
+
+- (void)setUp {
+    [super setUp];
+    [SPLogger setLogLevel:SPLogLevelVerbose];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testUpdatingConfigurationRetainsPausedEmitter {
+    SPMockNetworkConnection *networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost successfulConnection:YES];
+    SPEmitterConfiguration *emitterConfig = [[SPEmitterConfiguration alloc] init];
+    emitterConfig.eventStore = [SPMockEventStore new];
+    emitterConfig.bufferOption = SPBufferOptionSingle;
+    SPNetworkConfiguration *networkConfig = [[SPNetworkConfiguration alloc] initWithEndpoint:@"" method:SPHttpMethodPost];
+    networkConfig.networkConnection = networkConnection;
+    SPTrackerConfiguration *trackerConfig = [[SPTrackerConfiguration new] appId:@"appid"];
+    trackerConfig.installAutotracking = false;
+    trackerConfig.screenViewAutotracking = false;
+    trackerConfig.lifecycleAutotracking = false;
+    SPServiceProvider *serviceProvider = [[SPServiceProvider alloc] initWithNamespace:@"ns" network:networkConfig configurations:@[emitterConfig, trackerConfig]];
+    XCTAssertNotNil(serviceProvider);
+
+    // pause emitter
+    [[serviceProvider emitterController] pause];
+
+    // refresh configuration
+    [serviceProvider resetWithConfigurations:@[[[SPEmitterConfigurationUpdate alloc] init]]];
+
+    // track event and check that emitter is paused
+    [[serviceProvider trackerController] track:[[SPStructured alloc] initWithCategory:@"cat" action:@"act"]];
+    [NSThread sleepForTimeInterval:3];
+    XCTAssertEqual(1, [[serviceProvider emitter] getDbCount]);
+    XCTAssertEqual(0, [networkConnection sendingCount]);
+
+    // resume emitting
+    [[serviceProvider emitterController] resume];
+    [NSThread sleepForTimeInterval:3];
+    XCTAssertEqual(1, [networkConnection sendingCount]);
+    XCTAssertEqual(0, [[serviceProvider emitter] getDbCount]);
+}
+
+
+@end


### PR DESCRIPTION
* Renames `pause` and `resume` functions in `Emitter` to `pauseTimer` and `resumeTimer`
* Add a `pause` and `resume` function to `EmitterController` that calls `pauseEmit` and `resumeEmit` on `Emitter`
* Add a test for the pause functionality into a new `TestEmitterConfiguration` test case