### PR TITLE
Fix object cannot be nil (key: userId) when initialising Snowplow tracker (close #675)

### DIFF
--- a/Snowplow/Internal/Session/SPSessionState.m
+++ b/Snowplow/Internal/Session/SPSessionState.m
@@ -37,6 +37,18 @@
 
 @implementation SPSessionState
 
++ (NSMutableDictionary<NSString *, NSObject *> *)buildSessionDictionaryWithFirstEventId:(NSString *)firstEventId currentSessionId:(NSString *)currentSessionId previousSessionId:(NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary new];
+    [dictionary setObject:previousSessionId ?: [NSNull null] forKey:kSPSessionPreviousId];
+    [dictionary setObject:currentSessionId forKey:kSPSessionId];
+    [dictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
+    [dictionary setObject:[NSNumber numberWithInteger:sessionIndex] forKey:kSPSessionIndex];
+    [dictionary setObject:storage forKey:kSPSessionStorage];
+    [dictionary setObject:userId forKey:kSPSessionUserId];
+    return dictionary;
+}
+
 - (instancetype)initWithFirstEventId:(NSString *)firstEventId currentSessionId:(NSString *)currentSessionId previousSessionId:(NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage {
     if (self = [super init]) {
         self.firstEventId = firstEventId;
@@ -46,46 +58,46 @@
         self.userId = userId;
         self.storage = storage;
         
-        NSMutableDictionary *dictionary = [NSMutableDictionary new];
-        [dictionary setObject:previousSessionId ?: [NSNull null] forKey:kSPSessionPreviousId];
-        [dictionary setObject:currentSessionId forKey:kSPSessionId];
-        [dictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
-        [dictionary setObject:[NSNumber numberWithInteger:sessionIndex] forKey:kSPSessionIndex];
-        [dictionary setObject:storage forKey:kSPSessionStorage];
-        [dictionary setObject:userId forKey:kSPSessionUserId];
-        self.sessionDictionary = dictionary;
+        self.sessionDictionary = [SPSessionState buildSessionDictionaryWithFirstEventId:firstEventId
+                                                                       currentSessionId:currentSessionId
+                                                                      previousSessionId:previousSessionId
+                                                                           sessionIndex:sessionIndex
+                                                                                 userId:userId
+                                                                                storage:storage];
     }
     return self;
 }
 
 - (instancetype)initWithStoredState:(NSDictionary<NSString *,NSObject *> *)storedState {
     if (self = [super init]) {
-        self.sessionDictionary = [storedState mutableCopy];
-        
-        self.firstEventId = [self.sessionDictionary sp_stringForKey:kSPSessionFirstEventId defaultValue:nil];
-        if (!self.firstEventId) return nil;
-        
-        self.sessionId = [self.sessionDictionary sp_stringForKey:kSPSessionId defaultValue:nil];
+        self.sessionId = [storedState sp_stringForKey:kSPSessionId defaultValue:nil];
         if (!self.sessionId) return nil;
         
-        self.previousSessionId = [self.sessionDictionary sp_stringForKey:kSPSessionPreviousId defaultValue:nil];
-        
-        NSNumber *sessionIndexNumber = [self.sessionDictionary sp_numberForKey:kSPSessionIndex defaultValue:nil];
+        NSNumber *sessionIndexNumber = [storedState sp_numberForKey:kSPSessionIndex defaultValue:nil];
         if (!sessionIndexNumber) return nil;
         self.sessionIndex = sessionIndexNumber.integerValue;
         
-        self.userId = [self.sessionDictionary sp_stringForKey:kSPSessionUserId defaultValue:nil];
+        self.userId = [storedState sp_stringForKey:kSPSessionUserId defaultValue:nil];
         if (!self.userId) return nil;
         
-        self.storage = [self.sessionDictionary sp_stringForKey:kSPSessionStorage defaultValue:nil];
-        if (!self.storage) return nil;
+        self.previousSessionId = [storedState sp_stringForKey:kSPSessionPreviousId defaultValue:nil];
+
+        // The FirstEventId should be stored in legacy persisted sessions even
+        // if it wasn't used. Anyway we provide a default value in order to be
+        // defensive and exclude any possible issue with a missing value.
+        self.firstEventId = [storedState sp_stringForKey:kSPSessionFirstEventId
+                                                       defaultValue:@"00000000-0000-0000-0000-000000000000"];
+                
+        self.storage = [storedState sp_stringForKey:kSPSessionStorage defaultValue:@"LOCAL_STORAGE"];
+        
+        self.sessionDictionary = [SPSessionState buildSessionDictionaryWithFirstEventId:self.firstEventId
+                                                                       currentSessionId:self.sessionId
+                                                                      previousSessionId:self.previousSessionId
+                                                                           sessionIndex:self.sessionIndex
+                                                                                 userId:self.userId
+                                                                                storage:self.storage];
     }
     return self;
-}
-
-- (void)setUserId:(NSString *)userId {
-    _userId = userId;
-    [self.sessionDictionary setObject:userId forKey:kSPSessionUserId];
 }
 
 - (NSDictionary<NSString *,NSObject *> *)sessionContext {


### PR DESCRIPTION
The bug is due to a wrong migration of the userId.
The userId wasn't were expected causing a nil value that the SPSessionState wasn't able to manage because it expected a non-nil value.

The new implementation test the migration from the previous stored data and makes the SPSessionState creation more defensive handling better possible missing values.

This patch release is urgent and should be released ASAP.
We should also re-check the Android tracker, in case we spot anything like this.
