### PR TITLE
Add interface to subscribe for events tracked in Web views (close #691)

### DIFF
--- a/Snowplow iOSTests/TestWebViewMessageHandler.m
+++ b/Snowplow iOSTests/TestWebViewMessageHandler.m
@@ -39,8 +39,8 @@
     self.webViewMessageHandler = [[SPWebViewMessageHandler alloc] init];
     self.networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
     
-    id networkConfig = [[SPNetworkConfiguration alloc] initWithNetworkConnection:self.networkConnection];
-    id trackerConfig = [[SPTrackerConfiguration alloc] init];
+    SPNetworkConfiguration *networkConfig = [[SPNetworkConfiguration alloc] initWithNetworkConnection:self.networkConnection];
+    SPTrackerConfiguration *trackerConfig = [[SPTrackerConfiguration alloc] init];
     [trackerConfig base64Encoding:NO];
     [trackerConfig sessionContext:NO];
     [trackerConfig platformContext:NO];
@@ -54,7 +54,7 @@
 }
 
 - (void)testTracksStructuredEventWithAllProperties {
-    id message = [[SPMockWKScriptMessage alloc] initWithBody:@{
+    SPMockWKScriptMessage *message = [[SPMockWKScriptMessage alloc] initWithBody:@{
         @"command": @"trackStructEvent",
         @"event": @{
             @"category": @"cat",
@@ -72,8 +72,8 @@
     
     XCTAssertEqual(1, [self.networkConnection sendingCount]);
     XCTAssertEqual(1, [[self.networkConnection.previousRequests objectAtIndex:0] count]);
-    id request = [[self.networkConnection.previousRequests objectAtIndex:0] objectAtIndex:0];
-    id payload = [(NSArray *)[[[request payload] getAsDictionary] objectForKey:@"data"] objectAtIndex:0];
+    SPRequest *request = [[self.networkConnection.previousRequests objectAtIndex:0] objectAtIndex:0];
+    NSDictionary *payload = [(NSArray *)[[[request payload] getAsDictionary] objectForKey:@"data"] objectAtIndex:0];
     XCTAssert([[payload objectForKey:@"se_ca"] isEqualToString:@"cat"]);
     XCTAssert([[payload objectForKey:@"se_ac"] isEqualToString:@"act"]);
     XCTAssert([[payload objectForKey:@"se_pr"] isEqualToString:@"prop"]);
@@ -83,12 +83,12 @@
 
 - (void)testTracksEventWithCorrectTracker {
     // create the second tracker
-    id networkConnection2 = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
-    id networkConfig = [[SPNetworkConfiguration alloc] initWithNetworkConnection:networkConnection2];
+    SPMockNetworkConnection *networkConnection2 = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
+    SPNetworkConfiguration *networkConfig = [[SPNetworkConfiguration alloc] initWithNetworkConnection:networkConnection2];
     [SPSnowplow createTrackerWithNamespace:@"ns2" network:networkConfig configurations:@[]];
 
     // track an event using the second tracker
-    id message = [[SPMockWKScriptMessage alloc] initWithBody:@{
+    SPMockWKScriptMessage *message = [[SPMockWKScriptMessage alloc] initWithBody:@{
         @"command": @"trackPageView",
         @"event": @{
             @"url": @"http://localhost"
@@ -108,7 +108,7 @@
 }
 
 - (void)testTracksEventWithContext {
-    id message = [[SPMockWKScriptMessage alloc] initWithBody:@{
+    SPMockWKScriptMessage *message = [[SPMockWKScriptMessage alloc] initWithBody:@{
         @"command": @"trackSelfDescribingEvent",
         @"event": @{
             @"schema": @"http://schema.com",
@@ -133,8 +133,8 @@
 
     XCTAssertEqual(1, [self.networkConnection sendingCount]);
     XCTAssertEqual(1, [[self.networkConnection.previousRequests objectAtIndex:0] count]);
-    id request = [[self.networkConnection.previousRequests objectAtIndex:0] objectAtIndex:0];
-    id payload = [(NSArray *)[[[request payload] getAsDictionary] objectForKey:@"data"] objectAtIndex:0];
+    SPRequest *request = [[self.networkConnection.previousRequests objectAtIndex:0] objectAtIndex:0];
+    NSDictionary *payload = [(NSArray *)[[[request payload] getAsDictionary] objectForKey:@"data"] objectAtIndex:0];
 
     NSString *context = [payload objectForKey:@"co"];
     XCTAssert([context containsString:@"{\"a\":\"b\"}"]);

--- a/Snowplow iOSTests/TestWebViewMessageHandler.m
+++ b/Snowplow iOSTests/TestWebViewMessageHandler.m
@@ -1,0 +1,143 @@
+//
+//  TestWebViewMessageHandler.h
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Matus Tomlein
+//  License: Apache License Version 2.0
+//
+
+#import <XCTest/XCTest.h>
+
+#import "SPSnowplow.h"
+#import "SPWebViewMessageHandler.h"
+#import "Utils/SPMockNetworkConnection.h"
+#import "Utils/SPMockWKScriptMessage.h"
+
+@interface TestWebViewMessageHandler : XCTestCase
+
+@property (nonatomic) SPWebViewMessageHandler *webViewMessageHandler;
+@property (nonatomic) SPMockNetworkConnection *networkConnection;
+
+@end
+
+@implementation TestWebViewMessageHandler
+
+- (void)setUp {
+    self.webViewMessageHandler = [[SPWebViewMessageHandler alloc] init];
+    self.networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
+    
+    id networkConfig = [[SPNetworkConfiguration alloc] initWithNetworkConnection:self.networkConnection];
+    id trackerConfig = [[SPTrackerConfiguration alloc] init];
+    [trackerConfig base64Encoding:NO];
+    [trackerConfig sessionContext:NO];
+    [trackerConfig platformContext:NO];
+
+    [SPSnowplow removeAllTrackers];
+    [SPSnowplow createTrackerWithNamespace:[[NSUUID UUID] UUIDString] network:networkConfig configurations:@[trackerConfig]];
+}
+
+- (void)tearDown {
+    [SPSnowplow removeAllTrackers];
+}
+
+- (void)testTracksStructuredEventWithAllProperties {
+    id message = [[SPMockWKScriptMessage alloc] initWithBody:@{
+        @"command": @"trackStructEvent",
+        @"event": @{
+            @"category": @"cat",
+            @"action": @"act",
+            @"label": @"lbl",
+            @"property": @"prop",
+            @"value": @10.0,
+        }
+    }];
+    [self.webViewMessageHandler userContentController:nil didReceiveScriptMessage:message];
+    
+    for (int i = 0; i < 10 && [self.networkConnection sendingCount] == 0; i++) {
+        [NSThread sleepForTimeInterval:0.5];
+    }
+    
+    XCTAssertEqual(1, [self.networkConnection sendingCount]);
+    XCTAssertEqual(1, [[self.networkConnection.previousRequests objectAtIndex:0] count]);
+    id request = [[self.networkConnection.previousRequests objectAtIndex:0] objectAtIndex:0];
+    id payload = [(NSArray *)[[[request payload] getAsDictionary] objectForKey:@"data"] objectAtIndex:0];
+    XCTAssert([[payload objectForKey:@"se_ca"] isEqualToString:@"cat"]);
+    XCTAssert([[payload objectForKey:@"se_ac"] isEqualToString:@"act"]);
+    XCTAssert([[payload objectForKey:@"se_pr"] isEqualToString:@"prop"]);
+    XCTAssert([[payload objectForKey:@"se_la"] isEqualToString:@"lbl"]);
+    XCTAssert([[payload objectForKey:@"se_va"] isEqualToString:@"10"]);
+}
+
+- (void)testTracksEventWithCorrectTracker {
+    // create the second tracker
+    id networkConnection2 = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
+    id networkConfig = [[SPNetworkConfiguration alloc] initWithNetworkConnection:networkConnection2];
+    [SPSnowplow createTrackerWithNamespace:@"ns2" network:networkConfig configurations:@[]];
+
+    // track an event using the second tracker
+    id message = [[SPMockWKScriptMessage alloc] initWithBody:@{
+        @"command": @"trackPageView",
+        @"event": @{
+            @"url": @"http://localhost"
+        },
+        @"trackers": @[@"ns2"]
+    }];
+    [self.webViewMessageHandler userContentController:nil didReceiveScriptMessage:message];
+
+    // wait and check for the event
+    for (int i = 0; i < 10 && [networkConnection2 sendingCount] == 0; i++) {
+        [NSThread sleepForTimeInterval:0.5];
+    }
+
+    XCTAssertEqual(0, [self.networkConnection sendingCount]);
+    XCTAssertEqual(1, [networkConnection2 sendingCount]);
+    XCTAssertEqual(1, [[[networkConnection2 previousRequests] objectAtIndex:0] count]);
+}
+
+- (void)testTracksEventWithContext {
+    id message = [[SPMockWKScriptMessage alloc] initWithBody:@{
+        @"command": @"trackSelfDescribingEvent",
+        @"event": @{
+            @"schema": @"http://schema.com",
+            @"data": @{
+                @"key": @"val"
+            }
+        },
+        @"context": @[
+            @{
+                @"schema": @"http://context-schema.com",
+                @"data": @{
+                    @"a": @"b"
+                }
+            }
+        ]
+    }];
+    [self.webViewMessageHandler userContentController:nil didReceiveScriptMessage:message];
+
+    for (int i = 0; i < 10 && [self.networkConnection sendingCount] == 0; i++) {
+        [NSThread sleepForTimeInterval:0.5];
+    }
+
+    XCTAssertEqual(1, [self.networkConnection sendingCount]);
+    XCTAssertEqual(1, [[self.networkConnection.previousRequests objectAtIndex:0] count]);
+    id request = [[self.networkConnection.previousRequests objectAtIndex:0] objectAtIndex:0];
+    id payload = [(NSArray *)[[[request payload] getAsDictionary] objectForKey:@"data"] objectAtIndex:0];
+
+    NSString *context = [payload objectForKey:@"co"];
+    XCTAssert([context containsString:@"{\"a\":\"b\"}"]);
+}
+
+@end

--- a/Snowplow iOSTests/Utils/SPMockNetworkConnection.m
+++ b/Snowplow iOSTests/Utils/SPMockNetworkConnection.m
@@ -29,6 +29,7 @@
         self.httpMethod = httpMethod;
         self.statusCode = statusCode;
         self.previousResults = [NSMutableArray new];
+        self.previousRequests = [NSMutableArray new];
     }
     return self;
 }
@@ -40,6 +41,7 @@
         SPLogVerbose(@"Sent %@ with success %@", request.emitterEventIds, [result isSuccessful] ? @"YES" : @"NO");
         [requestResults addObject:result];
     }
+    [self.previousRequests addObject:requests];
     [self.previousResults addObject:requestResults];
     return requestResults;
 }

--- a/Snowplow iOSTests/Utils/SPMockWKScriptMessage.h
+++ b/Snowplow iOSTests/Utils/SPMockWKScriptMessage.h
@@ -1,5 +1,5 @@
 //
-//  SPMockNetworkConnection.h
+//  SPMockWKScriptMessage.h
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -15,26 +15,18 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Authors: Alex Benini, Matus Tomlein
+//  Authors: Matus Tomlein
 //  License: Apache License Version 2.0
 //
 
-#import <Foundation/Foundation.h>
-#import "SPEmitter.h"
+#import <WebKit/WebKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SPMockNetworkConnection : NSObject <SPNetworkConnection>
+@interface SPMockWKScriptMessage : WKScriptMessage
 
-- (instancetype)initWithRequestOption:(SPHttpMethod)httpMethod statusCode:(NSInteger)statusCode;
-
-@property (nonatomic) NSInteger statusCode;
-@property (nonatomic) SPHttpMethod httpMethod;
-@property (nonatomic) NSMutableArray<NSMutableArray<SPRequestResult *> *> *previousResults;
-@property (nonatomic) NSMutableArray<NSArray<SPRequest *> *> *previousRequests;
-@property (nonatomic) NSUInteger sendingCount;
+- (id) initWithBody:(id)body;
 
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/Snowplow iOSTests/Utils/SPMockWKScriptMessage.m
+++ b/Snowplow iOSTests/Utils/SPMockWKScriptMessage.m
@@ -1,5 +1,5 @@
 //
-//  SPMockNetworkConnection.h
+//  SPMockWKScriptMessage.m
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -15,26 +15,33 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Authors: Alex Benini, Matus Tomlein
+//  Authors: Matus Tomlein
 //  License: Apache License Version 2.0
 //
 
-#import <Foundation/Foundation.h>
-#import "SPEmitter.h"
+#import "SPMockWKScriptMessage.h"
 
-NS_ASSUME_NONNULL_BEGIN
+@interface SPMockWKScriptMessage()
 
-@interface SPMockNetworkConnection : NSObject <SPNetworkConnection>
-
-- (instancetype)initWithRequestOption:(SPHttpMethod)httpMethod statusCode:(NSInteger)statusCode;
-
-@property (nonatomic) NSInteger statusCode;
-@property (nonatomic) SPHttpMethod httpMethod;
-@property (nonatomic) NSMutableArray<NSMutableArray<SPRequestResult *> *> *previousResults;
-@property (nonatomic) NSMutableArray<NSArray<SPRequest *> *> *previousRequests;
-@property (nonatomic) NSUInteger sendingCount;
+@property (nonatomic, strong) id messageBody;
 
 @end
 
+@implementation SPMockWKScriptMessage
 
-NS_ASSUME_NONNULL_END
+- (id) initWithBody:(id)body {
+    self = [super init];
+    
+    if (self) {
+        _messageBody = body;
+    }
+    
+    return self;
+}
+
+- (id) body {
+    return self.messageBody;
+}
+
+
+@end

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -13,6 +13,17 @@
 		23DFEC802362FAD500BD19C4 /* FMDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 752DAC0C21CC3EEA0065F874 /* FMDB.framework */; };
 		23DFEC822362FAED00BD19C4 /* SnowplowIgluClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75CAC3B921F28BD600271FB3 /* SnowplowIgluClient.framework */; };
 		23DFEC832362FAF800BD19C4 /* VVJSONSchemaValidation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75CAC3C021F2930100271FB3 /* VVJSONSchemaValidation.framework */; };
+		6B07CDAD287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B07CDAB287721C600E510D6 /* SPWebViewMessageHandler.h */; };
+		6B07CDAE287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B07CDAB287721C600E510D6 /* SPWebViewMessageHandler.h */; };
+		6B07CDAF287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B07CDAB287721C600E510D6 /* SPWebViewMessageHandler.h */; };
+		6B07CDB0287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B07CDAB287721C600E510D6 /* SPWebViewMessageHandler.h */; };
+		6B07CDB1287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B07CDAC287721C600E510D6 /* SPWebViewMessageHandler.m */; };
+		6B07CDB2287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B07CDAC287721C600E510D6 /* SPWebViewMessageHandler.m */; };
+		6B07CDB3287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B07CDAC287721C600E510D6 /* SPWebViewMessageHandler.m */; };
+		6B07CDB4287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B07CDAC287721C600E510D6 /* SPWebViewMessageHandler.m */; };
+		6B4B3087287730D200B4C16B /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4B3086287730D200B4C16B /* WebKit.framework */; };
+		6B4B3089287730E000B4C16B /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4B3088287730E000B4C16B /* WebKit.framework */; };
+		6B4B308A287730F000B4C16B /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4B3086287730D200B4C16B /* WebKit.framework */; };
 		6B4B77D227C64F6000F4E878 /* TestServiceProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B4B77D127C64F6000F4E878 /* TestServiceProvider.m */; };
 		6B871F6127C3913300BCF742 /* TestEmitterConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */; };
 		6B871F6427C3928900BCF742 /* SPMockNetworkConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */; };
