### PR TITLE
Extend the onSuccess callback when setting up remote configuration to pass configuration state (close #694)

### DIFF
--- a/Snowplow iOSTests/Configurations/TestRemoteConfiguration.m
+++ b/Snowplow iOSTests/Configurations/TestRemoteConfiguration.m
@@ -86,9 +86,10 @@
     XCTestExpectation *expectation = [XCTestExpectation new];
 
     SPRemoteConfiguration *remoteConfig = [[SPRemoteConfiguration alloc] initWithEndpoint:endpoint method:SPHttpMethodGet];
-    [[SPConfigurationFetcher alloc] initWithRemoteSource:remoteConfig onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [[SPConfigurationFetcher alloc] initWithRemoteSource:remoteConfig onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
         XCTAssertNotNil(fetchedConfigurationBundle);
         XCTAssertEqualObjects(@"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-0-0", fetchedConfigurationBundle.schema);
+        XCTAssertEqual(SPConfigurationStateFetched, configurationState);
         [expectation fulfill];
     }];
 
@@ -136,7 +137,7 @@
     // test
     XCTestExpectation *expectation = [XCTestExpectation new];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
-    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
         XCTFail();
     }];
     XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:5];
@@ -161,7 +162,7 @@
     // test
     XCTestExpectation *expectation = [XCTestExpectation new];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
-    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
         XCTFail();
     }];
     XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:5];
@@ -196,7 +197,8 @@
     XCTestExpectation *expectation = [XCTestExpectation new];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     __block int i = 0;
-    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
+        XCTAssertEqual(SPConfigurationStateCached, configurationState);
         if (i == 1 || [fetchedConfigurationBundle.schema isEqualToString:@"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-1-0"]) {
             XCTFail();
         }
@@ -237,7 +239,9 @@
     XCTestExpectation *expectation = [XCTestExpectation new];
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     __block int i = 0;
-    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
+        XCTAssertEqual(i == 0 ? SPConfigurationStateCached : SPConfigurationStateFetched,
+                       configurationState);
         if (i == 1 && [fetchedConfigurationBundle.schema isEqualToString:@"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-1-0"]) {
             i++;
         }
@@ -270,7 +274,8 @@
     
     SPConfigurationProvider *provider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfig];
     XCTestExpectation *expectation = [XCTestExpectation new];
-    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [provider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
+        XCTAssertEqual(SPConfigurationStateCached, configurationState);
         [expectation fulfill];
     }];
     [self waitForExpectations:@[expectation] timeout:5];
@@ -283,7 +288,7 @@
     
     // test
     expectation = [XCTestExpectation new];
-    [provider retrieveConfigurationOnlyRemote:YES onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [provider retrieveConfigurationOnlyRemote:YES onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
         XCTFail();
     }];
     XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:5];
@@ -319,7 +324,7 @@
 
     // initialize tracker with remote config
     XCTestExpectation *expectation = [XCTestExpectation new];
-    [[SPConfigurationFetcher alloc] initWithRemoteSource:remoteConfig onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [[SPConfigurationFetcher alloc] initWithRemoteSource:remoteConfig onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
         XCTAssertNotNil(fetchedConfigurationBundle);
         // should be the non-cache configuration (version 1)
         XCTAssertEqualObjects(@"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-1-0", fetchedConfigurationBundle.schema);

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		6B871F6827C3976C00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
 		6B871F6927C3976D00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
 		6BABC50E270B40450043BB5C /* TestSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BF15D1227035A480048F376 /* TestSubject.m */; };
+		6BACDF922897C2580013276E /* SPConfigurationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BACDF912897C2580013276E /* SPConfigurationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BACDF932897C2580013276E /* SPConfigurationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BACDF912897C2580013276E /* SPConfigurationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BACDF942897C2580013276E /* SPConfigurationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BACDF912897C2580013276E /* SPConfigurationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BACDF952897C2630013276E /* SPConfigurationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BACDF912897C2580013276E /* SPConfigurationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6BBDCD4227019AF4001B547F /* SPPlatformContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BBDCD4027019AF4001B547F /* SPPlatformContext.h */; };
 		6BBDCD4327019AF4001B547F /* SPPlatformContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BBDCD4027019AF4001B547F /* SPPlatformContext.h */; };
 		6BBDCD4427019AF4001B547F /* SPPlatformContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BBDCD4027019AF4001B547F /* SPPlatformContext.h */; };
@@ -934,6 +938,7 @@
 		6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestEmitterConfiguration.m; sourceTree = "<group>"; };
 		6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockNetworkConnection.h; sourceTree = "<group>"; };
 		6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMockNetworkConnection.m; sourceTree = "<group>"; };
