### PR TITLE
Add a customizable set of failure HTTP status codes for which collector requests should not be retried (close #684)

### DIFF
--- a/Snowplow iOSTests/Configurations/TestEmitterConfiguration.m
+++ b/Snowplow iOSTests/Configurations/TestEmitterConfiguration.m
@@ -46,7 +46,7 @@
 }
 
 - (void)testPauseEmitter {
-    SPMockNetworkConnection *networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost successfulConnection:YES];
+    SPMockNetworkConnection *networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
     SPEmitterConfiguration *emitterConfig = [[SPEmitterConfiguration alloc] init];
     emitterConfig.eventStore = [SPMockEventStore new];
     emitterConfig.bufferOption = SPBufferOptionSingle;

--- a/Snowplow iOSTests/TestRequest.m
+++ b/Snowplow iOSTests/TestRequest.m
@@ -129,10 +129,9 @@
 }
 
 - (NSArray<SPRequestResult *> *)sendRequests:(NSArray<SPRequest *> *)requests {
-    BOOL isSuccess = self.resultCode == 200;
     NSMutableArray<SPRequestResult *> *results = [NSMutableArray new];
     for (SPRequest *request in requests) {
-        SPRequestResult *result = [[SPRequestResult alloc] initWithSuccess:isSuccess storeIds:request.emitterEventIds];
+        SPRequestResult *result = [[SPRequestResult alloc] initWithStatusCode:self.resultCode oversize:request.oversize storeIds:request.emitterEventIds];
         [results addObject:result];
     }
     return results;

--- a/Snowplow iOSTests/TestRequestResult.m
+++ b/Snowplow iOSTests/TestRequestResult.m
@@ -45,7 +45,7 @@
 
     XCTAssertNotNil(result);
     XCTAssertEqual(result.isSuccessful, YES);
-    XCTAssertEqual([result shouldRetry:[[NSDictionary alloc] init]], NO);
+    XCTAssertEqual([result shouldRetry:@{}], NO);
     XCTAssertEqual(result.storeIds, emitterEventIds);
 }
 
@@ -54,7 +54,7 @@
     [emitterEventIds addObject:@1];
     SPRequestResult *result = [[SPRequestResult alloc] initWithStatusCode:500 oversize:NO storeIds:emitterEventIds];
     XCTAssertEqual(result.isSuccessful, NO);