@@ -33,6 +44,9 @@
 		6BBDCD4727019AF4001B547F /* SPPlatformContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BBDCD4127019AF4001B547F /* SPPlatformContext.m */; };
 		6BBDCD4827019AF4001B547F /* SPPlatformContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BBDCD4127019AF4001B547F /* SPPlatformContext.m */; };
 		6BBDCD4927019AF4001B547F /* SPPlatformContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BBDCD4127019AF4001B547F /* SPPlatformContext.m */; };
+		6BD6A6A928871262002D6D40 /* TestWebViewMessageHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD6A6A828871262002D6D40 /* TestWebViewMessageHandler.m */; };
+		6BD6A6AC288719C7002D6D40 /* SPMockWKScriptMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD6A6AA288719C7002D6D40 /* SPMockWKScriptMessage.h */; };
+		6BD6A6AD288719C7002D6D40 /* SPMockWKScriptMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD6A6AB288719C7002D6D40 /* SPMockWKScriptMessage.m */; };
 		6BF08DA6270DEED6009C7E2B /* SPDeviceInfoMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BF08DA4270DEED6009C7E2B /* SPDeviceInfoMonitor.h */; };
 		6BF08DA7270DEED6009C7E2B /* SPDeviceInfoMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BF08DA4270DEED6009C7E2B /* SPDeviceInfoMonitor.h */; };
 		6BF08DA8270DEED6009C7E2B /* SPDeviceInfoMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BF08DA4270DEED6009C7E2B /* SPDeviceInfoMonitor.h */; };
