### PR TITLE
Add eventIndex and firstEventTimestamp properties to client sessions (close #682)

### DIFF
--- a/Snowplow iOSTests/TestGeneratedJsons.m
+++ b/Snowplow iOSTests/TestGeneratedJsons.m
@@ -76,7 +76,7 @@ const NSString* IGLU_PATH = @"http://raw.githubusercontent.com/snowplow/iglu-cen
 
 - (void)testClientSessionContextJson {
     SPSession * session = [[SPSession alloc] init];
-    NSDictionary * data = [session getSessionDictWithEventId:@"first-event-id"];
+    NSDictionary * data = [session getSessionDictWithEventId:@"first-event-id" eventTimestamp:1654496481346];
     NSDictionary * json = [[[SPSelfDescribingJson alloc] initWithSchema:kSPSessionContextSchema andData:data] getAsDictionary];
     XCTAssertTrue([validator validateJson:json]);
 }

--- a/Snowplow iOSTests/TestSession.m
+++ b/Snowplow iOSTests/TestSession.m
@@ -55,7 +55,7 @@
     SPSession * session = [[SPSession alloc] init];
     XCTAssertNil([session getTracker]);
     XCTAssertTrue(![session getInBackground]);
-    XCTAssertNotNil([session getSessionDictWithEventId:@"eventid-1"]);
+    XCTAssertNotNil([session getSessionDictWithEventId:@"eventid-1" eventTimestamp:1654496481346]);
     XCTAssertTrue(session.state.sessionIndex >= 1);
     XCTAssertEqual([session getForegroundTimeout], 600000);
     XCTAssertEqual([session getBackgroundTimeout], 300000);
@@ -86,48 +86,53 @@
 - (void)testFirstSession {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
     NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.346Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
 }
 
 - (void)testForegroundEventsOnSameSession {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
     NSInteger sessionIndex = session.state.sessionIndex;
     NSString *sessionId = [sessionContext objectForKey:kSPSessionId];
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.346Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     
     [NSThread sleepForTimeInterval:1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_2"];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.346Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertEqualObjects(sessionId, [sessionContext objectForKey:kSPSessionId]);
     
     [NSThread sleepForTimeInterval:1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_3"];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.346Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertEqualObjects(sessionId, [sessionContext objectForKey:kSPSessionId]);
 
     [NSThread sleepForTimeInterval:3.1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_4"];
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(2, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_4", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.349Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertNotEqualObjects(sessionId, [sessionContext objectForKey:kSPSessionId]);
 }
 
@@ -147,11 +152,12 @@
     
     [session updateInBackground];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
     NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.346Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertFalse([session getInBackground]);
     XCTAssertEqual(0, [session getBackgroundIndex]);
 }
@@ -175,7 +181,7 @@
 
     NSString *sessionId = session.state.sessionId;
 
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
     NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -185,7 +191,7 @@
     
     [NSThread sleepForTimeInterval:1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2"];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -195,7 +201,7 @@
     
     [NSThread sleepForTimeInterval:1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_3"];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -205,11 +211,12 @@
     
     [NSThread sleepForTimeInterval:2.1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_4"];
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(2, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_4", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.349Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertNotEqualObjects(sessionId, [sessionContext objectForKey:kSPSessionId]);
     XCTAssertTrue([session getInBackground]);
     XCTAssertEqual(1, [session getBackgroundIndex]);
@@ -229,8 +236,9 @@
     }];
     SPSession *session = tracker.session;
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481351];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.351Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertFalse([session getInBackground]);
     XCTAssertEqual(0, [session getBackgroundIndex]);
     XCTAssertEqual(0, [session getForegroundIndex]);
@@ -239,9 +247,10 @@
     [session updateInBackground];
     [NSThread sleepForTimeInterval:1.1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2"];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481352];
     XCTAssertEqualObjects(oldSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_2", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.352Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertTrue([session getInBackground]);
     XCTAssertEqual(1, [session getBackgroundIndex]);
     XCTAssertEqual(0, [session getForegroundIndex]);
@@ -250,9 +259,10 @@
     [session updateInForeground];
     [NSThread sleepForTimeInterval:1.1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_3"];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481353];
     XCTAssertEqualObjects(oldSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_3", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.353Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertFalse([session getInBackground]);
     XCTAssertEqual(1, [session getBackgroundIndex]);
     XCTAssertEqual(1, [session getForegroundIndex]);
@@ -261,9 +271,10 @@
     [session updateInBackground];
     [NSThread sleepForTimeInterval:1.1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_4"];
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481354];
     XCTAssertEqualObjects(oldSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_4", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.354Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertTrue([session getInBackground]);
     XCTAssertEqual(2, [session getBackgroundIndex]);
     XCTAssertEqual(1, [session getForegroundIndex]);
@@ -272,25 +283,28 @@
 - (void)testTimeoutSessionWhenPauseAndResume {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:1 andBackgroundTimeout:1 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481355];
     NSString *prevSessionId = [sessionContext objectForKey:kSPSessionId];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.355Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     
     [session stopChecker];
     [NSThread sleepForTimeInterval:2];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2"];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481356];
     XCTAssertEqual(1, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(prevSessionId, [sessionContext objectForKey:kSPSessionId]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.355Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     prevSessionId = [sessionContext objectForKey:kSPSessionId];
     
     [session startChecker];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_3"];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481357];
     XCTAssertEqual(2, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(prevSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_3", [sessionContext objectForKey:kSPSessionFirstEventId]);
+    XCTAssertEqualObjects(@"2022-06-06T06:21:21.357Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
 }
 
 - (void)testBackgroundTimeBiggerThanBackgroundTimeoutCausesNewSession {
@@ -307,7 +321,7 @@
     }];
     SPSession *session = tracker.session;
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481361];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertFalse([session getInBackground]);
     XCTAssertEqual(0, [session getBackgroundIndex]);
@@ -340,7 +354,7 @@
     }];
     SPSession *session = tracker.session;
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481358];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertFalse([session getInBackground]);
     XCTAssertEqual(0, [session getBackgroundIndex]);
@@ -362,12 +376,12 @@
 - (void)testNoEventsForLongTimeDontIncreaseSessionIndexMultipleTimes {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:1 andBackgroundTimeout:1 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1"];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481359];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     
     [NSThread sleepForTimeInterval:4];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2"];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481360];
     XCTAssertEqual(2, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_2", [sessionContext objectForKey:kSPSessionFirstEventId]);
 }
@@ -455,7 +469,27 @@
     XCTAssertNotEqualObjects(@"eventId", sessionState.firstEventId);
 }
 
+- (void)testIncrementsEventIndex {
+    SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
+    
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
+    XCTAssertEqualObjects(@1, [sessionContext objectForKey:kSPSessionEventIndex]);
+    
+    [NSThread sleepForTimeInterval:1];
 
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347];
+    XCTAssertEqualObjects(@2, [sessionContext objectForKey:kSPSessionEventIndex]);
+    
+    [NSThread sleepForTimeInterval:1];
+
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348];
+    XCTAssertEqualObjects(@3, [sessionContext objectForKey:kSPSessionEventIndex]);
+
+    [NSThread sleepForTimeInterval:3.1];
+
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349];
+    XCTAssertEqualObjects(@1, [sessionContext objectForKey:kSPSessionEventIndex]);
+}
 
 // Service methods
 

--- a/Snowplow iOSTests/TestUtils.m
+++ b/Snowplow iOSTests/TestUtils.m
@@ -90,6 +90,11 @@
 
 }
 
+- (void) testTimestampToISOString {
+    XCTAssertEqualObjects([SPUtilities timestampToISOString:1654496481347], @"2022-06-06T06:21:21.347Z");
+    XCTAssertEqualObjects([SPUtilities timestampToISOString:1654498990916], @"2022-06-06T07:03:10.916Z");
+}
+
 - (void)testAppId {
     // This is always NULL in a test environment
     NSLog(@"appId: %@", [SPUtilities getAppId]);

--- a/Snowplow/Internal/SPTrackerConstants.h
+++ b/Snowplow/Internal/SPTrackerConstants.h
@@ -164,6 +164,8 @@ extern NSString * const kSPSessionPreviousId;
 extern NSString * const kSPSessionIndex;
 extern NSString * const kSPSessionStorage;
 extern NSString * const kSPSessionFirstEventId;
+extern NSString * const kSPSessionFirstEventTimestamp;
+extern NSString * const kSPSessionEventIndex;
 
 // --- Geo-Location Context
 

--- a/Snowplow/Internal/SPTrackerConstants.m
+++ b/Snowplow/Internal/SPTrackerConstants.m
@@ -59,7 +59,7 @@ NSString * const kSPUnstructSchema        = @"iglu:com.snowplowanalytics.snowplo
 NSString * const kSPContextSchema         = @"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1";
 NSString * const kSPMobileContextSchema   = @"iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2";
 NSString * const kSPDesktopContextSchema  = @"iglu:com.snowplowanalytics.snowplow/desktop_context/jsonschema/1-0-0";
-NSString * const kSPSessionContextSchema  = @"iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1";
+NSString * const kSPSessionContextSchema  = @"iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2";
 NSString * const kSPScreenContextSchema   = @"iglu:com.snowplowanalytics.mobile/screen/jsonschema/1-0-0";
 NSString * const kSPGeoContextSchema      = @"iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-1-0";
 NSString * const kSPConsentDocumentSchema = @"iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0";
@@ -142,12 +142,14 @@ NSString * const kSPApplicationBuild      = @"build";
 
 // --- Session Context
 
-NSString * const kSPSessionUserId         = @"userId";
-NSString * const kSPSessionId             = @"sessionId";
-NSString * const kSPSessionPreviousId     = @"previousSessionId";
-NSString * const kSPSessionIndex          = @"sessionIndex";
-NSString * const kSPSessionStorage        = @"storageMechanism";
-NSString * const kSPSessionFirstEventId   = @"firstEventId";
+NSString * const kSPSessionUserId              = @"userId";
+NSString * const kSPSessionId                  = @"sessionId";
+NSString * const kSPSessionPreviousId          = @"previousSessionId";
+NSString * const kSPSessionIndex               = @"sessionIndex";
+NSString * const kSPSessionStorage             = @"storageMechanism";
+NSString * const kSPSessionFirstEventId        = @"firstEventId";
+NSString * const kSPSessionFirstEventTimestamp = @"firstEventTimestamp";
+NSString * const kSPSessionEventIndex          = @"eventIndex";
 
 // --- Geo-Location Context
 

--- a/Snowplow/Internal/Session/SPSession.h
+++ b/Snowplow/Internal/Session/SPSession.h
@@ -106,9 +106,10 @@ NS_SWIFT_NAME(Session)
 /**
  * Returns the session dictionary
  * @param firstEventId The potential first event id of the session
+ * @param firstEventTimestamp Device created timestamp of the first event of the session
  * @return a SnowplowPayload containing the session dictionary
  */
-- (NSDictionary *) getSessionDictWithEventId:(NSString *)firstEventId;
+- (NSDictionary *) getSessionDictWithEventId:(NSString *)firstEventId eventTimestamp:(long long)firstEventTimestamp;
 
 /**
  * Returns the foreground index count

--- a/Snowplow/Internal/Session/SPSessionState.h
+++ b/Snowplow/Internal/Session/SPSessionState.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SPSessionState : NSObject <SPState>
 
 @property (nonatomic, nonnull, readonly) NSString *firstEventId;
+@property (nonatomic, nullable, readonly) NSString *firstEventTimestamp;
 @property (nonatomic, nullable, readonly) NSString *previousSessionId;
 @property (nonatomic, nonnull, readonly) NSString *sessionId;
 @property (nonatomic, readonly) NSInteger sessionIndex;
@@ -35,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nonnull, readonly) NSMutableDictionary<NSString *, NSObject *> *sessionContext;
 
-- (instancetype)initWithFirstEventId:(NSString *)firstEventId currentSessionId:(NSString *)currentSessionId previousSessionId:(nullable NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage;
+- (instancetype)initWithFirstEventId:(NSString *)firstEventId firstEventTimestamp: (NSString *)firstEventTimestamp currentSessionId:(NSString *)currentSessionId previousSessionId:(nullable NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage;
 
 - (instancetype)initWithStoredState:(NSDictionary<NSString *, NSObject *> *)storedState;
 

--- a/Snowplow/Internal/Session/SPSessionState.m
+++ b/Snowplow/Internal/Session/SPSessionState.m
@@ -26,6 +26,7 @@
 @interface SPSessionState ()
 
 @property (nonatomic, nonnull, readwrite) NSString *firstEventId;
+@property (nonatomic, nullable, readwrite) NSString *firstEventTimestamp;
 @property (nonatomic, nullable, readwrite) NSString *previousSessionId;
 @property (nonatomic, nonnull, readwrite) NSString *sessionId;
 @property (nonatomic, readwrite) NSInteger sessionIndex;
@@ -37,21 +38,23 @@
 
 @implementation SPSessionState
 
-+ (NSMutableDictionary<NSString *, NSObject *> *)buildSessionDictionaryWithFirstEventId:(NSString *)firstEventId currentSessionId:(NSString *)currentSessionId previousSessionId:(NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage
++ (NSMutableDictionary<NSString *, NSObject *> *)buildSessionDictionaryWithFirstEventId:(NSString *)firstEventId firstEventTimestamp:(NSString *)firstEventTimestamp currentSessionId:(NSString *)currentSessionId previousSessionId:(NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage
 {
     NSMutableDictionary *dictionary = [NSMutableDictionary new];
     [dictionary setObject:previousSessionId ?: [NSNull null] forKey:kSPSessionPreviousId];
     [dictionary setObject:currentSessionId forKey:kSPSessionId];
     [dictionary setObject:firstEventId forKey:kSPSessionFirstEventId];
+    [dictionary setObject:firstEventTimestamp ?: [NSNull null] forKey:kSPSessionFirstEventTimestamp];
     [dictionary setObject:[NSNumber numberWithInteger:sessionIndex] forKey:kSPSessionIndex];
     [dictionary setObject:storage forKey:kSPSessionStorage];
     [dictionary setObject:userId forKey:kSPSessionUserId];
     return dictionary;
 }
 
-- (instancetype)initWithFirstEventId:(NSString *)firstEventId currentSessionId:(NSString *)currentSessionId previousSessionId:(NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage {
+- (instancetype)initWithFirstEventId:(NSString *)firstEventId firstEventTimestamp:(NSString *)firstEventTimestamp currentSessionId:(NSString *)currentSessionId previousSessionId:(NSString *)previousSessionId sessionIndex:(NSInteger)sessionIndex userId:(NSString *)userId storage:(NSString *)storage {
     if (self = [super init]) {
         self.firstEventId = firstEventId;
+        self.firstEventTimestamp = firstEventTimestamp;
         self.sessionId = currentSessionId;
         self.previousSessionId = previousSessionId;
         self.sessionIndex = sessionIndex;
@@ -59,6 +62,7 @@
         self.storage = storage;
         
         self.sessionDictionary = [SPSessionState buildSessionDictionaryWithFirstEventId:firstEventId
+                                                                    firstEventTimestamp:firstEventTimestamp
                                                                        currentSessionId:currentSessionId
                                                                       previousSessionId:previousSessionId
                                                                            sessionIndex:sessionIndex
@@ -87,10 +91,12 @@
         // defensive and exclude any possible issue with a missing value.
         self.firstEventId = [storedState sp_stringForKey:kSPSessionFirstEventId
                                                        defaultValue:@"00000000-0000-0000-0000-000000000000"];
+        self.firstEventTimestamp = [storedState sp_stringForKey:kSPSessionFirstEventTimestamp defaultValue:nil];
                 
         self.storage = [storedState sp_stringForKey:kSPSessionStorage defaultValue:@"LOCAL_STORAGE"];
         
         self.sessionDictionary = [SPSessionState buildSessionDictionaryWithFirstEventId:self.firstEventId
+                                                                    firstEventTimestamp:self.firstEventTimestamp
                                                                        currentSessionId:self.sessionId
                                                                       previousSessionId:self.previousSessionId
                                                                            sessionIndex:self.sessionIndex

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -624,10 +624,10 @@ void uncaughtExceptionHandler(NSException *exception) {
 }
 
 - (void)addBasicContextsToContexts:(NSMutableArray<SPSelfDescribingJson *> *)contexts event:(SPTrackerEvent *)event {
-    [self addBasicContextsToContexts:contexts eventId:event.eventId.UUIDString isService:event.isService];
+    [self addBasicContextsToContexts:contexts eventId:event.eventId.UUIDString eventTimestamp:event.timestamp isService:event.isService];
 }
 
-- (void)addBasicContextsToContexts:(NSMutableArray<SPSelfDescribingJson *> *)contexts eventId:(NSString *)eventId isService:(BOOL)isService {
+- (void)addBasicContextsToContexts:(NSMutableArray<SPSelfDescribingJson *> *)contexts eventId:(NSString *)eventId eventTimestamp:(long long)eventTimestamp isService:(BOOL)isService {
     if (_subject) {
         NSDictionary * platformDict = [[_subject getPlatformDict] getAsDictionary];
         if (platformDict != nil) {
@@ -652,7 +652,7 @@ void uncaughtExceptionHandler(NSException *exception) {
 
     // Add session
     if (_session) {
-        NSDictionary *sessionDict = [_session getSessionDictWithEventId:eventId];
+        NSDictionary *sessionDict = [_session getSessionDictWithEventId:eventId eventTimestamp:eventTimestamp];
         if (sessionDict) {
             [contexts addObject:[[SPSelfDescribingJson alloc] initWithSchema:kSPSessionContextSchema andData:sessionDict]];
         } else {

--- a/Snowplow/Internal/Utils/SPUtilities.h
+++ b/Snowplow/Internal/Utils/SPUtilities.h
@@ -70,6 +70,12 @@
 + (NSNumber *) getTimestamp;
 
 /*!
+ @brief Converts a timestamp (in milliseconds) to ISO8601 formatted string
+ @return ISO8601 formatted string
+ */
++ (NSString *) timestampToISOString:(long long)timestamp;
+
+/*!
  @brief Calculates the resolution of the screen in-terms of actual pixels of the device. This doesn't count Retine-pixels which are technically subpixels.
  @return A formatted string with resolution 'width' and 'height'.
  */

--- a/Snowplow/Internal/Utils/SPUtilities.m
+++ b/Snowplow/Internal/Utils/SPUtilities.m
@@ -80,6 +80,15 @@
     return @([time timeIntervalSince1970] * 1000);
 }
 
++ (NSString *) timestampToISOString:(long long)timestamp {
+    NSDate *eventDate = [NSDate dateWithTimeIntervalSince1970:timestamp / 1000.0];
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+    [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+    return [formatter stringFromDate:eventDate];
+}
+
 + (NSString *) getResolution {
 #if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_TV
     CGRect mainScreen = [[UIScreen mainScreen] bounds];


### PR DESCRIPTION
This PR addresses issue #682 and updates the version of the `client_session` schema to 1-0-2. This adds two new entities:

* `eventIndex` which counts the order of the event in the session
* `firstEventTimestamp` which is the timestamp of the first event in the session

The changes are only internal within the session.

The only change in the documentation was to update the version of the schema. [Here is the PR for it](https://github.com/snowplow-incubator/data-value-resources/pull/111).