-    XCTAssertEqual([result shouldRetry:[[NSDictionary alloc] init]], YES);
+    XCTAssertEqual([result shouldRetry:@{}], YES);
 }
 
 - (void)testDefaultResult {
@@ -68,19 +68,19 @@
 - (void)testOversizedFailedRequest {
     SPRequestResult *result = [[SPRequestResult alloc] initWithStatusCode:500 oversize:YES storeIds:@[]];
     XCTAssertEqual(result.isSuccessful, NO);
-    XCTAssertEqual([result shouldRetry:[[NSDictionary alloc] init]], NO);
+    XCTAssertEqual([result shouldRetry:@{}], NO);
 }
 
 - (void)testFailedRequestWithNoRetryStatus {
     SPRequestResult *result = [[SPRequestResult alloc] initWithStatusCode:403 oversize:NO storeIds:@[]];
     XCTAssertEqual(result.isSuccessful, NO);
-    XCTAssertEqual([result shouldRetry:[[NSDictionary alloc] init]], NO);
+    XCTAssertEqual([result shouldRetry:@{}], NO);
 }
 
 - (void)testFailedRequestWithCustomNoRetryStatus {
     NSMutableDictionary *customRetryRules = [[NSMutableDictionary alloc] init];
-    [customRetryRules setObject:[NSNumber numberWithBool:YES] forKey:[NSNumber numberWithInt:403]];
-    [customRetryRules setObject:[NSNumber numberWithBool:NO] forKey:[NSNumber numberWithInt:500]];
+    [customRetryRules setObject:@YES forKey:@403];
+    [customRetryRules setObject:@NO forKey:@500];
     
     SPRequestResult *result = [[SPRequestResult alloc] initWithStatusCode:403 oversize:NO storeIds:@[]];
     XCTAssertEqual([result shouldRetry:customRetryRules], YES);

--- a/Snowplow iOSTests/Utils/SPMockNetworkConnection.h
+++ b/Snowplow iOSTests/Utils/SPMockNetworkConnection.h
@@ -26,9 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPMockNetworkConnection : NSObject <SPNetworkConnection>
 
-- (instancetype)initWithRequestOption:(SPHttpMethod)httpMethod successfulConnection:(BOOL)successfulConnection;
+- (instancetype)initWithRequestOption:(SPHttpMethod)httpMethod statusCode:(NSInteger)statusCode;
 
-@property (nonatomic) BOOL successfulConnection;
+@property (nonatomic) NSInteger statusCode;
 @property (nonatomic) SPHttpMethod httpMethod;
 @property (nonatomic) NSMutableArray<NSMutableArray<SPRequestResult *> *> *previousResults;
 @property (nonatomic) NSUInteger sendingCount;

--- a/Snowplow iOSTests/Utils/SPMockNetworkConnection.m
+++ b/Snowplow iOSTests/Utils/SPMockNetworkConnection.m
@@ -24,10 +24,10 @@
 
 @implementation SPMockNetworkConnection
 
-- initWithRequestOption:(SPHttpMethod)httpMethod successfulConnection:(BOOL)successfulConnection {
+- initWithRequestOption:(SPHttpMethod)httpMethod statusCode:(NSInteger)statusCode {
     if (self = [super init]) {
         self.httpMethod = httpMethod;
-        self.successfulConnection = successfulConnection;
+        self.statusCode = statusCode;
         self.previousResults = [NSMutableArray new];
     }
     return self;
@@ -36,9 +36,8 @@
 - (nonnull NSArray<SPRequestResult *> *)sendRequests:(nonnull NSArray<SPRequest *> *)requests {
     NSMutableArray<SPRequestResult *> *requestResults = [NSMutableArray new];
     for (SPRequest *request in requests) {
-        BOOL isSuccessful = request.oversize || self.successfulConnection;
-        SPRequestResult *result = [[SPRequestResult alloc] initWithSuccess:isSuccessful storeIds:request.emitterEventIds];
-        SPLogVerbose(@"Sent %@ with success %@", request.emitterEventIds, isSuccessful ? @"YES" : @"NO");
+        SPRequestResult *result = [[SPRequestResult alloc] initWithStatusCode:_statusCode oversize:request.oversize storeIds:request.emitterEventIds];
+        SPLogVerbose(@"Sent %@ with success %@", request.emitterEventIds, [result isSuccessful] ? @"YES" : @"NO");
         [requestResults addObject:result];
     }
     [self.previousResults addObject:requestResults];

--- a/Snowplow/Internal/Configurations/SPEmitterConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPEmitterConfiguration.h
@@ -77,6 +77,11 @@ NS_SWIFT_NAME(EmitterConfigurationProtocol)
  * Callback called for each request performed by the tracker to the collector.
  */
 @property (nullable) id<SPRequestCallback> requestCallback;
+/**
+ *  Custom retry rules for HTTP status codes returned from the Collector.
+ *  The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
+ */
+@property (nonatomic, nullable) NSDictionary<NSNumber *, NSNumber *> *customRetryForStatusCodes;
 
 @end
 
@@ -136,6 +141,11 @@ SP_BUILDER_DECLARE_NULLABLE(id<SPRequestCallback>, requestCallback)
  * If it's not set the tracker will use a SQLite database as default EventStore.
  */
 SP_BUILDER_DECLARE_NULLABLE(id<SPEventStore>, eventStore)
+/**
+ * Custom retry rules for HTTP status codes returned from the Collector.
+ * The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
+ */
+SP_BUILDER_DECLARE_NULLABLE(NSDictionary *, customRetryForStatusCodes)
 
 @end
 

--- a/Snowplow/Internal/Configurations/SPEmitterConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPEmitterConfiguration.m
@@ -67,6 +67,7 @@ SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
     copy.byteLimitPost = self.byteLimitPost;
     copy.requestCallback = self.requestCallback;
     copy.eventStore = self.eventStore;
+    copy.customRetryForStatusCodes = self.customRetryForStatusCodes;
     return copy;
 }
 

--- a/Snowplow/Internal/Configurations/SPEmitterConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPEmitterConfiguration.m
@@ -29,6 +29,7 @@
 @synthesize emitRange;
 @synthesize threadPoolSize;
 @synthesize requestCallback;
+@synthesize customRetryForStatusCodes;
 
 - (instancetype)init {
     if (self = [super init]) {
@@ -51,6 +52,7 @@ SP_BUILDER_METHOD(NSInteger, threadPoolSize)
 SP_BUILDER_METHOD(NSInteger, byteLimitGet)
 SP_BUILDER_METHOD(NSInteger, byteLimitPost)
 SP_BUILDER_METHOD(id<SPRequestCallback>, requestCallback)
+SP_BUILDER_METHOD(NSDictionary *, customRetryForStatusCodes)
 
 SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
 
@@ -80,6 +82,7 @@ SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
     [coder encodeInteger:self.threadPoolSize forKey:SP_STR_PROP(threadPoolSize)];
     [coder encodeInteger:self.byteLimitGet forKey:SP_STR_PROP(byteLimitGet)];
     [coder encodeInteger:self.byteLimitPost forKey:SP_STR_PROP(byteLimitPost)];
+    [coder encodeObject:self.customRetryForStatusCodes forKey:SP_STR_PROP(customRetryForStatusCodes)];
 }
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
@@ -89,6 +92,7 @@ SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
         self.threadPoolSize = [coder decodeIntegerForKey:SP_STR_PROP(threadPoolSize)];
         self.byteLimitGet = [coder decodeIntegerForKey:SP_STR_PROP(byteLimitGet)];
         self.byteLimitPost = [coder decodeIntegerForKey:SP_STR_PROP(byteLimitPost)];
+        self.customRetryForStatusCodes = [coder decodeObjectForKey:SP_STR_PROP(customRetryForStatusCodes)];
     }
     return self;
 }

--- a/Snowplow/Internal/Emitter/SPEmitter.h
+++ b/Snowplow/Internal/Emitter/SPEmitter.h
@@ -114,6 +114,13 @@ NS_SWIFT_NAME(EmitterBuilder)
  */
 - (void) setEventStore:(id<SPEventStore>)eventStore;
 
+/**
+ @brief Set a custom retry rules for HTTP status codes received in emit responses from the Collector.
+ 
+ @param customRetryForStatusCodes Mapping of integers (status codes) to booleans (true for retry and false for not retry)
+ */
+- (void) setCustomRetryForStatusCodes:(NSDictionary<NSNumber *, NSNumber *> *)customRetryForStatusCodes;
+
 @end
 
 /*!
@@ -147,6 +154,8 @@ NS_SWIFT_NAME(Emitter)
 @property (readonly, nonatomic) NSDictionary<NSString *, NSString *> *requestHeaders;
 /*! @brief Custom NetworkConnection istance to handle connection outside the emitter. */
 @property (readonly, nonatomic) id<SPNetworkConnection> networkConnection;
+/*! @brief Custom retry rules for HTTP status codes. */
+@property (readonly, nonatomic) NSDictionary<NSNumber *, NSNumber *> *customRetryForStatusCodes;
 
 /*!
  @brief Builds the emitter using a build block of functions.

--- a/Snowplow/Internal/Emitter/SPEmitter.m
+++ b/Snowplow/Internal/Emitter/SPEmitter.m
@@ -80,7 +80,7 @@ const NSUInteger POST_WRAPPER_BYTES = 88;
         _eventStore = nil;
         _networkConnection = nil;
         _pausedEmit = NO;
-        _customRetryForStatusCodes = [[NSDictionary alloc] init];
+        _customRetryForStatusCodes = @{};
     }
     return self;
 }
@@ -219,11 +219,7 @@ const NSUInteger POST_WRAPPER_BYTES = 88;
 }
 
 - (void)setCustomRetryForStatusCodes:(NSDictionary<NSNumber *, NSNumber *> *)customRetryForStatusCodes {
-    if (customRetryForStatusCodes) {
-        _customRetryForStatusCodes = customRetryForStatusCodes;
-    } else {
-        _customRetryForStatusCodes = [[NSDictionary alloc] init];
-    }
+    _customRetryForStatusCodes = customRetryForStatusCodes ?: @{};
 }
 
 // MARK: - Pause/Resume methods

--- a/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.h
+++ b/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.h
@@ -34,6 +34,7 @@ SP_DIRTYFLAG(byteLimitGet)
 SP_DIRTYFLAG(byteLimitPost)
 SP_DIRTYFLAG(emitRange)
 SP_DIRTYFLAG(threadPoolSize)
+SP_DIRTYFLAG(customRetryForStatusCodes)
 
 @end
 

--- a/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.m
+++ b/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.m
@@ -31,5 +31,6 @@ SP_DIRTY_GETTER(NSInteger, emitRange)
 SP_DIRTY_GETTER(NSInteger, threadPoolSize)
 SP_DIRTY_GETTER(NSInteger, byteLimitGet)
 SP_DIRTY_GETTER(NSInteger, byteLimitPost)
+SP_DIRTY_GETTER(NSDictionary *, customRetryForStatusCodes)
 
 @end

--- a/Snowplow/Internal/Emitter/SPRequestResult.h
+++ b/Snowplow/Internal/Emitter/SPRequestResult.h
@@ -24,16 +24,29 @@
 NS_SWIFT_NAME(RequestResult)
 @interface SPRequestResult : NSObject
 
-/// Returns the success of the request operation.
-@property (nonatomic, readonly) BOOL isSuccessful;
+/// Returns the HTTP status code from Collector.
+@property (nonatomic, readonly) NSInteger statusCode;
+/// Was the request oversize
+@property (nonatomic, readonly) BOOL isOversize;
 /// Returns the stored index array, needed to remove the events after sending.
 @property (nonatomic, readonly) NSArray<NSNumber *> *storeIds;
 
 /**
  * Creates a request result object
- * @param success whether the operation was a success or not
+ * @param statusCode HTTP status code from collector response
  * @param storeIds the event indexes in the database
  */
-- (instancetype)initWithSuccess:(BOOL)success storeIds:(NSArray<NSNumber *> *)storeIds;
+- (instancetype)initWithStatusCode:(NSInteger)statusCode oversize:(BOOL)isOversize storeIds:(NSArray<NSNumber *> *)storeIds;
+
+/**
+ * @return Whether the events were successfuly sent to the Collector.
+ */
+- (BOOL)isSuccessful;
+
+/**
+ * @param customRetryForStatusCodes mapping of custom retry rules for HTTP status codes in Collector response.
+ * @return Whether sending the events to the Collector should be retried.
+ */
+- (BOOL)shouldRetry:(NSDictionary<NSNumber *, NSNumber *> *)customRetryForStatusCodes;
 
 @end

--- a/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.m
+++ b/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.m
@@ -173,11 +173,10 @@
             
             dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
 
-            BOOL isSuccessful = [httpResponse statusCode] >= 200 && [httpResponse statusCode] < 300;
-            if (!isSuccessful) {
+            SPRequestResult *result = [[SPRequestResult alloc] initWithStatusCode:[httpResponse statusCode] oversize:request.oversize storeIds:request.emitterEventIds];
+            if (![result isSuccessful]) {
                 SPLogError(@"Connection error: %@", connectionError);
             }
-            SPRequestResult *result = [[SPRequestResult alloc] initWithSuccess:isSuccessful storeIds:request.emitterEventIds];
 
             @synchronized (results) {
                 [results addObject:result];

--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -286,6 +286,7 @@
             [builder setByteLimitGet:emitterConfig.byteLimitGet];
             [builder setEmitThreadPoolSize:emitterConfig.threadPoolSize];
             [builder setCallback:emitterConfig.requestCallback];
+            [builder setCustomRetryForStatusCodes:emitterConfig.customRetryForStatusCodes];
         }
     }];
     if (emitterConfig && emitterConfig.isPaused) {

--- a/TestServiceProvider.m
+++ b/TestServiceProvider.m
@@ -50,7 +50,7 @@
 }
 
 - (void)testUpdatingConfigurationRetainsPausedEmitter {
-    SPMockNetworkConnection *networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost successfulConnection:YES];
+    SPMockNetworkConnection *networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
     SPEmitterConfiguration *emitterConfig = [[SPEmitterConfiguration alloc] init];
     emitterConfig.eventStore = [SPMockEventStore new];
     emitterConfig.bufferOption = SPBufferOptionSingle;


### PR DESCRIPTION
This PR addresses issue #684.

It adds a set of 5 HTTP status codes (400, 401, 403, 410, and 422) for which sending events should not be retried and the events should be dropped. This is in line with the strategy for handling HTTP status codes that we [outlined here](https://github.com/snowplow-incubator/data-value-resources/blob/main/30%20Tracker%20Architecture/emitter_architecture/handling_http_status_codes.md).

It also makes the retry behaviour configurable. It adds the `customRetryForStatusCodes` property to `EmitterConfiguration`. This is a dictionary mapping status codes (int) to booleans stating whether to retry or not.

I added a note about the property in the documentation as well. [Here is a PR](https://github.com/snowplow-incubator/data-value-resources/pull/112) for it on data-value-resources.