@@ -934,6 +948,10 @@
 		0485CA141BAC658500214BC5 /* SPSelfDescribingJson.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPSelfDescribingJson.h; sourceTree = "<group>"; };
 		0485CA151BAC65A300214BC5 /* SPSelfDescribingJson.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPSelfDescribingJson.m; sourceTree = "<group>"; };
 		049B2BDA1B7A203200BD82FC /* SPRequestCallback.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPRequestCallback.h; sourceTree = "<group>"; };
+		6B07CDAB287721C600E510D6 /* SPWebViewMessageHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPWebViewMessageHandler.h; sourceTree = "<group>"; };
+		6B07CDAC287721C600E510D6 /* SPWebViewMessageHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPWebViewMessageHandler.m; sourceTree = "<group>"; };
+		6B4B3086287730D200B4C16B /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/System/iOSSupport/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
+		6B4B3088287730E000B4C16B /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
 		6B4B77D127C64F6000F4E878 /* TestServiceProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestServiceProvider.m; sourceTree = SOURCE_ROOT; };
 		6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestEmitterConfiguration.m; sourceTree = "<group>"; };
 		6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockNetworkConnection.h; sourceTree = "<group>"; };
@@ -941,6 +959,9 @@
 		6BACDF912897C2580013276E /* SPConfigurationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPConfigurationState.h; sourceTree = "<group>"; };
 		6BBDCD4027019AF4001B547F /* SPPlatformContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPPlatformContext.h; path = Snowplow/Internal/Subject/SPPlatformContext.h; sourceTree = SOURCE_ROOT; };
 		6BBDCD4127019AF4001B547F /* SPPlatformContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPPlatformContext.m; path = Snowplow/Internal/Subject/SPPlatformContext.m; sourceTree = SOURCE_ROOT; };
+		6BD6A6A828871262002D6D40 /* TestWebViewMessageHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestWebViewMessageHandler.m; sourceTree = "<group>"; };
+		6BD6A6AA288719C7002D6D40 /* SPMockWKScriptMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockWKScriptMessage.h; sourceTree = "<group>"; };
+		6BD6A6AB288719C7002D6D40 /* SPMockWKScriptMessage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMockWKScriptMessage.m; sourceTree = "<group>"; };
 		6BF08DA4270DEED6009C7E2B /* SPDeviceInfoMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDeviceInfoMonitor.h; sourceTree = "<group>"; };
 		6BF08DA5270DEED6009C7E2B /* SPDeviceInfoMonitor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPDeviceInfoMonitor.m; sourceTree = "<group>"; };
 		6BF08DAE270DF2E8009C7E2B /* SPMockDeviceInfoMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockDeviceInfoMonitor.h; sourceTree = "<group>"; };
@@ -1193,6 +1214,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B4B3087287730D200B4C16B /* WebKit.framework in Frameworks */,
 				752DAC4021CC4A830065F874 /* UIKit.framework in Frameworks */,
 				752DAC3F21CC4A7B0065F874 /* CoreTelephony.framework in Frameworks */,
 			);
