### PR TITLE
Ignore trailing slashes in the network configuration endpoint (close #695)

### DIFF
--- a/Snowplow iOSTests/TestNetworkConnection.m
+++ b/Snowplow iOSTests/TestNetworkConnection.m
@@ -146,4 +146,12 @@ NSString *const TEST_URL_ENDPOINT = @"acme.test.url.com";
     XCTAssertTrue([connection.url.absoluteString hasPrefix:@"http://acme.test.url.com"]);
 }
 
+- (void)testStripsTrailingSlashInEndpoint {
+    SPDefaultNetworkConnection *connection = [SPDefaultNetworkConnection build:^(id<SPDefaultNetworkConnectionBuilder> builder) {
+        [builder setUrlEndpoint:@"http://acme.test.url.com/"];
+        [builder setHttpMethod:SPHttpMethodGet];
+    }];
+    XCTAssertTrue([[[connection url] absoluteString] isEqualToString:@"http://acme.test.url.com/i"]);
+}
+
 @end

--- a/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.m
+++ b/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.m
@@ -82,7 +82,11 @@
     if (_customPostPath && _httpMethod == SPHttpMethodPost) {
         urlSuffix = _customPostPath;
     }
-    _urlEndpoint = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", endpoint, urlSuffix]];
+
+    // Remove trailing slashes from endpoint to avoid double slashes when appending path
+    endpoint = [endpoint stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
+
+    _urlEndpoint = [[NSURL URLWithString:endpoint] URLByAppendingPathComponent:urlSuffix];
     
     // Log
     if ([_urlEndpoint scheme] && [_urlEndpoint host]) {


### PR DESCRIPTION
Addresses issue #695 and adds simple logic to strip trailing slashes in collector endpoint URLs.