+		6BACDF912897C2580013276E /* SPConfigurationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPConfigurationState.h; sourceTree = "<group>"; };
 		6BBDCD4027019AF4001B547F /* SPPlatformContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPPlatformContext.h; path = Snowplow/Internal/Subject/SPPlatformContext.h; sourceTree = SOURCE_ROOT; };
 		6BBDCD4127019AF4001B547F /* SPPlatformContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPPlatformContext.m; path = Snowplow/Internal/Subject/SPPlatformContext.m; sourceTree = SOURCE_ROOT; };
 		6BF08DA4270DEED6009C7E2B /* SPDeviceInfoMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPDeviceInfoMonitor.h; sourceTree = "<group>"; };
@@ -1380,6 +1385,7 @@
 				ED277BE12625F5C5002C7B6D /* SPFetchedConfigurationBundle.m */,
 				ED98972426287F7900145157 /* SPConfigurationCache.h */,
 				ED98972526287F7900145157 /* SPConfigurationCache.m */,
+				6BACDF912897C2580013276E /* SPConfigurationState.h */,
 			);
 			path = RemoteConfiguration;
 			sourceTree = "<group>";
@@ -1827,6 +1833,7 @@
 				75264A30224E5DBC000E0E9B /* SPInstallTracker.h in Headers */,
 				ED88B6DB2583DFC80048FAD1 /* SPServiceProvider.h in Headers */,
 				EDDD7039264F27E700259404 /* SPNetworkConfigurationUpdate.h in Headers */,
+				6BACDF922897C2580013276E /* SPConfigurationState.h in Headers */,
 				ED38D92B26EBCEBE002AEC8E /* SPLifecycleState.h in Headers */,
 				ED8866E22571445300DB53BB /* SPSubjectConfiguration.h in Headers */,
 				ED7CE17D26DFC12C0035C323 /* SPState.h in Headers */,
@@ -1959,6 +1966,7 @@
 				CE4F9CBF244B066500968CFC /* SPForeground.h in Headers */,
 				ED88B56A2578F8820048FAD1 /* SPEmitterConfiguration.h in Headers */,
 				CE4F9CF3244B066500968CFC /* SPStructured.h in Headers */,
+				6BACDF932897C2580013276E /* SPConfigurationState.h in Headers */,
 				ED9897172627006F00145157 /* NSDictionary+SP_TypeMethods.h in Headers */,
 				EDD8542124EFEFB900661F6B /* SPDefaultNetworkConnection.h in Headers */,
 				ED34672B26415C1D0018BA61 /* SPJSONSerialization.h in Headers */,
@@ -2044,6 +2052,7 @@
 				EDF2A1BC264032F9009032AB /* SPSubjectControllerImpl.h in Headers */,
 				ED88B5E1257950210048FAD1 /* SPGDPRConfiguration.h in Headers */,
 				CE4F9D14244B066500968CFC /* SPBackground.h in Headers */,
+				6BACDF942897C2580013276E /* SPConfigurationState.h in Headers */,
 				ED98972826287F7A00145157 /* SPConfigurationCache.h in Headers */,
 				ED7F082C2619199D005D377E /* SPRemoteConfiguration.h in Headers */,
 				EDDD6FFF264E873B00259404 /* SPController.h in Headers */,
@@ -2178,6 +2187,7 @@
 				ED88B6DE2583DFC90048FAD1 /* SPServiceProvider.h in Headers */,
 				ED8866E52571445300DB53BB /* SPSubjectConfiguration.h in Headers */,
 				EDDD703C264F27E700259404 /* SPNetworkConfigurationUpdate.h in Headers */,
+				6BACDF952897C2630013276E /* SPConfigurationState.h in Headers */,
 				ED38D92E26EBCEBE002AEC8E /* SPLifecycleState.h in Headers */,
 				CE4F9CCD244B066500968CFC /* SPGlobalContext.h in Headers */,
 				ED7CE18026DFC12C0035C323 /* SPState.h in Headers */,

--- a/Snowplow/Internal/RemoteConfiguration/SPConfigurationFetcher.m
+++ b/Snowplow/Internal/RemoteConfiguration/SPConfigurationFetcher.m
@@ -66,7 +66,7 @@
     }
     SPFetchedConfigurationBundle *fetchedConfigurationBundle = [[SPFetchedConfigurationBundle alloc] initWithDictionary:(NSDictionary *)jsonObject];
     if (fetchedConfigurationBundle) {
-        self.onFetchCallback(fetchedConfigurationBundle);
+        self.onFetchCallback(fetchedConfigurationBundle, SPConfigurationStateFetched);
     }
 }
 

--- a/Snowplow/Internal/RemoteConfiguration/SPConfigurationProvider.h
+++ b/Snowplow/Internal/RemoteConfiguration/SPConfigurationProvider.h
@@ -22,10 +22,11 @@
 #import <Foundation/Foundation.h>
 #import "SPRemoteConfiguration.h"
 #import "SPFetchedConfigurationBundle.h"