@@ -1202,6 +1224,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B4B308A287730F000B4C16B /* WebKit.framework in Frameworks */,
 				ED26E6BA23842AB00096AF7C /* AdSupport.framework in Frameworks */,
 				23DFEC832362FAF800BD19C4 /* VVJSONSchemaValidation.framework in Frameworks */,
 				23DFEC822362FAED00BD19C4 /* SnowplowIgluClient.framework in Frameworks */,
@@ -1225,6 +1248,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B4B3089287730E000B4C16B /* WebKit.framework in Frameworks */,
 				23DFEC7E2362FAB100BD19C4 /* FMDB.framework in Frameworks */,
 				753DDA6D21F803B10007C3AE /* Cocoa.framework in Frameworks */,
 				75CAC45621F2A1CC00271FB3 /* Foundation.framework in Frameworks */,
@@ -1282,6 +1306,7 @@
 				6BF15D0B2702ECD70048F376 /* TestPlatformContext.m */,
 				6BF15D1227035A480048F376 /* TestSubject.m */,
 				6B4B77D127C64F6000F4E878 /* TestServiceProvider.m */,
+				6BD6A6A828871262002D6D40 /* TestWebViewMessageHandler.m */,
 			);
 			path = "Snowplow iOSTests";
 			sourceTree = "<group>";
@@ -1338,6 +1363,8 @@
 		AB0C27BF191B408200018557 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6B4B3086287730D200B4C16B /* WebKit.framework */,
+				6B4B3088287730E000B4C16B /* WebKit.framework */,
 				ED26E6B923842AAF0096AF7C /* AdSupport.framework */,
 				753DDA6C21F803B10007C3AE /* Cocoa.framework */,
 				75CAC3C021F2930100271FB3 /* VVJSONSchemaValidation.framework */,
@@ -1472,6 +1499,8 @@
 				6BF08DAF270DF2E8009C7E2B /* SPMockDeviceInfoMonitor.m */,
 				6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */,
 				6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */,
+				6BD6A6AA288719C7002D6D40 /* SPMockWKScriptMessage.h */,
+				6BD6A6AB288719C7002D6D40 /* SPMockWKScriptMessage.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1626,6 +1655,8 @@
 				ED38D92A26EBCEBE002AEC8E /* SPLifecycleState.m */,
 				ED38D92926EBCEBE002AEC8E /* SPLifecycleStateMachine.h */,
 				ED38D92826EBCEBE002AEC8E /* SPLifecycleStateMachine.m */,
+				6B07CDAB287721C600E510D6 /* SPWebViewMessageHandler.h */,
+				6B07CDAC287721C600E510D6 /* SPWebViewMessageHandler.m */,
 			);
 			path = Tracker;
 			sourceTree = "<group>";
