### PR TITLE
Do not resume remote configuration from cache in case it has different endpoint (close #688)

### DIFF
--- a/Snowplow iOSTests/Configurations/TestRemoteConfiguration.m
+++ b/Snowplow iOSTests/Configurations/TestRemoteConfiguration.m
@@ -103,13 +103,15 @@
     expected.configurationVersion = 12;
     expected.configurationBundle = @[bundle];
     
-    SPConfigurationCache *cache = [SPConfigurationCache new];
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:@"http://example.com" method:SPHttpMethodGet];
+    
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     [cache clearCache];
     [cache writeCache:expected];
     
     [NSThread sleepForTimeInterval:5]; // wait the config is written on cache.
     
-    cache = [SPConfigurationCache new];
+    cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     SPFetchedConfigurationBundle *config = [cache readCache];
     
     XCTAssertEqual(expected.configurationVersion, config.configurationVersion);
@@ -124,7 +126,8 @@
 - (void)testConfigurationProvider_notDownloading_fails {
     // prepare test
     NSString *endpoint = @"https://fake-snowplowanalytics.com/config.json";
-    SPConfigurationCache *cache = [SPConfigurationCache new];
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     [cache clearCache];
     [[LSNocilla sharedInstance] start];
     stubRequest(@"GET", endpoint)
@@ -132,7 +135,6 @@
     
     // test
     XCTestExpectation *expectation = [XCTestExpectation new];
-    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
         XCTFail();
@@ -147,7 +149,8 @@
 - (void)testConfigurationProvider_downloadOfWrongSchema_fails {
     // prepare test
     NSString *endpoint = @"https://fake-snowplowanalytics.com/config.json";
-    SPConfigurationCache *cache = [SPConfigurationCache new];
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     [cache clearCache];
     [[LSNocilla sharedInstance] start];
     stubRequest(@"GET", endpoint)
@@ -157,7 +160,6 @@
     
     // test
     XCTestExpectation *expectation = [XCTestExpectation new];
-    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
         XCTFail();
@@ -172,8 +174,9 @@
 - (void)testConfigurationProvider_downloadSameConfigVersionThanCached_dontUpdate {
     // prepare test
     NSString *endpoint = @"https://fake-snowplowanalytics.com/config.json";
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     
-    SPConfigurationCache *cache = [SPConfigurationCache new];
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     [cache clearCache];
     SPConfigurationBundle *bundle = [[SPConfigurationBundle alloc] initWithNamespace:@"namespace" networkConfiguration:[[SPNetworkConfiguration alloc] initWithEndpoint:@"endpoint"]];
     SPFetchedConfigurationBundle *cached = [[SPFetchedConfigurationBundle alloc] init];
@@ -191,7 +194,6 @@
     
     // test
     XCTestExpectation *expectation = [XCTestExpectation new];
-    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     __block int i = 0;
     [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
@@ -213,8 +215,9 @@
 - (void)testConfigurationProvider_downloadHigherConfigVersionThanCached_doUpdate {
     // prepare test
     NSString *endpoint = @"https://fake-snowplowanalytics.com/config.json";
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     
-    SPConfigurationCache *cache = [SPConfigurationCache new];
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     [cache clearCache];
     SPConfigurationBundle *bundle = [[SPConfigurationBundle alloc] initWithNamespace:@"namespace" networkConfiguration:[[SPNetworkConfiguration alloc] initWithEndpoint:@"endpoint"]];
     SPFetchedConfigurationBundle *cached = [[SPFetchedConfigurationBundle alloc] init];
@@ -232,7 +235,6 @@
     
     // test
     XCTestExpectation *expectation = [XCTestExpectation new];
-    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     __block int i = 0;
     [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
@@ -254,8 +256,9 @@
 - (void)testConfigurationProvider_justRefresh_downloadSameConfigVersionThanCached_dontUpdate {
     // prepare test
     NSString *endpoint = @"https://fake-snowplowanalytics.com/config.json";
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     
-    SPConfigurationCache *cache = [SPConfigurationCache new];
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     [cache clearCache];
     SPConfigurationBundle *bundle = [[SPConfigurationBundle alloc] initWithNamespace:@"namespace" networkConfiguration:[[SPNetworkConfiguration alloc] initWithEndpoint:@"endpoint"]];
     SPFetchedConfigurationBundle *cached = [[SPFetchedConfigurationBundle alloc] init];
@@ -265,7 +268,6 @@
     [cache writeCache:cached];
     [NSThread sleepForTimeInterval:5]; // wait to write on cache
     
-    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     XCTestExpectation *expectation = [XCTestExpectation new];
     [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
@@ -291,13 +293,52 @@
     [[LSNocilla sharedInstance] stop];
 }
 
+- (void)testDoesntUseCachedConfigurationIfDifferentRemoteEndpoint {
+    // prepare test
+    NSString *endpoint = @"https://fake-snowplowanalytics.com/config.json";
+    SPRemoteConfiguration *cachedRemoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:@"https://cached-snowplowanalytics.com/config.json" method:SPHttpMethodGet];
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
+    
+    // write configuration (version 2) to cache
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:cachedRemoteConfig];
+    [cache clearCache];
+    SPConfigurationBundle *bundle = [[SPConfigurationBundle alloc] initWithNamespace:@"namespace" networkConfiguration:[[SPNetworkConfiguration alloc] initWithEndpoint:@"endpoint"]];
+    SPFetchedConfigurationBundle *cached = [[SPFetchedConfigurationBundle alloc] init];
+    cached.schema = @"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-0-0";
+    cached.configurationVersion = 2;
+    cached.configurationBundle = @[bundle];
+    [cache writeCache:cached];
+    [NSThread sleepForTimeInterval:5]; // wait to write on cache
+
+    // stub request for configuration (return version 1)
+    [[LSNocilla sharedInstance] start];
+    stubRequest(@"GET", endpoint)
+    .andReturn(200)
+    .withHeaders(@{@"Content-Type": @"application/json"})
+    .withBody(@"{\"$schema\":\"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-1-0\",\"configurationVersion\":1,\"configurationBundle\":[]}");
+
+    // initialize tracker with remote config
+    XCTestExpectation *expectation = [XCTestExpectation new];
+    [[SPConfigurationFetcher alloc] initWithRemoteSource:remoteConfig onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+        XCTAssertNotNil(fetchedConfigurationBundle);
+        // should be the non-cache configuration (version 1)
+        XCTAssertEqualObjects(@"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-1-0", fetchedConfigurationBundle.schema);
+        XCTAssertEqual(1, fetchedConfigurationBundle.configurationVersion);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectations:@[expectation] timeout:10];
+    [[LSNocilla sharedInstance] stop];
+}
+
 // TODO: Replace LSNocilla as it's unreliable and unsupported. It causes this test failure.
 /*
 - (void)testConfigurationProvider_justRefresh_downloadHigherConfigVersionThanCached_doUpdate {
     // prepare test
     NSString *endpoint = @"https://fake-snowplowanalytics.com/config.json";
+    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
 
-    SPConfigurationCache *cache = [SPConfigurationCache new];
+    SPConfigurationCache *cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfig];
     [cache clearCache];
     SPConfigurationBundle *bundle = [[SPConfigurationBundle alloc] init];
     bundle.networkConfiguration = [[SPNetworkConfiguration alloc] initWithEndpoint:@"endpoint"];
@@ -308,7 +349,6 @@
     [cache writeCache:cached];
     [NSThread sleepForTimeInterval:5]; // wait to write on cache
     
-    SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     XCTestExpectation *expectation = [XCTestExpectation new];
     [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {

--- a/Snowplow/Internal/Configurations/SPRemoteConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPRemoteConfiguration.h
@@ -33,12 +33,12 @@ NS_SWIFT_NAME(RemoteConfiguration)
 @interface SPRemoteConfiguration : SPConfiguration
 
 /**
- * URL (without schema/protocol) used to send events to the collector.
+ * URL of the remote configuration.
  */
 @property (nonatomic, nullable, readonly) NSString *endpoint;
 
 /**
- * Method used to send events to the collector.
+ * The method used to send the request.
  */
 @property (nonatomic, readonly) SPHttpMethod method;
 

--- a/Snowplow/Internal/RemoteConfiguration/SPConfigurationCache.h
+++ b/Snowplow/Internal/RemoteConfiguration/SPConfigurationCache.h
@@ -21,11 +21,13 @@
 
 #import <Foundation/Foundation.h>
 #import "SPFetchedConfigurationBundle.h"
+#import "SPRemoteConfiguration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SPConfigurationCache : NSObject
 
+- (instancetype)initWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration;
 - (nullable SPFetchedConfigurationBundle *)readCache;
 - (void)writeCache:(SPFetchedConfigurationBundle *)configuration;
 - (void)clearCache;

--- a/Snowplow/Internal/RemoteConfiguration/SPConfigurationCache.m
+++ b/Snowplow/Internal/RemoteConfiguration/SPConfigurationCache.m
@@ -31,10 +31,10 @@
 
 @implementation SPConfigurationCache
 
-- (instancetype)init {
+- (instancetype)initWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration {
     if (self = [super init]) {
 #if !(TARGET_OS_TV) && !(TARGET_OS_WATCH)
-        [self createCachePath];
+        [self createCachePathWithRemoteConfiguration:remoteConfiguration];
 #endif
     }
     return self;
@@ -131,13 +131,14 @@
     });
 }
 
-- (void)createCachePath {
+- (void)createCachePathWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration {
     NSFileManager *fm = [NSFileManager defaultManager];
     NSURL *url = [fm URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask].lastObject;
     url = [url URLByAppendingPathComponent:@"snowplow-cache"];
     NSError *error = nil;
     [fm createDirectoryAtURL:url withIntermediateDirectories:YES attributes:nil error:&error];
-    url = [url URLByAppendingPathComponent:@"remoteConfig.data" isDirectory:NO];
+    NSString *fileName = [NSString stringWithFormat:@"remoteConfig-%lu.data", (unsigned long)[remoteConfiguration.endpoint hash]];
+    url = [url URLByAppendingPathComponent:fileName isDirectory:NO];
     self.cacheFileUrl = url;
 }
 

--- a/Snowplow/Internal/RemoteConfiguration/SPConfigurationProvider.m
+++ b/Snowplow/Internal/RemoteConfiguration/SPConfigurationProvider.m
@@ -42,7 +42,7 @@
 - (instancetype)initWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration defaultConfigurationBundles:(nullable NSArray<SPConfigurationBundle *> *)defaultBundles {
     if (self = [super init]) {
         self.remoteConfiguration = remoteConfiguration;
-        self.cache = [SPConfigurationCache new];
+        self.cache = [[SPConfigurationCache alloc] initWithRemoteConfiguration:remoteConfiguration];
         if (defaultBundles) {
             SPFetchedConfigurationBundle *bundle = [[SPFetchedConfigurationBundle alloc] init];
             bundle.schema = @"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-0-0";


### PR DESCRIPTION
Addresses issue #688 which goal was to support switching between remote configurations with different endpoints. This was not previously possible because the tracker cached previous configurations and didn't consider the endpoint when using the cache. Thus, if one switched to a new remote configuration with a new endpoint, a cache for the previous one could still be used by the tracker.

The approach that I chose is to add a hash of the remote config endpoint URL into the cache file name. So instead of `.../snowplow-cache/remoteConfig.data`, the cache files are now called `.../snowplow-cache/remoteConfig-12498219.data` where the number (12498219) is the hashcode of the URL. I make use of the NSString hash function which is not the most reliable hash but I think it's sufficient for this purpose.