+#import "SPConfigurationState.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^OnFetchCallback)(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle);
+typedef void(^OnFetchCallback)(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState);
 
 /*!
  This class fetch a configuration from a remote source otherwise it provides a cached configuration.

--- a/Snowplow/Internal/RemoteConfiguration/SPConfigurationProvider.m
+++ b/Snowplow/Internal/RemoteConfiguration/SPConfigurationProvider.m
@@ -60,12 +60,13 @@
             if (!self.cacheBundle) {
                 self.cacheBundle = [self.cache readCache];
             }
-            SPFetchedConfigurationBundle *retrievedBundle = self.cacheBundle ?: self.defaultBundle;
-            if (retrievedBundle) {
-                onFetchCallback(retrievedBundle);
+            if (self.cacheBundle) {
+                onFetchCallback(self.cacheBundle, SPConfigurationStateCached);
+            } else if (self.defaultBundle) {
+                onFetchCallback(self.defaultBundle, SPConfigurationStateDefault);
             }
         }
-        self.fetcher = [[SPConfigurationFetcher alloc] initWithRemoteSource:self.remoteConfiguration onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+        self.fetcher = [[SPConfigurationFetcher alloc] initWithRemoteSource:self.remoteConfiguration onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
             if (![self schemaCompatibility:fetchedConfigurationBundle.schema]) {
                 return;
             }
@@ -75,7 +76,7 @@
                 }
                 [self.cache writeCache:fetchedConfigurationBundle];
                 self.cacheBundle = fetchedConfigurationBundle;
-                onFetchCallback(fetchedConfigurationBundle);
+                onFetchCallback(fetchedConfigurationBundle, SPConfigurationStateFetched);
             }
         }];
     }

--- a/Snowplow/Internal/RemoteConfiguration/SPConfigurationState.h
+++ b/Snowplow/Internal/RemoteConfiguration/SPConfigurationState.h
@@ -1,0 +1,47 @@
+//
+//  SPConfigurationState.h
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Matus Tomlein
+//  License: Apache License Version 2.0
+//
+
+#ifndef SPConfigurationState_h
+#define SPConfigurationState_h
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ @brief State of retrieved remote configuration that states where the configuration was retrieved from.
+ */
+typedef NS_ENUM(NSUInteger, SPConfigurationState) {
+    /**
+     * The default configuration was used.
+     */
+    SPConfigurationStateDefault,
+    /**
+     * The configuration was retrieved from local cache.
+     */
+    SPConfigurationStateCached,
+    /**
+     * The configuration was retrieved from the remote configuration endpoint.
+     */
+    SPConfigurationStateFetched,
+} NS_SWIFT_NAME(ConfigurationState);
+
+NS_ASSUME_NONNULL_END
+
+#endif /* SPConfigurationState_h */

--- a/Snowplow/Internal/SPSnowplow.h
+++ b/Snowplow/Internal/SPSnowplow.h
@@ -25,6 +25,7 @@
 #import "SPTrackerConfiguration.h"
 #import "SPRemoteConfiguration.h"
 #import "SPConfigurationBundle.h"
+#import "SPConfigurationState.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -60,10 +61,11 @@ NS_SWIFT_NAME(Snowplow)
  *
  * @param remoteConfiguration The remote configuration used to indicate where to download the configuration from.
  * @param defaultBundles The default configuration passed by default in case there isn't a cached version and it's able to download a new one.
- * @param onSuccess The callback called when a configuration (cached or downloaded) is set It passes the list of the namespaces associated
- *                  to the created trackers.
+ * @param onSuccess The callback called when a configuration (cached or downloaded) is set.
+ *                  It passes two arguments: list of the namespaces associated to the created trackers
+ *                  and the state of the configuration – whether it was retrieved from cache or fetched over the network.
  */
-+ (void)setupWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration defaultConfigurationBundles:(nullable NSArray<SPConfigurationBundle *> *)defaultBundles onSuccess:(void(^)(NSArray<NSString *> * _Nullable namespaces))onSuccess NS_SWIFT_NAME(setup(remoteConfiguration:defaultConfiguration:onSuccess:));
++ (void)setupWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration defaultConfigurationBundles:(nullable NSArray<SPConfigurationBundle *> *)defaultBundles onSuccess:(void(^)(NSArray<NSString *> * _Nullable namespaces, SPConfigurationState configurationState))onSuccess NS_SWIFT_NAME(setup(remoteConfiguration:defaultConfiguration:onSuccess:));
 
 /**
  * Reconfigure, create or delete the trackers based on the configuration downloaded remotely.
@@ -84,7 +86,7 @@ NS_SWIFT_NAME(Snowplow)
  * @param onSuccess The callback called when a configuration (cached or downloaded) is set It passes the list of the namespaces associated
  *                  to the created trackers.
  */