@@ -1775,6 +1806,7 @@
 				EDB693FA26B7F61D00B76A79 /* SPMemoryEventStore.h in Headers */,
 				CE4F9D02244B066500968CFC /* SPEcommerceItem.h in Headers */,
 				EDD8541624EEC25100661F6B /* SPEmitterEvent.h in Headers */,
+				6B07CDAD287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */,
 				752DAC3221CC43C60065F874 /* SPTrackerConstants.h in Headers */,
 				ED87A3EB25766BB4000C54EB /* SPSessionControllerImpl.h in Headers */,
 				ED8866BE25711EC000DB53BB /* SPLoggerDelegate.h in Headers */,
@@ -1872,6 +1904,7 @@
 				ED9081B52703747C00EE9421 /* SPMessageNotification.h in Headers */,
 				EDD8540C24EE786900661F6B /* SPEventStore.h in Headers */,
 				CE4F9CAE244B066500968CFC /* SPConsentWithdrawn.h in Headers */,
+				6BD6A6AC288719C7002D6D40 /* SPMockWKScriptMessage.h in Headers */,
 				EDAB666026D6ACCB0067755F /* SPDeepLinkState.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1926,6 +1959,7 @@
 				CE4F9CCB244B066500968CFC /* SPGlobalContext.h in Headers */,
 				CE4F9CE3244B066500968CFC /* SPConsentGranted.h in Headers */,
 				EDDD701C264F230400259404 /* SPSubjectConfigurationUpdate.h in Headers */,
+				6B07CDAE287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */,
 				CE4F9CE7244B066500968CFC /* SPPushNotification.h in Headers */,
 				EDDD7008264E8ECE00259404 /* SPServiceProviderProtocol.h in Headers */,
 				CE4F9CA7244B066500968CFC /* SPTiming.h in Headers */,
@@ -2103,6 +2137,7 @@
 				6BBDCD4427019AF4001B547F /* SPPlatformContext.h in Headers */,
 				EDDD7009264E8ECE00259404 /* SPServiceProviderProtocol.h in Headers */,
 				ED8A3EED2371709100E51827 /* SPInstallTracker.h in Headers */,
+				6B07CDAF287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */,
 				ED8122AC25E9578600AE7FE8 /* SPSnowplow.h in Headers */,
 				ED88B591257922490048FAD1 /* SPEmitterController.h in Headers */,
 				75CAC43521F2A0CC00271FB3 /* SPWeakTimerTarget.h in Headers */,
@@ -2129,6 +2164,7 @@
 				EDB693FD26B7F61D00B76A79 /* SPMemoryEventStore.h in Headers */,
 				CE4F9D05244B066500968CFC /* SPEcommerceItem.h in Headers */,
 				EDD8541924EEC25100661F6B /* SPEmitterEvent.h in Headers */,
+				6B07CDB0287721C600E510D6 /* SPWebViewMessageHandler.h in Headers */,
 				75F9C5E521FA35BC00A5B8FC /* Snowplow-umbrella-header.h in Headers */,
 				ED87A3EE25766BB4000C54EB /* SPSessionControllerImpl.h in Headers */,
 				ED8866C125711EC000DB53BB /* SPLoggerDelegate.h in Headers */,
@@ -2541,6 +2577,7 @@
 				ED98972A26287F7A00145157 /* SPConfigurationCache.m in Sources */,
 				ED88B5AB25792C620048FAD1 /* SPEmitterControllerImpl.m in Sources */,
 				CE4F9CC6244B066500968CFC /* SPSchemaRuleset.m in Sources */,
+				6B07CDB1287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */,
 				EDDD7047264F2A8800259404 /* SPEmitterConfigurationUpdate.m in Sources */,
 				754774D0222756470043B814 /* UIViewController+SPScreenView_SWIZZLE.m in Sources */,
 				CE4F9CDA244B066500968CFC /* SPPageView.m in Sources */,
@@ -2572,6 +2609,7 @@
 				ED8BF8B725700B40001DFDD9 /* SPTrackerConfiguration.m in Sources */,
 				ED7F082E2619199D005D377E /* SPRemoteConfiguration.m in Sources */,
 				EDEE835E24BE0944000B8530 /* SPLogger.m in Sources */,
+				6BD6A6AD288719C7002D6D40 /* SPMockWKScriptMessage.m in Sources */,
 				ED88B56D2578F8820048FAD1 /* SPEmitterConfiguration.m in Sources */,
 				ED88B5E3257950210048FAD1 /* SPGDPRConfiguration.m in Sources */,
 				6BBDCD4627019AF4001B547F /* SPPlatformContext.m in Sources */,
@@ -2645,6 +2683,7 @@
 				75CAC40621F2955100271FB3 /* TestSQLiteEventStore.m in Sources */,
 				ED914EB72432081F0068DA0A /* TestSchemaRuleset.m in Sources */,
 				6B4B77D227C64F6000F4E878 /* TestServiceProvider.m in Sources */,
+				6BD6A6A928871262002D6D40 /* TestWebViewMessageHandler.m in Sources */,
 				75CAC41121F2955100271FB3 /* LegacyTestTracker.m in Sources */,
 				75CAC40D21F2955100271FB3 /* LegacyTestEmitter.m in Sources */,
 				75CAC40721F2955100271FB3 /* TestPayload.m in Sources */,
@@ -2739,6 +2778,7 @@
 				75CAC44021F2A17500271FB3 /* SPSelfDescribingJson.m in Sources */,
 				CE4F9CCF244B066500968CFC /* SNOWError.m in Sources */,
 				CE4F9C87244B066500968CFC /* SPTiming.m in Sources */,
+				6B07CDB2287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */,
 				ED49DF412757E4F500610843 /* SPSessionState.m in Sources */,
 				CE4F9D1F244B066500968CFC /* SPEcommerce.m in Sources */,
 				EDDD703E264F27E700259404 /* SPNetworkConfigurationUpdate.m in Sources */,
