### PR TITLE
Upgrade deprecated macOS and XCode versions in Github actions (close #696)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {ios: 14.4, iphone: iPhone 11, watchos: 7.2, watch: Apple Watch Series 5 - 44mm, macos: '10.15', xcode: 12.4}
-          - {ios: 12.4, iphone: iPhone 5s, watchos: 5.3, watch: Apple Watch Series 2 - 38mm, macos: 10.15, xcode: 10.3}
+          - {ios: 15.5, iphone: iPhone 12 Pro, watchos: 8.5, watch: Apple Watch Series 5 - 44mm, macos: '12', xcode: 13.4}
+          - {ios: 14.4, iphone: iPhone 8, watchos: 7.2, watch: Apple Watch Series 4 - 40mm, macos: '11', xcode: 12.4}
 
     steps:
       - name: Checkout
@@ -41,8 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {ios: '14.4', iphone: iPhone 11, watchos: '7.2', watch: Apple Watch Series 5 - 44mm, macos: '10.15', xcode: 12.4}
-          - {ios: 12.4, iphone: iPhone 5s, watchos: 5.3, watch: Apple Watch Series 2 - 38mm, macos: 10.15, xcode: 10.3}
+          - {ios: 15.5, iphone: iPhone 12 Pro, watchos: 8.5, watch: Apple Watch Series 5 - 44mm, macos: '12', xcode: 13.4}
+          - {ios: 14.4, iphone: iPhone 8, watchos: 7.2, watch: Apple Watch Series 4 - 40mm, macos: '11', xcode: 12.4}
 
     steps:
       - name: Checkout
@@ -83,8 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {ios: '14.4', iphone: iPhone 11, watchos: '7.2', watch: Apple Watch Series 5 - 44mm, macos: '10.15', xcode: 12.4}
-          #- {ios: 12.4, iphone: iPhone 5s, watchos: 5.3, watch: Apple Watch Series 2 - 38mm, macos: 10.15, xcode: 10.3}
+          - {ios: '14.4', iphone: iPhone 11, watchos: '7.2', watch: Apple Watch Series 5 - 44mm, macos: '11', xcode: 12.4}
 
     steps:
       - name: Checkout
@@ -132,8 +131,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {ios: '14.4', iphone: iPhone 12 Pro, watchos: '7.2', watch: Apple Watch Series 5 - 44mm, macos: '10.15', xcode: 12.4}
-          #- {ios: 12.4, iphone: iPhone Xs Max, watchos: 5.3, watch: Apple Watch Series 2 - 38mm, macos: 10.15, xcode: 10.3}
+          - {ios: '14.4', iphone: iPhone 12 Pro, watchos: '7.2', watch: Apple Watch Series 5 - 44mm, macos: '11', xcode: 12.4}
         podfile:
           - {file: Podfile, type: "no directive"}
           - {file: Podfile_frameworks, type: "use_frameworks! directive"}
@@ -178,7 +176,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {ios: '14.4', iphone: iPhone 11 Pro, watchos: '7.2', watch: Apple Watch Series 5 - 44mm, macos: '10.15', xcode: 12.4}
+          - {ios: '14.4', iphone: iPhone 11 Pro, watchos: '7.2', watch: Apple Watch Series 5 - 44mm, macos: '11', xcode: 12.4}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Github deprecated macos 10.15 for use in Github actions so I had to bump a few platform versions in the build. iOS 12.4 is also no longer available. I tried iOS 13 but there were issues with build using Carthage that I wasn't able to fix. Ended up with iOS 14.4 and added also 15.5 into the test builds.

| Previously | Now |
|---|---|
| {ios: 14.4, iphone: iPhone 11, watchos: 7.2, watch: Apple Watch Series 5 - 44mm, macos: '10.15', xcode: 12.4} | {ios: 15.5, iphone: iPhone 12 Pro, watchos: 8.5, watch: Apple Watch Series 5 - 44mm, macos: '12', xcode: 13.4} |
| {ios: 12.4, iphone: iPhone 5s, watchos: 5.3, watch: Apple Watch Series 2 - 38mm, macos: 10.15, xcode: 10.3} | {ios: 14.4, iphone: iPhone 8, watchos: 7.2, watch: Apple Watch Series 4 - 40mm, macos: '11', xcode: 12.4} |