-+ (void)refreshIfRemoteUpdate:(void(^)(NSArray<NSString *> * _Nullable namespaces))onSuccess NS_SWIFT_NAME(refresh(onSuccess:));
++ (void)refreshIfRemoteUpdate:(void(^)(NSArray<NSString *> * _Nullable namespaces, SPConfigurationState configurationState))onSuccess NS_SWIFT_NAME(refresh(onSuccess:));
 
 /// Standard Configuration
 

--- a/Snowplow/Internal/SPSnowplow.m
+++ b/Snowplow/Internal/SPSnowplow.m
@@ -33,23 +33,23 @@
 
 @implementation SPSnowplow
 
-+ (void)setupWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration defaultConfigurationBundles:(NSArray<SPConfigurationBundle *> *)defaultBundles onSuccess:(void (^)(NSArray<NSString *> * _Nullable))onSuccess
++ (void)setupWithRemoteConfiguration:(SPRemoteConfiguration *)remoteConfiguration defaultConfigurationBundles:(NSArray<SPConfigurationBundle *> *)defaultBundles onSuccess:(void (^)(NSArray<NSString *> * _Nullable, SPConfigurationState configurationState))onSuccess
 {
     SPSnowplow *snowplow = [SPSnowplow sharedInstance];
     snowplow.configurationProvider = [[SPConfigurationProvider alloc] initWithRemoteConfiguration:remoteConfiguration defaultConfigurationBundles:defaultBundles];
-    [snowplow.configurationProvider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [snowplow.configurationProvider retrieveConfigurationOnlyRemote:NO onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
         NSArray<SPConfigurationBundle *> *bundles = fetchedConfigurationBundle.configurationBundle;
         NSArray<NSString *> *namespaces = [SPSnowplow createTrackersWithConfigurationBundles:bundles];
-        onSuccess(namespaces);
+        onSuccess(namespaces, configurationState);
     }];
 }
 
-+ (void)refreshIfRemoteUpdate:(void (^)(NSArray<NSString *> * _Nullable))onSuccess {
++ (void)refreshIfRemoteUpdate:(void (^)(NSArray<NSString *> * _Nullable, SPConfigurationState configurationState))onSuccess {
     SPSnowplow *snowplow = [SPSnowplow sharedInstance];
-    [snowplow.configurationProvider retrieveConfigurationOnlyRemote:YES onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle) {
+    [snowplow.configurationProvider retrieveConfigurationOnlyRemote:YES onFetchCallback:^(SPFetchedConfigurationBundle * _Nonnull fetchedConfigurationBundle, SPConfigurationState configurationState) {
         NSArray<SPConfigurationBundle *> *bundles = fetchedConfigurationBundle.configurationBundle;
         NSArray<NSString *> *namespaces = [SPSnowplow createTrackersWithConfigurationBundles:bundles];
-        onSuccess(namespaces);
+        onSuccess(namespaces, configurationState);
     }];
 }
 

--- a/Snowplow/include/SPConfigurationState.h
+++ b/Snowplow/include/SPConfigurationState.h
@@ -1,0 +1,1 @@
+../Internal/RemoteConfiguration/SPConfigurationState.h

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -81,7 +81,8 @@ Pod::Spec.new do |s|
     'Snowplow/Internal/**/SPSchemaRule.h',
     'Snowplow/Internal/**/SPTrackerStateSnapshot.h',
     'Snowplow/Internal/**/SPState.h',
-    'Snowplow/Internal/**/SPSessionState.h'
+    'Snowplow/Internal/**/SPSessionState.h',
+    'Snowplow/Internal/**/SPConfigurationState.h'
   ]
 
   s.osx.exclude_files = 'Snowplow/**/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.*'


### PR DESCRIPTION
This PR addresses issue #694 and adds information about the remote configuration state to the `onSuccess` callback.

The configuration state describes where was the configuration retrieved from. It can have one of three values:

1. `CACHED` - retrieved from local cache file
2. `DEFAULT` - there was no cache, so the default settings provided by user were used
3. `FETCHED` - retrieved from the remote endpoint

This should make it more clear how to handle repeating calls to the `onSuccess` callback.

## Limitations

There are still some cases when we don't give any information to the user which makes it more difficult to get visibility of the remote config. However, these states don't really fit into the `onSuccess` callback so I decided to skip them here. But we could provide additional callbacks in the future.

These states are not covered by a calback:

* initial configuration was retrieved from cache and when the remote one was downloaded, the tracker decided not to use it.
* any failure to download the configuration or process the downloaded configuration

## Example app

The CI build of the example app breaks as the callback change is a breaking change. I updated the example app and opened a PR for it [here](https://github.com/snowplow-incubator/snowplow-objc-tracker-examples/pull/19).