@@ -2837,6 +2877,7 @@
 				75CAC44C21F2A19500271FB3 /* SPSession.m in Sources */,
 				CE4F9CD0244B066500968CFC /* SNOWError.m in Sources */,
 				CE4F9C88244B066500968CFC /* SPTiming.m in Sources */,
+				6B07CDB3287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */,
 				ED49DF422757E4F500610843 /* SPSessionState.m in Sources */,
 				CE4F9D20244B066500968CFC /* SPEcommerce.m in Sources */,
 				EDDD703F264F27E700259404 /* SPNetworkConfigurationUpdate.m in Sources */,
@@ -2943,6 +2984,7 @@
 				75F9C5DA21FA357100A5B8FC /* SPSession.m in Sources */,
 				CE4F9CD1244B066500968CFC /* SNOWError.m in Sources */,
 				75F9C5DB21FA357100A5B8FC /* SPPayload.m in Sources */,
+				6B07CDB4287721C600E510D6 /* SPWebViewMessageHandler.m in Sources */,
 				ED49DF432757E4F500610843 /* SPSessionState.m in Sources */,
 				CE4F9CF1244B066500968CFC /* SPSchemaRule.m in Sources */,
 				EDDD7040264F27E700259404 /* SPNetworkConfigurationUpdate.m in Sources */,

--- a/Snowplow/Internal/SPSnowplow.h
+++ b/Snowplow/Internal/SPSnowplow.h
@@ -27,6 +27,10 @@
 #import "SPConfigurationBundle.h"
 #import "SPConfigurationState.h"
 
+#if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_OSX
+@import WebKit;
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -214,6 +218,16 @@ NS_SWIFT_NAME(Snowplow)
  * @return Set of namespace of the active trackers in the app.
  */
 + (NSArray<NSString *> *)instancedTrackerNamespaces;
+
+#if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_OSX
+
+/**
+ * Subscribe to events tracked in a Web view using the Snowplow WebView tracker JavaScript library.
+ * @param webViewConfiguration Configuration of the Web view to subscribe to events from
+ */
++ (void)subscribeToWebViewEventsWithConfiguration:(WKWebViewConfiguration *)webViewConfiguration;
+
+#endif
 
 @end
 

--- a/Snowplow/Internal/SPSnowplow.m
+++ b/Snowplow/Internal/SPSnowplow.m
@@ -22,6 +22,7 @@
 #import "SPSnowplow.h"
 #import "SPServiceProvider.h"
 #import "SPConfigurationProvider.h"
+#import "SPWebViewMessageHandler.h"
 
 @interface SPSnowplow ()
 
@@ -163,6 +164,16 @@
     }
     return namespaces;
 }
+
+#if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_OSX
+
++ (void)subscribeToWebViewEventsWithConfiguration:(WKWebViewConfiguration *)webViewConfiguration {
+    SPWebViewMessageHandler *messageHandler = [[SPWebViewMessageHandler alloc] init];
+    
+    [webViewConfiguration.userContentController addScriptMessageHandler:messageHandler name:@"snowplow"];
+}
+
+#endif
 
 // Global singleton
 

--- a/Snowplow/Internal/Tracker/SPWebViewMessageHandler.h
+++ b/Snowplow/Internal/Tracker/SPWebViewMessageHandler.h
@@ -1,5 +1,5 @@
 //
-//  SPMockNetworkConnection.h
+//  SPWebViewMessageHandler.h
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -15,26 +15,28 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Authors: Alex Benini, Matus Tomlein
+//  Authors: Matus Tomlein
 //  License: Apache License Version 2.0
 //
 
 #import <Foundation/Foundation.h>
-#import "SPEmitter.h"
+
+#import "SPTrackerConstants.h"
+
+#if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_OSX
+@import WebKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SPMockNetworkConnection : NSObject <SPNetworkConnection>
-
-- (instancetype)initWithRequestOption:(SPHttpMethod)httpMethod statusCode:(NSInteger)statusCode;
-
-@property (nonatomic) NSInteger statusCode;
-@property (nonatomic) SPHttpMethod httpMethod;
-@property (nonatomic) NSMutableArray<NSMutableArray<SPRequestResult *> *> *previousResults;
-@property (nonatomic) NSMutableArray<NSArray<SPRequest *> *> *previousRequests;
-@property (nonatomic) NSUInteger sendingCount;
+/**
+ * Handler for messages from the JavaScript library embedded in Web views.
+ *
+ * The handler parses messages from the JavaScript library calls and forwards the tracked events to be tracked by the mobile tracker.
+ */
+@interface SPWebViewMessageHandler : NSObject <WKScriptMessageHandler>
 
 @end
 
-
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Snowplow/Internal/Tracker/SPWebViewMessageHandler.m
+++ b/Snowplow/Internal/Tracker/SPWebViewMessageHandler.m
@@ -1,0 +1,152 @@
+//
+//  SPWebViewMessageHandler.m
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Matus Tomlein
+//  License: Apache License Version 2.0
+//
+
+#import "SPWebViewMessageHandler.h"
+#import "SPSnowplow.h"
+#import "SPSelfDescribing.h"
+#import "SPStructured.h"
+#import "SPPageView.h"
+#import "SPScreenView.h"
+
+#if SNOWPLOW_TARGET_IOS || SNOWPLOW_TARGET_OSX
+
+@implementation SPWebViewMessageHandler
+
+/**
+ * Callback called when the message handler receives a new message.
+ *
+ * The message dictionary should contain three properties:
+ * 1. "event" with a dictionary containing the event information (structure depends on the tracked event)
+ * 2. "context" (optional) with a list of self-describing JSONs
+ * 3. "trackers" (optional) with a list of tracker namespaces to track the event with
+ */
+- (void)userContentController:(WKUserContentController *)userContentController
+      didReceiveScriptMessage:(WKScriptMessage *)message {
+    NSDictionary *event = message.body[@"event"];
+    NSArray *context = message.body[@"context"];
+    NSArray *trackers = message.body[@"trackers"];
+
+    if ([message.body[@"command"] isEqual:@"trackSelfDescribingEvent"]) {
+        [self trackSelfDescribing:event withContext:context andTrackers:trackers];
+    } else if ([message.body[@"command"] isEqual: @"trackStructEvent"]) {
+        [self trackStructEvent:event withContext:context andTrackers:trackers];
+    } else if ([message.body[@"command"] isEqual: @"trackPageView"]) {
+        [self trackPageView:event withContext:context andTrackers:trackers];
+    } else if ([message.body[@"command"] isEqual: @"trackScreenView"]) {
+        [self trackScreenView:event withContext:context andTrackers:trackers];
+    }
+}
+
+- (void)trackSelfDescribing:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+    NSString *schema = [event objectForKey:@"schema"];
+    NSDictionary *payload = [event objectForKey:@"data"];
+    
+    if (schema && payload) {
+        SPSelfDescribing *selfDescribing = [[SPSelfDescribing alloc] initWithSchema:schema payload:payload];
+        [self track:selfDescribing withContext:context andTrackers:trackers];
+    }
+}
+
+- (void)trackStructEvent:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+    NSString *category = [event objectForKey:@"category"];
+    NSString *action = [event objectForKey:@"action"];
+    NSString *label = [event objectForKey:@"label"];
+    NSString *property = [event objectForKey:@"property"];
+    NSNumber *value = [event objectForKey:@"value"];
+    
+    if (category && action) {
+        SPStructured *structured = [[SPStructured alloc] initWithCategory:category action:action];
+        if (label) { structured.label = label; }
+        if (property) { structured.property = property; }
+        if (value) { structured.value = value; }
+        [self track:structured withContext:context andTrackers:trackers];
+    }
+}
+
+- (void)trackPageView:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+    NSString *url = [event objectForKey:@"url"];
+    NSString *title = [event objectForKey:@"title"];
+    NSString *referrer = [event objectForKey:@"referrer"];
+    
+    if (url) {
+        SPPageView *pageView = [[SPPageView alloc] initWithPageUrl:url];
+        if (title) { pageView.pageTitle = title; }
+        if (referrer) { pageView.referrer = referrer; }
+        [self track:pageView withContext:context andTrackers:trackers];
+    }
+}
+
+- (void)trackScreenView:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+    NSString *name = [event objectForKey:@"name"];
+    NSString *screenId = [event objectForKey:@"id"];
+    NSString *type = [event objectForKey:@"type"];
+    NSString *previousName = [event objectForKey:@"previousName"];
+    NSString *previousId = [event objectForKey:@"previousId"];
+    NSString *previousType = [event objectForKey:@"previousType"];
+    NSString *transitionType = [event objectForKey:@"transitionType"];
+    
+    if (name && screenId) {
+        NSUUID *screenUuid = [[NSUUID alloc] initWithUUIDString:screenId];
+        SPScreenView *screenView = [[SPScreenView alloc] initWithName:name screenId:screenUuid];
+        if (type) { screenView.type = type; }
+        if (previousName) { screenView.previousName = previousName; }
+        if (previousId) { screenView.previousId = previousId; }
+        if (previousType) { screenView.previousType = previousType; }
+        if (transitionType) { screenView.transitionType = transitionType; }
+        [self track:screenView withContext:context andTrackers:trackers];
+    }
+}
+
+- (void)track:(SPEvent *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+    if (context) {
+        [event setContexts:[self parseContext:context]];
+    }
+    if (trackers && [trackers count] > 0) {
+        for (NSString *namespace in trackers) {
+            id tracker = [SPSnowplow trackerByNamespace:namespace];
+            if (tracker) {
+                [tracker track:event];
+            }
+        }
+    } else {
+        [[SPSnowplow defaultTracker] track:event];
+    }
+}
+
+- (NSMutableArray<SPSelfDescribingJson *> *) parseContext:(NSArray *)context {
+    NSMutableArray<SPSelfDescribingJson *> *contextEntities = [[NSMutableArray alloc] init];
+
+    for (id entityJson in context) {
+        NSString *schema = [entityJson objectForKey:@"schema"];
+        NSDictionary *payload = [entityJson objectForKey:@"data"];
+        
+        if (schema && payload) {
+            SPSelfDescribingJson *entity = [[SPSelfDescribingJson alloc] initWithSchema:schema andData:payload];
+            [contextEntities addObject:entity];
+        }
+    }
+    
+    return contextEntities;
+}
+
+@end
+
+#endif

--- a/Snowplow/Internal/Tracker/SPWebViewMessageHandler.m
+++ b/Snowplow/Internal/Tracker/SPWebViewMessageHandler.m
@@ -41,21 +41,22 @@
 - (void)userContentController:(WKUserContentController *)userContentController
       didReceiveScriptMessage:(WKScriptMessage *)message {
     NSDictionary *event = message.body[@"event"];
-    NSArray *context = message.body[@"context"];
-    NSArray *trackers = message.body[@"trackers"];
+    NSArray<NSDictionary *> *context = message.body[@"context"];
+    NSArray<NSString *> *trackers = message.body[@"trackers"];
+    NSString *command = message.body[@"command"];
 
-    if ([message.body[@"command"] isEqual:@"trackSelfDescribingEvent"]) {
+    if ([command isEqual:@"trackSelfDescribingEvent"]) {
         [self trackSelfDescribing:event withContext:context andTrackers:trackers];
-    } else if ([message.body[@"command"] isEqual: @"trackStructEvent"]) {
+    } else if ([command isEqual: @"trackStructEvent"]) {
         [self trackStructEvent:event withContext:context andTrackers:trackers];
-    } else if ([message.body[@"command"] isEqual: @"trackPageView"]) {
+    } else if ([command isEqual: @"trackPageView"]) {
         [self trackPageView:event withContext:context andTrackers:trackers];
-    } else if ([message.body[@"command"] isEqual: @"trackScreenView"]) {
+    } else if ([command isEqual: @"trackScreenView"]) {
         [self trackScreenView:event withContext:context andTrackers:trackers];
     }
 }
 
-- (void)trackSelfDescribing:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+- (void)trackSelfDescribing:(NSDictionary *)event withContext:(NSArray<NSDictionary *> *)context andTrackers:(NSArray<NSString *> *)trackers {
     NSString *schema = [event objectForKey:@"schema"];
     NSDictionary *payload = [event objectForKey:@"data"];
     
@@ -65,7 +66,7 @@
     }
 }
 
-- (void)trackStructEvent:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+- (void)trackStructEvent:(NSDictionary *)event withContext:(NSArray<NSDictionary *> *)context andTrackers:(NSArray<NSString *> *)trackers {
     NSString *category = [event objectForKey:@"category"];
     NSString *action = [event objectForKey:@"action"];
     NSString *label = [event objectForKey:@"label"];
@@ -81,7 +82,7 @@
     }
 }
 
-- (void)trackPageView:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+- (void)trackPageView:(NSDictionary *)event withContext:(NSArray<NSDictionary *> *)context andTrackers:(NSArray<NSString *> *)trackers {
     NSString *url = [event objectForKey:@"url"];
     NSString *title = [event objectForKey:@"title"];
     NSString *referrer = [event objectForKey:@"referrer"];
@@ -94,7 +95,7 @@
     }
 }
 
-- (void)trackScreenView:(NSDictionary *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+- (void)trackScreenView:(NSDictionary *)event withContext:(NSArray<NSDictionary *> *)context andTrackers:(NSArray<NSString *> *)trackers {
     NSString *name = [event objectForKey:@"name"];
     NSString *screenId = [event objectForKey:@"id"];
     NSString *type = [event objectForKey:@"type"];
@@ -115,13 +116,13 @@
     }
 }
 
-- (void)track:(SPEvent *)event withContext:(NSArray *)context andTrackers:(NSArray *)trackers {
+- (void)track:(SPEvent *)event withContext:(NSArray<NSDictionary *> *)context andTrackers:(NSArray<NSString *> *)trackers {
     if (context) {
         [event setContexts:[self parseContext:context]];
     }
-    if (trackers && [trackers count] > 0) {
+    if (trackers.count > 0) {
         for (NSString *namespace in trackers) {
-            id tracker = [SPSnowplow trackerByNamespace:namespace];
+            id<SPTrackerController> tracker = [SPSnowplow trackerByNamespace:namespace];
             if (tracker) {
                 [tracker track:event];
             }
@@ -131,15 +132,15 @@
     }
 }
 
-- (NSMutableArray<SPSelfDescribingJson *> *) parseContext:(NSArray *)context {
+- (NSMutableArray<SPSelfDescribingJson *> *) parseContext:(NSArray<NSDictionary *> *)context {
     NSMutableArray<SPSelfDescribingJson *> *contextEntities = [[NSMutableArray alloc] init];
 
-    for (id entityJson in context) {
+    for (NSDictionary *entityJson in context) {
         NSString *schema = [entityJson objectForKey:@"schema"];
         NSDictionary *payload = [entityJson objectForKey:@"data"];
         
         if (schema && payload) {
-            SPSelfDescribingJson *entity = [[SPSelfDescribingJson alloc] initWithSchema:schema andData:payload];
+            SPSelfDescribingJson *entity = [[SPSelfDescribingJson alloc] initWithSchema:schema andDictionary:payload];
             [contextEntities addObject:entity];
         }
     }


### PR DESCRIPTION
This PR addresses issue #691 and adds an option to subscribe to events tracked inside web view using the [WebView tracker](https://github.com/snowplow-incubator/snowplow-webview-tracker) ([WebView tracker PR here](https://github.com/snowplow-incubator/snowplow-webview-tracker/pull/3)).

The change is part of the hybrid app tracking solution – this PR enables the iOS tracker to listen for the forwarded events from the WebView tracker.

```mermaid
flowchart TB

subgraph hybridApp[Hybrid Mobile App]

    subgraph webView[Web View]
        webViewCode[App logic]
        webViewTracker[Snowplow WebView tracker]

        webViewCode -- "Tracks events" --> webViewTracker
    end

    subgraph nativeCode[Native Code]
        nativeAppCode[App logic]
        nativeTracker[Snowplow iOS/Android tracker]

        nativeAppCode -- "Tracks events" --> nativeTracker
    end

    webViewTracker -- "Forwards events" --> nativeTracker
end

subgraph cloud[Cloud]
    collector[Snowplow Collector]
end

nativeTracker -- "Sends tracked events" --> collector
```

## Implementation

In order for the tracker to listen to events from the Web view, it was necessary to implement a message handler – `SPWebViewMessageHandler`. The message handler parses messages with tracked events and tracks them using the default or selected trackers (the tracked messages can contain tracker namespaces to use).

The user needs to subscribe the tracker for events from a Web view. This can be done as follows (`webView` is an instance of `WKWebView`):

```swift
Snowplow.subscribeToWebViewEvents(with: webView.configuration)
```

## Documentation

The documentation is common for the whole hybrid tracking setup and written as an accelerator/tutorial [here](https://github.com/snowplow-incubator/snowplow-hybrid-apps-accelerator).

## Example app

I added a new screen to the example app with a URL bar to navigate to a given page and a Web view under that. The Web view is subscribed to by the tracker so events from it are forwarded.

The example app [PR is here](https://github.com/snowplow-incubator/snowplow-objc-tracker-examples/pull/18).

![ios-screenshot](https://user-images.githubusercontent.com/42166/180754618-3e8f79f6-0a01-41c7-9bf8-ddf364e50c5d.png)
