### PR TITLE
Add anonymous tracking features (close #702)

### DIFF
--- a/Snowplow iOSTests/Configurations/TestEmitterConfiguration.m
+++ b/Snowplow iOSTests/Configurations/TestEmitterConfiguration.m
@@ -72,5 +72,16 @@
     XCTAssertEqual(0, [[tracker emitter] dbCount]);
 }
 
+- (void)testActivatesServerAnonymisationInEmitter {
+    SPEmitterConfiguration *emitterConfig = [[SPEmitterConfiguration alloc] init];
+    emitterConfig.serverAnonymisation = YES;
+    
+    SPNetworkConfiguration *networkConfig = [[SPNetworkConfiguration alloc] initWithEndpoint:@"" method:SPHttpMethodPost];
+    
+    id<SPTrackerController> tracker = [SPSnowplow createTrackerWithNamespace:@"namespace" network:networkConfig configurations:@[emitterConfig]];
+    
+    XCTAssertTrue(tracker.emitter.serverAnonymisation);
+}
+
 
 @end

--- a/Snowplow iOSTests/Legacy Tests/LegacyTestSubject.m
+++ b/Snowplow iOSTests/Legacy Tests/LegacyTestSubject.m
@@ -49,7 +49,7 @@
 
 - (void)testSubjectInitWithOptions {
     SPSubject * subject = [[SPSubject alloc] initWithPlatformContext:YES andGeoContext:NO];
-    XCTAssertNotNil([subject getPlatformDict]);
+    XCTAssertNotNil([subject getPlatformDictWithUserAnonymisation:NO]);
     XCTAssertNotNil([subject getStandardDict]);
 }
 

--- a/Snowplow iOSTests/TestGeneratedJsons.m
+++ b/Snowplow iOSTests/TestGeneratedJsons.m
@@ -76,7 +76,7 @@ const NSString* IGLU_PATH = @"http://raw.githubusercontent.com/snowplow/iglu-cen
 
 - (void)testClientSessionContextJson {
     SPSession * session = [[SPSession alloc] init];
-    NSDictionary * data = [session getSessionDictWithEventId:@"first-event-id" eventTimestamp:1654496481346];
+    NSDictionary * data = [session getSessionDictWithEventId:@"first-event-id" eventTimestamp:1654496481346 userAnonymisation:NO];
     NSDictionary * json = [[[SPSelfDescribingJson alloc] initWithSchema:kSPSessionContextSchema andData:data] getAsDictionary];
     XCTAssertTrue([validator validateJson:json]);
 }
@@ -86,7 +86,7 @@ const NSString* IGLU_PATH = @"http://raw.githubusercontent.com/snowplow/iglu-cen
 
 - (void)testPlatformContextJson {
     SPSubject * subject = [[SPSubject alloc] initWithPlatformContext:YES andGeoContext:YES];
-    NSDictionary * data = [[subject getPlatformDict] getAsDictionary];
+    NSDictionary * data = [[subject getPlatformDictWithUserAnonymisation:NO] getAsDictionary];
     NSDictionary * json;
 #if TARGET_OS_IPHONE
     json = [[[SPSelfDescribingJson alloc] initWithSchema:kSPMobileContextSchema andData:data] getAsDictionary];

--- a/Snowplow iOSTests/TestPlatformContext.m
+++ b/Snowplow iOSTests/TestPlatformContext.m
@@ -32,7 +32,7 @@
 
 - (void)testContainsPlatformInfo {
     SPPlatformContext *context = [[SPPlatformContext alloc] init];
-    NSDictionary *platformDict = [[context fetchPlatformDict] getAsDictionary];
+    NSDictionary *platformDict = [[context fetchPlatformDictWithUserAnonymisation:NO] getAsDictionary];
     XCTAssertNotNil([platformDict objectForKey:kSPPlatformOsType]);
     XCTAssertNotNil([platformDict objectForKey:kSPPlatformOsVersion]);
 }
@@ -40,7 +40,7 @@
 - (void)testContainsMobileInfo {
 #if SNOWPLOW_TARGET_IOS
     SPPlatformContext *context = [[SPPlatformContext alloc] init];
-    NSDictionary *platformDict = [[context fetchPlatformDict] getAsDictionary];
+    NSDictionary *platformDict = [[context fetchPlatformDictWithUserAnonymisation:NO] getAsDictionary];
     XCTAssertNotNil([platformDict objectForKey:kSPMobileAvailableStorage]);
     XCTAssertNotNil([platformDict objectForKey:kSPMobileTotalStorage]);
 #endif
@@ -49,7 +49,7 @@
 - (void)testAddsAllMockedInfo {
     SPDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
-    NSDictionary *platformDict = [[context fetchPlatformDict] getAsDictionary];
+    NSDictionary *platformDict = [[context fetchPlatformDictWithUserAnonymisation:NO] getAsDictionary];
     XCTAssertTrue([@"appleIdfa" isEqualToString: [platformDict valueForKey:kSPMobileAppleIdfa]]);
     XCTAssertTrue([@"appleIdfv" isEqualToString: [platformDict valueForKey:kSPMobileAppleIdfv]]);
     XCTAssertTrue([@"Apple Inc." isEqualToString: [platformDict valueForKey:kSPPlatformDeviceManu]]);
@@ -74,10 +74,10 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(3, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(3, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
 #endif
@@ -89,10 +89,10 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:1000 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"batteryLevel"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appAvailableMemory"]);
 #endif
@@ -104,10 +104,10 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:1 networkDictUpdateFrequency:0 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkType"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"networkType"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(3, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(3, [deviceInfoMonitor accessCount:@"networkType"]);
 #endif
@@ -119,10 +119,10 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1000 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkType"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkType"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkTechnology"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"networkType"]);
 #endif
@@ -134,10 +134,10 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:0 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"physicalMemory"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"totalStorage"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"physicalMemory"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"totalStorage"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"physicalMemory"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"totalStorage"]);
 #endif
@@ -149,7 +149,7 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfa"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfv"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfa"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfv"]);
 #endif
@@ -163,9 +163,19 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfa"]);
     XCTAssertEqual(1, [deviceInfoMonitor accessCount:@"appleIdfv"]);
-    [context fetchPlatformDict];
+    [context fetchPlatformDictWithUserAnonymisation:NO];
     XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"appleIdfa"]);
     XCTAssertEqual(2, [deviceInfoMonitor accessCount:@"appleIdfv"]);
+#endif
+}
+
+- (void)testAnonymisesUserIdentifiers {
+#if SNOWPLOW_TARGET_IOS
+    SPDeviceInfoMonitor *deviceInfoMonitor = [[SPMockDeviceInfoMonitor alloc] init];
+    SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1 deviceInfoMonitor:deviceInfoMonitor];
+    NSDictionary *platformDict = [[context fetchPlatformDictWithUserAnonymisation:YES] getAsDictionary];
+    XCTAssertNil([platformDict valueForKey:kSPMobileAppleIdfa]);
+    XCTAssertNil([platformDict valueForKey:kSPMobileAppleIdfv]);
 #endif
 }
 
@@ -173,7 +183,7 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:1000 networkDictUpdateFrequency:0];
     [self measureBlock:^{
         for (int i = 0; i < 100; i++) {
-            [context fetchPlatformDict];
+            [context fetchPlatformDictWithUserAnonymisation:NO];
         }
     }];
 }
@@ -182,7 +192,7 @@
     SPPlatformContext *context = [[SPPlatformContext alloc] initWithMobileDictUpdateFrequency:0 networkDictUpdateFrequency:1000];
     [self measureBlock:^{
         for (int i = 0; i < 10000; i++) {
-            [context fetchPlatformDict];
+            [context fetchPlatformDictWithUserAnonymisation:NO];
         }
     }];
 }

--- a/Snowplow iOSTests/TestSession.m
+++ b/Snowplow iOSTests/TestSession.m
@@ -55,7 +55,7 @@
     SPSession * session = [[SPSession alloc] init];
     XCTAssertNil([session getTracker]);
     XCTAssertTrue(![session getInBackground]);
-    XCTAssertNotNil([session getSessionDictWithEventId:@"eventid-1" eventTimestamp:1654496481346]);
+    XCTAssertNotNil([session getSessionDictWithEventId:@"eventid-1" eventTimestamp:1654496481346 userAnonymisation:NO]);
     XCTAssertTrue(session.state.sessionIndex >= 1);
     XCTAssertEqual([session getForegroundTimeout], 600000);
     XCTAssertEqual([session getBackgroundTimeout], 300000);
@@ -86,7 +86,7 @@
 - (void)testFirstSession {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346 userAnonymisation:NO];
     NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -97,7 +97,7 @@
 - (void)testForegroundEventsOnSameSession {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346 userAnonymisation:NO];
     NSInteger sessionIndex = session.state.sessionIndex;
     NSString *sessionId = [sessionContext objectForKey:kSPSessionId];
     XCTAssertEqual(1, sessionIndex);
@@ -107,7 +107,7 @@
     
     [NSThread sleepForTimeInterval:1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347 userAnonymisation:NO];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -117,7 +117,7 @@
     
     [NSThread sleepForTimeInterval:1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348 userAnonymisation:NO];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -127,7 +127,7 @@
 
     [NSThread sleepForTimeInterval:3.1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349];
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349 userAnonymisation:NO];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(2, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -152,7 +152,7 @@
     
     [session updateInBackground];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346 userAnonymisation:NO];
     NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -181,7 +181,7 @@
 
     NSString *sessionId = session.state.sessionId;
 
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346 userAnonymisation:NO];
     NSInteger sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -191,7 +191,7 @@
     
     [NSThread sleepForTimeInterval:1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347 userAnonymisation:NO];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -201,7 +201,7 @@
     
     [NSThread sleepForTimeInterval:1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348 userAnonymisation:NO];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(1, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -211,7 +211,7 @@
     
     [NSThread sleepForTimeInterval:2.1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349];
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349 userAnonymisation:NO];
     sessionIndex = session.state.sessionIndex;
     XCTAssertEqual(2, sessionIndex);
     XCTAssertEqual(sessionIndex, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
@@ -236,7 +236,7 @@
     }];
     SPSession *session = tracker.session;
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481351];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481351 userAnonymisation:NO];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertEqualObjects(@"2022-06-06T06:21:21.351Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
     XCTAssertFalse([session getInBackground]);
@@ -247,7 +247,7 @@
     [session updateInBackground];
     [NSThread sleepForTimeInterval:1.1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481352];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481352 userAnonymisation:NO];
     XCTAssertEqualObjects(oldSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_2", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertEqualObjects(@"2022-06-06T06:21:21.352Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
@@ -259,7 +259,7 @@
     [session updateInForeground];
     [NSThread sleepForTimeInterval:1.1];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481353];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481353 userAnonymisation:NO];
     XCTAssertEqualObjects(oldSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_3", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertEqualObjects(@"2022-06-06T06:21:21.353Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
@@ -271,7 +271,7 @@
     [session updateInBackground];
     [NSThread sleepForTimeInterval:1.1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481354];
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481354 userAnonymisation:NO];
     XCTAssertEqualObjects(oldSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_4", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertEqualObjects(@"2022-06-06T06:21:21.354Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
@@ -283,7 +283,7 @@
 - (void)testTimeoutSessionWhenPauseAndResume {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:1 andBackgroundTimeout:1 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481355];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481355 userAnonymisation:NO];
     NSString *prevSessionId = [sessionContext objectForKey:kSPSessionId];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertEqualObjects(@"2022-06-06T06:21:21.355Z", [sessionContext objectForKey:kSPSessionFirstEventTimestamp]);
@@ -291,7 +291,7 @@
     [session stopChecker];
     [NSThread sleepForTimeInterval:2];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481356];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481356 userAnonymisation:NO];
     XCTAssertEqual(1, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(prevSessionId, [sessionContext objectForKey:kSPSessionId]);
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -300,7 +300,7 @@
     
     [session startChecker];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481357];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481357 userAnonymisation:NO];
     XCTAssertEqual(2, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(prevSessionId, [sessionContext objectForKey:kSPSessionPreviousId]);
     XCTAssertEqualObjects(@"event_3", [sessionContext objectForKey:kSPSessionFirstEventId]);
@@ -321,7 +321,7 @@
     }];
     SPSession *session = tracker.session;
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481361];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481361 userAnonymisation:NO];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertFalse([session getInBackground]);
     XCTAssertEqual(0, [session getBackgroundIndex]);
@@ -354,7 +354,7 @@
     }];
     SPSession *session = tracker.session;
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481358];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481358 userAnonymisation:NO];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     XCTAssertFalse([session getInBackground]);
     XCTAssertEqual(0, [session getBackgroundIndex]);
@@ -376,12 +376,12 @@
 - (void)testNoEventsForLongTimeDontIncreaseSessionIndexMultipleTimes {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:1 andBackgroundTimeout:1 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481359];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481359 userAnonymisation:NO];
     XCTAssertEqualObjects(@"event_1", [sessionContext objectForKey:kSPSessionFirstEventId]);
     
     [NSThread sleepForTimeInterval:4];
     
-    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481360];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481360 userAnonymisation:NO];
     XCTAssertEqual(2, [[sessionContext objectForKey:kSPSessionIndex] intValue]);
     XCTAssertEqualObjects(@"event_2", [sessionContext objectForKey:kSPSessionFirstEventId]);
 }
@@ -472,23 +472,33 @@
 - (void)testIncrementsEventIndex {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
     
-    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346];
+    NSDictionary *sessionContext = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346 userAnonymisation:NO];
     XCTAssertEqualObjects(@1, [sessionContext objectForKey:kSPSessionEventIndex]);
     
     [NSThread sleepForTimeInterval:1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347];
+    sessionContext = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347 userAnonymisation:NO];
     XCTAssertEqualObjects(@2, [sessionContext objectForKey:kSPSessionEventIndex]);
     
     [NSThread sleepForTimeInterval:1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348];
+    sessionContext = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481348 userAnonymisation:NO];
     XCTAssertEqualObjects(@3, [sessionContext objectForKey:kSPSessionEventIndex]);
 
     [NSThread sleepForTimeInterval:3.1];
 
-    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349];
+    sessionContext = [session getSessionDictWithEventId:@"event_4" eventTimestamp:1654496481349 userAnonymisation:NO];
     XCTAssertEqualObjects(@1, [sessionContext objectForKey:kSPSessionEventIndex]);
+}
+
+- (void)testAnonymisesUserIdentifiers {
+    SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
+    
+    NSDictionary *withoutAnonymisation = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346 userAnonymisation:NO];
+    XCTAssertFalse([[withoutAnonymisation objectForKey:kSPSessionUserId] isEqualToString:@"00000000-0000-0000-0000-000000000000"]);
+    
+    NSDictionary *withAnonymisation = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347 userAnonymisation:YES];
+    XCTAssertTrue([[withAnonymisation objectForKey:kSPSessionUserId] isEqualToString:@"00000000-0000-0000-0000-000000000000"]);
 }
 
 // Service methods

--- a/Snowplow iOSTests/TestSubject.m
+++ b/Snowplow iOSTests/TestSubject.m
@@ -31,14 +31,14 @@
 
 - (void)testReturnsPlatformContextIfEnabled {
     SPSubject *subject = [[SPSubject alloc] initWithPlatformContext:YES andGeoContext:NO];
-    SPPayload *platformDict = [subject getPlatformDict];
+    SPPayload *platformDict = [subject getPlatformDictWithUserAnonymisation:NO];
     XCTAssertNotNil(platformDict);
     XCTAssertNotNil([[platformDict getAsDictionary] objectForKey:kSPPlatformOsType]);
 }
 
 - (void)testDoesntReturnPlatformContextIfDisabled {
     SPSubject *subject = [[SPSubject alloc] initWithPlatformContext:NO andGeoContext:NO];
-    SPPayload *platformDict = [subject getPlatformDict];
+    SPPayload *platformDict = [subject getPlatformDictWithUserAnonymisation:NO];
     XCTAssertNil(platformDict);
 }
 

--- a/Snowplow/Internal/Configurations/SPEmitterConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPEmitterConfiguration.h
@@ -82,6 +82,10 @@ NS_SWIFT_NAME(EmitterConfigurationProtocol)
  *  The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
  */
 @property (nonatomic, nullable) NSDictionary<NSNumber *, NSNumber *> *customRetryForStatusCodes;
+/**
+ * Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+ */
+@property () BOOL serverAnonymisation;
 
 @end
 
@@ -107,6 +111,7 @@ NS_SWIFT_NAME(EmitterConfiguration)
  *         threadPoolSize = 15;
  *         byteLimitGet = 40000;
  *         byteLimitPost = 40000;
+ *         serverAnonymisation = false;
  */
 - (instancetype)init;
 
@@ -146,6 +151,10 @@ SP_BUILDER_DECLARE_NULLABLE(id<SPEventStore>, eventStore)
  * The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
  */
 SP_BUILDER_DECLARE_NULLABLE(NSDictionary *, customRetryForStatusCodes)
+/**
+ * Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+ */
+SP_BUILDER_DECLARE(BOOL, serverAnonymisation)
 
 @end
 

--- a/Snowplow/Internal/Configurations/SPEmitterConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPEmitterConfiguration.m
@@ -30,6 +30,7 @@
 @synthesize threadPoolSize;
 @synthesize requestCallback;
 @synthesize customRetryForStatusCodes;
+@synthesize serverAnonymisation;
 
 - (instancetype)init {
     if (self = [super init]) {
@@ -40,6 +41,7 @@
         self.byteLimitPost = 40000;
         self.eventStore = nil;
         self.requestCallback = nil;
+        self.serverAnonymisation = NO;
     }
     return self;
 }
@@ -53,6 +55,7 @@ SP_BUILDER_METHOD(NSInteger, byteLimitGet)
 SP_BUILDER_METHOD(NSInteger, byteLimitPost)
 SP_BUILDER_METHOD(id<SPRequestCallback>, requestCallback)
 SP_BUILDER_METHOD(NSDictionary *, customRetryForStatusCodes)
+SP_BUILDER_METHOD(BOOL, serverAnonymisation)
 
 SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
 
@@ -68,6 +71,7 @@ SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
     copy.requestCallback = self.requestCallback;
     copy.eventStore = self.eventStore;
     copy.customRetryForStatusCodes = self.customRetryForStatusCodes;
+    copy.serverAnonymisation = self.serverAnonymisation;
     return copy;
 }
 
@@ -84,6 +88,7 @@ SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
     [coder encodeInteger:self.byteLimitGet forKey:SP_STR_PROP(byteLimitGet)];
     [coder encodeInteger:self.byteLimitPost forKey:SP_STR_PROP(byteLimitPost)];
     [coder encodeObject:self.customRetryForStatusCodes forKey:SP_STR_PROP(customRetryForStatusCodes)];
+    [coder encodeBool:self.serverAnonymisation forKey:SP_STR_PROP(serverAnonymisation)];
 }
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
@@ -94,6 +99,7 @@ SP_BUILDER_METHOD(id<SPEventStore>, eventStore)
         self.byteLimitGet = [coder decodeIntegerForKey:SP_STR_PROP(byteLimitGet)];
         self.byteLimitPost = [coder decodeIntegerForKey:SP_STR_PROP(byteLimitPost)];
         self.customRetryForStatusCodes = [coder decodeObjectForKey:SP_STR_PROP(customRetryForStatusCodes)];
+        self.serverAnonymisation = [coder decodeBoolForKey:SP_STR_PROP(serverAnonymisation)];
     }
     return self;
 }

--- a/Snowplow/Internal/Configurations/SPTrackerConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPTrackerConfiguration.h
@@ -101,6 +101,10 @@ NS_SWIFT_NAME(TrackerConfigurationProtocol)
  * @note Do not use. Internal use only.
  */
 @property (nonatomic, nullable) NSString *trackerVersionSuffix;
+/**
+ * Whether to anonymise client-side user identifiers in session and platform context entities.
+ */
+@property () BOOL userAnonymisation;
 
 @end
 
@@ -130,6 +134,7 @@ NS_SWIFT_NAME(TrackerConfiguration)
  *         installAutotracking = true;
  *         exceptionAutotracking = true;
  *         diagnosticAutotracking = false;
+ *         userAnonymisation = false;
  */
 - (instancetype)init;
 
@@ -201,6 +206,10 @@ SP_BUILDER_DECLARE(BOOL, diagnosticAutotracking)
  * Internal use only.
  */
 SP_BUILDER_DECLARE(NSString *, trackerVersionSuffix)
+/**
+ * Whether to anonymise client-side user identifiers in session and platform context entities
+ */
+SP_BUILDER_DECLARE(BOOL, userAnonymisation)
 
 @end
 

--- a/Snowplow/Internal/Configurations/SPTrackerConfiguration.m
+++ b/Snowplow/Internal/Configurations/SPTrackerConfiguration.m
@@ -41,6 +41,7 @@
 @synthesize exceptionAutotracking;
 @synthesize diagnosticAutotracking;
 @synthesize trackerVersionSuffix;
+@synthesize userAnonymisation;
 
 - (instancetype)initWithDictionary:(NSDictionary<NSString *,NSObject *> *)dictionary {
     if (self = [self init]) {
@@ -67,6 +68,7 @@
         self.installAutotracking = [dictionary sp_boolForKey:SP_STR_PROP(installAutotracking) defaultValue:self.installAutotracking];
         self.exceptionAutotracking = [dictionary sp_boolForKey:SP_STR_PROP(exceptionAutotracking) defaultValue:self.exceptionAutotracking];
         self.diagnosticAutotracking = [dictionary sp_boolForKey:SP_STR_PROP(diagnosticAutotracking) defaultValue:self.diagnosticAutotracking];
+        self.userAnonymisation = [dictionary sp_boolForKey:SP_STR_PROP(userAnonymisation) defaultValue:self.userAnonymisation];
     }
     return self;
 }
@@ -92,6 +94,7 @@
         self.installAutotracking = YES;
         self.exceptionAutotracking = YES;
         self.diagnosticAutotracking = NO;
+        self.userAnonymisation = NO;
     }
     return self;
 }
@@ -114,6 +117,7 @@ SP_BUILDER_METHOD(BOOL, lifecycleAutotracking)
 SP_BUILDER_METHOD(BOOL, installAutotracking)
 SP_BUILDER_METHOD(BOOL, exceptionAutotracking)
 SP_BUILDER_METHOD(BOOL, diagnosticAutotracking)
+SP_BUILDER_METHOD(BOOL, userAnonymisation)
 SP_BUILDER_METHOD(NSString *, trackerVersionSuffix)
 
 // MARK: - NSCopying
@@ -137,6 +141,7 @@ SP_BUILDER_METHOD(NSString *, trackerVersionSuffix)
     copy.exceptionAutotracking = self.exceptionAutotracking;
     copy.diagnosticAutotracking = self.diagnosticAutotracking;
     copy.trackerVersionSuffix = self.trackerVersionSuffix;
+    copy.userAnonymisation = self.userAnonymisation;
     return copy;
 }
 
@@ -164,6 +169,7 @@ SP_BUILDER_METHOD(NSString *, trackerVersionSuffix)
     [coder encodeBool:self.exceptionAutotracking forKey:SP_STR_PROP(exceptionAutotracking)];
     [coder encodeBool:self.diagnosticAutotracking forKey:SP_STR_PROP(diagnosticAutotracking)];
     [coder encodeObject:self.trackerVersionSuffix forKey:SP_STR_PROP(trackerVersionSuffix)];
+    [coder encodeBool:self.userAnonymisation forKey:SP_STR_PROP(userAnonymisation)];
 }
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
@@ -185,6 +191,7 @@ SP_BUILDER_METHOD(NSString *, trackerVersionSuffix)
         self.exceptionAutotracking = [coder decodeBoolForKey:SP_STR_PROP(exceptionAutotracking)];
         self.diagnosticAutotracking = [coder decodeBoolForKey:SP_STR_PROP(diagnosticAutotracking)];
         self.trackerVersionSuffix = [coder decodeObjectForKey:SP_STR_PROP(trackerVersionSuffix)];
+        self.userAnonymisation = [coder decodeBoolForKey:SP_STR_PROP(userAnonymisation)];
     }
     return self;
 }

--- a/Snowplow/Internal/Emitter/SPEmitter.h
+++ b/Snowplow/Internal/Emitter/SPEmitter.h
@@ -97,6 +97,12 @@ NS_SWIFT_NAME(EmitterBuilder)
 - (void) setCustomPostPath:(NSString *)customPath;
 
 /*!
+ @brief Emitter builder method to set the server anonymisation flag.
+ @param serverAnonymisation  Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+ */
+- (void) setServerAnonymisation:(BOOL)serverAnonymisation;
+
+/*!
  @brief Builder method to set request headers.
  @param requestHeadersKeyValue custom headers (key, value) for http requests.
  */
@@ -156,6 +162,8 @@ NS_SWIFT_NAME(Emitter)
 @property (readonly, nonatomic) id<SPNetworkConnection> networkConnection;
 /*! @brief Custom retry rules for HTTP status codes. */
 @property (readonly, nonatomic) NSDictionary<NSNumber *, NSNumber *> *customRetryForStatusCodes;
+/*! @brief Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`. */
+@property (readonly, nonatomic) BOOL serverAnonymisation;
 
 /*!
  @brief Builds the emitter using a build block of functions.

--- a/Snowplow/Internal/Emitter/SPEmitter.m
+++ b/Snowplow/Internal/Emitter/SPEmitter.m
@@ -81,6 +81,7 @@ const NSUInteger POST_WRAPPER_BYTES = 88;
         _networkConnection = nil;
         _pausedEmit = NO;
         _customRetryForStatusCodes = @{};
+        _serverAnonymisation = NO;
     }
     return self;
 }
@@ -112,6 +113,7 @@ const NSUInteger POST_WRAPPER_BYTES = 88;
         [builder setEmitThreadPoolSize:strongSelf->_emitThreadPoolSize];
         [builder setByteLimitGet:strongSelf->_byteLimitGet];
         [builder setByteLimitPost:strongSelf->_byteLimitPost];
+        [builder setServerAnonymisation:strongSelf->_serverAnonymisation];
     }];
 }
 
@@ -186,6 +188,13 @@ const NSUInteger POST_WRAPPER_BYTES = 88;
 
 - (void) setByteLimitPost:(NSInteger)byteLimitPost {
     _byteLimitPost = byteLimitPost;
+    if (_builderFinished && _networkConnection) {
+        [self setupNetworkConnection];
+    }
+}
+
+- (void) setServerAnonymisation:(BOOL)serverAnonymisation {
+    _serverAnonymisation = serverAnonymisation;
     if (_builderFinished && _networkConnection) {
         [self setupNetworkConnection];
     }

--- a/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.h
+++ b/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.h
@@ -35,6 +35,7 @@ SP_DIRTYFLAG(byteLimitPost)
 SP_DIRTYFLAG(emitRange)
 SP_DIRTYFLAG(threadPoolSize)
 SP_DIRTYFLAG(customRetryForStatusCodes)
+SP_DIRTYFLAG(serverAnonymisation)
 
 @end
 

--- a/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.m
+++ b/Snowplow/Internal/Emitter/SPEmitterConfigurationUpdate.m
@@ -32,5 +32,6 @@ SP_DIRTY_GETTER(NSInteger, threadPoolSize)
 SP_DIRTY_GETTER(NSInteger, byteLimitGet)
 SP_DIRTY_GETTER(NSInteger, byteLimitPost)
 SP_DIRTY_GETTER(NSDictionary *, customRetryForStatusCodes)
+SP_DIRTY_GETTER(BOOL, serverAnonymisation)
 
 @end

--- a/Snowplow/Internal/Emitter/SPEmitterControllerImpl.m
+++ b/Snowplow/Internal/Emitter/SPEmitterControllerImpl.m
@@ -67,6 +67,16 @@
     return [self.emitter byteLimitPost];
 }
 
+- (void)setServerAnonymisation:(BOOL)serverAnonymisation {
+    self.dirtyConfig.serverAnonymisation = serverAnonymisation;
+    self.dirtyConfig.serverAnonymisationUpdated = YES;
+    [self.emitter setServerAnonymisation:serverAnonymisation];
+}
+
+- (BOOL)serverAnonymisation {
+    return [self.emitter serverAnonymisation];
+}
+
 - (void)setEmitRange:(NSInteger)emitRange {
     self.dirtyConfig.emitRange = emitRange;
     self.dirtyConfig.emitRangeUpdated = YES;

--- a/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.h
+++ b/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.h
@@ -69,6 +69,12 @@ NS_SWIFT_NAME(DefaultNetworkConnectionBuilder)
  */
 - (void) setRequestHeaders:(NSDictionary<NSString *, NSString *> *)requestHeadersKeyValue;
 
+/*!
+ @brief Builder method to set the server anonymisation flag.
+ @param serverAnonymisation Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+ */
+- (void) setServerAnonymisation:(BOOL)serverAnonymisation;
+
 @end
 
 NS_SWIFT_NAME(DefaultNetworkConnection)

--- a/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.m
+++ b/Snowplow/Internal/NetworkConnection/SPDefaultNetworkConnection.m
@@ -33,6 +33,7 @@
     NSUInteger _byteLimitPost;
     NSString *_customPostPath;
     NSDictionary<NSString *, NSString *> *_requestHeaders;
+    BOOL _serverAnonymisation;
 
     NSOperationQueue *_dataOperationQueue;
     NSURL *_urlEndpoint;
@@ -59,6 +60,7 @@
         _requestHeaders = nil;
         _dataOperationQueue = [[NSOperationQueue alloc] init];
         _builderFinished = NO;
+        _serverAnonymisation = NO;
     }
     return self;
 }
@@ -141,6 +143,10 @@
     _requestHeaders = requestHeadersKeyValue;
 }
 
+- (void)setServerAnonymisation:(BOOL)serverAnonymisation {
+    _serverAnonymisation = serverAnonymisation;
+}
+
 // MARK: - Implement SPNetworkConnection protocol
 
 - (SPHttpMethod)httpMethod {
@@ -199,6 +205,9 @@
     [urlRequest setValue:[NSString stringWithFormat:@"%@", @(requestData.length).stringValue] forHTTPHeaderField:@"Content-Length"];
     [urlRequest setValue:kSPAcceptContentHeader forHTTPHeaderField:@"Accept"];
     [urlRequest setValue:kSPContentTypeHeader forHTTPHeaderField:@"Content-Type"];
+    if (_serverAnonymisation) {
+        [urlRequest setValue:@"*" forHTTPHeaderField:@"SP-Anonymous"];
+    }
     [self applyValuesAndHeaderFields:_requestHeaders toRequest:urlRequest];
     [urlRequest setHTTPMethod:@"POST"];
     [urlRequest setHTTPBody:requestData];
@@ -210,6 +219,9 @@
     NSString *url = [NSString stringWithFormat:@"%@?%@", _urlEndpoint.absoluteString, [SPUtilities urlEncodeDictionary:payload]];
     NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     [urlRequest setValue:kSPAcceptContentHeader forHTTPHeaderField:@"Accept"];
+    if (_serverAnonymisation) {
+        [urlRequest setValue:@"*" forHTTPHeaderField:@"SP-Anonymous"];
+    }
     [self applyValuesAndHeaderFields:_requestHeaders toRequest:urlRequest];
     [urlRequest setHTTPMethod:@"GET"];
     return urlRequest;

--- a/Snowplow/Internal/SPTrackerConstants.h
+++ b/Snowplow/Internal/SPTrackerConstants.h
@@ -166,6 +166,7 @@ extern NSString * const kSPSessionStorage;
 extern NSString * const kSPSessionFirstEventId;
 extern NSString * const kSPSessionFirstEventTimestamp;
 extern NSString * const kSPSessionEventIndex;
+extern NSString * const kSPSessionAnonymousUserId;
 
 // --- Geo-Location Context
 

--- a/Snowplow/Internal/SPTrackerConstants.m
+++ b/Snowplow/Internal/SPTrackerConstants.m
@@ -150,6 +150,7 @@ NSString * const kSPSessionStorage             = @"storageMechanism";
 NSString * const kSPSessionFirstEventId        = @"firstEventId";
 NSString * const kSPSessionFirstEventTimestamp = @"firstEventTimestamp";
 NSString * const kSPSessionEventIndex          = @"eventIndex";
+NSString * const kSPSessionAnonymousUserId     = @"00000000-0000-0000-0000-000000000000";
 
 // --- Geo-Location Context
 

--- a/Snowplow/Internal/Session/SPSession.h
+++ b/Snowplow/Internal/Session/SPSession.h
@@ -107,9 +107,12 @@ NS_SWIFT_NAME(Session)
  * Returns the session dictionary
  * @param firstEventId The potential first event id of the session
  * @param firstEventTimestamp Device created timestamp of the first event of the session
+ * @param userAnonymisation Whether to anonymise user identifiers
  * @return a SnowplowPayload containing the session dictionary
  */
-- (NSDictionary *) getSessionDictWithEventId:(NSString *)firstEventId eventTimestamp:(long long)firstEventTimestamp;
+- (NSDictionary *) getSessionDictWithEventId:(NSString *)firstEventId
+                              eventTimestamp:(long long)firstEventTimestamp
+                           userAnonymisation:(BOOL)userAnonymisation;
 
 /**
  * Returns the foreground index count

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -129,7 +129,8 @@
     _backgroundTimeout = backgroundTimeout;
 }
 
-- (NSDictionary *) getSessionDictWithEventId:(NSString *)eventId eventTimestamp:(long long)eventTimestamp {
+- (NSDictionary *) getSessionDictWithEventId:(NSString *)eventId eventTimestamp:(long long)eventTimestamp userAnonymisation:(BOOL)userAnonymisation {
+    NSMutableDictionary *context = nil;
     @synchronized (self) {
         if (_isSessionCheckerEnabled) {
             if ([self shouldUpdateSession]) {
@@ -145,8 +146,15 @@
         
         _eventIndex += 1;
         
-        NSMutableDictionary *context = _state.sessionContext;
+        context = _state.sessionContext;
         [context setObject:[NSNumber numberWithInteger:_eventIndex] forKey:kSPSessionEventIndex];
+    }
+    
+    if (userAnonymisation) { // mask the user identifier
+        NSMutableDictionary *copy = [[NSMutableDictionary alloc] initWithDictionary:context];
+        [copy setValue:kSPSessionAnonymousUserId forKey:kSPSessionUserId];
+        return copy;
+    } else {
         return context;
     }
 }

--- a/Snowplow/Internal/Subject/SPPlatformContext.h
+++ b/Snowplow/Internal/Subject/SPPlatformContext.h
@@ -45,7 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param networkDictUpdateFrequency Minimal gap between subsequent updates of network platform information
  * @return a PlatformContext object
  */
-- (instancetype) initWithMobileDictUpdateFrequency:(NSTimeInterval)mobileDictUpdateFrequency networkDictUpdateFrequency:(NSTimeInterval)networkDictUpdateFrequency;
+- (instancetype) initWithMobileDictUpdateFrequency:(NSTimeInterval)mobileDictUpdateFrequency
+                        networkDictUpdateFrequency:(NSTimeInterval)networkDictUpdateFrequency;
 
 /**
  * Initializes a newly allocated PlatformContext object with custom update frequency for mobile and network properties and a custom device info monitor
@@ -54,12 +55,15 @@ NS_ASSUME_NONNULL_BEGIN
  * @param deviceInfoMonitor Device monitor for fetching platform information
  * @return a PlatformContext object
  */
-- (instancetype) initWithMobileDictUpdateFrequency:(NSTimeInterval)mobileDictUpdateFrequency networkDictUpdateFrequency:(NSTimeInterval)networkDictUpdateFrequency deviceInfoMonitor:(SPDeviceInfoMonitor *)deviceInfoMonitor;
+- (instancetype) initWithMobileDictUpdateFrequency:(NSTimeInterval)mobileDictUpdateFrequency
+                        networkDictUpdateFrequency:(NSTimeInterval)networkDictUpdateFrequency
+                                 deviceInfoMonitor:(SPDeviceInfoMonitor *)deviceInfoMonitor;
 
 /**
  * Updates and returns payload dictionary with device context information.
+ * @param userAnonymisation Whether to anonymise user identifiers (IDFA values)
  */
-- (nonnull SPPayload *) fetchPlatformDict;
+- (nonnull SPPayload *) fetchPlatformDictWithUserAnonymisation:(BOOL)userAnonymisation;
 
 @end
 

--- a/Snowplow/Internal/Subject/SPPlatformContext.m
+++ b/Snowplow/Internal/Subject/SPPlatformContext.m
@@ -58,7 +58,7 @@
     return self;
 }
 
-- (SPPayload *) fetchPlatformDict {
+- (SPPayload *) fetchPlatformDictWithUserAnonymisation:(BOOL)userAnonymisation {
 #if SNOWPLOW_TARGET_IOS
     @synchronized (self) {
         NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
@@ -70,7 +70,14 @@
         }
     }
 #endif
-    return self.platformDict;
+    if (userAnonymisation) { // mask user identifiers
+        SPPayload *copy = [[SPPayload alloc] initWithNSDictionary:[self.platformDict getAsDictionary]];
+        [copy addValueToPayload:nil forKey:kSPMobileAppleIdfa];
+        [copy addValueToPayload:nil forKey:kSPMobileAppleIdfv];
+        return copy;
+    } else {
+        return self.platformDict;
+    }
 }
 
 // MARK: - Private methods

--- a/Snowplow/Internal/Subject/SPSubject.h
+++ b/Snowplow/Internal/Subject/SPSubject.h
@@ -73,9 +73,10 @@ NS_SWIFT_NAME(Subject)
 
 /*!
  @brief Gets all platform dictionary pairs to decorate event with. Returns nil if not enabled.
+ @param userAnonymisation Whether to anonymise user identifiers
  @return A SPPayload with all platform specific pairs.
  */
-- (SPPayload *) getPlatformDict;
+- (SPPayload *) getPlatformDictWithUserAnonymisation:(BOOL)userAnonymisation;
 
 /*!
  @brief Gets the geolocation dictionary if the required keys are available. Returns nil if not enabled.

--- a/Snowplow/Internal/Subject/SPSubject.m
+++ b/Snowplow/Internal/Subject/SPSubject.m
@@ -109,9 +109,9 @@
     return _standardDict;
 }
 
-- (SPPayload *) getPlatformDict {
+- (SPPayload *) getPlatformDictWithUserAnonymisation:(BOOL)userAnonymisation {
     if (self.platformContext) {
-        return [_platformContextManager fetchPlatformDict];
+        return [_platformContextManager fetchPlatformDictWithUserAnonymisation:userAnonymisation];
     } else {
         return nil;
     }

--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -287,6 +287,7 @@
             [builder setEmitThreadPoolSize:emitterConfig.threadPoolSize];
             [builder setCallback:emitterConfig.requestCallback];
             [builder setCustomRetryForStatusCodes:emitterConfig.customRetryForStatusCodes];
+            [builder setServerAnonymisation:emitterConfig.serverAnonymisation];
         }
     }];
     if (emitterConfig && emitterConfig.isPaused) {
@@ -320,6 +321,7 @@
         [builder setInstallEvent:trackerConfig.installAutotracking];
         [builder setExceptionEvents:trackerConfig.exceptionAutotracking];
         [builder setTrackerDiagnostic:trackerConfig.diagnosticAutotracking];
+        [builder setUserAnonymisation:trackerConfig.userAnonymisation];
         if (sessionConfig) {
             [builder setBackgroundTimeout:sessionConfig.backgroundTimeoutInSeconds];
             [builder setForegroundTimeout:sessionConfig.foregroundTimeoutInSeconds];

--- a/Snowplow/Internal/Tracker/SPTracker.h
+++ b/Snowplow/Internal/Tracker/SPTracker.h
@@ -212,6 +212,12 @@ NS_SWIFT_NAME(TrackerBuilder)
                 documentVersion:(nullable NSString *)documentVersion
             documentDescription:(nullable NSString *)documentDescription;
 
+/*!
+ @brief Tracker builder method to set whether to anonymise client-side user identifiers in session and platform context entities.
+ @param userAnonymisation Whether to anonymise client-side user identifiers in session and platform context entities
+ */
+- (void) setUserAnonymisation:(BOOL)userAnonymisation;
+
 @end
 
 
@@ -255,6 +261,7 @@ NS_SWIFT_NAME(TrackerBuilder)
 - (BOOL)autoTrackScreenView;
 - (BOOL)sessionContext;
 - (BOOL)trackerDiagnostic;
+- (BOOL)userAnonymisation;
 
 // MARK: - methods
 

--- a/Snowplow/Internal/Tracker/SPTrackerConfigurationUpdate.h
+++ b/Snowplow/Internal/Tracker/SPTrackerConfigurationUpdate.h
@@ -45,6 +45,7 @@ SP_DIRTYFLAG(lifecycleAutotracking)
 SP_DIRTYFLAG(installAutotracking)
 SP_DIRTYFLAG(exceptionAutotracking)
 SP_DIRTYFLAG(diagnosticAutotracking)
+SP_DIRTYFLAG(userAnonymisation)
 SP_DIRTYFLAG(trackerVersionSuffix)
 
 @end

--- a/Snowplow/Internal/Tracker/SPTrackerConfigurationUpdate.m
+++ b/Snowplow/Internal/Tracker/SPTrackerConfigurationUpdate.m
@@ -39,6 +39,7 @@ SP_DIRTY_GETTER(BOOL, lifecycleAutotracking)
 SP_DIRTY_GETTER(BOOL, installAutotracking)
 SP_DIRTY_GETTER(BOOL, exceptionAutotracking)
 SP_DIRTY_GETTER(BOOL, diagnosticAutotracking)
+SP_DIRTY_GETTER(BOOL, userAnonymisation)
 SP_DIRTY_GETTER(NSString *, trackerVersionSuffix)
 
 @end

--- a/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
+++ b/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
@@ -264,6 +264,16 @@
     return [self.tracker sessionContext];
 }
 
+- (void)setUserAnonymisation:(BOOL)userAnonymisation {
+    self.dirtyConfig.userAnonymisation = userAnonymisation;
+    self.dirtyConfig.userAnonymisationUpdated = YES;
+    [self.tracker setUserAnonymisation:userAnonymisation];
+}
+
+- (BOOL)userAnonymisation {
+    return self.tracker.userAnonymisation;
+}
+
 - (BOOL)isTracking {
     return [self.tracker getIsTracking];
 }


### PR DESCRIPTION
This PR addresses issue #702 and adds anonymous tracking features to the tracker.

Two properties were added in configuration:

* `TrackerConfiguration.userAnonymisation`
  * Disables user identifiers in session context (sets `userId` to `00000000-0000-0000-0000-000000000000`) and platform context (removes `androidIdfa`).
  * It is implemented by masking the identifiers at the time when the entities are added to events. So the `userId` is actually stored in session state but removed when adding to events (JS tracker does a similar thing).
* `EmitterConfiguraiton.serverAnonymisation`
  * Sets the `SP-Anonymous: *` header in requests to Collector (at the time when the requests are sent, not when the events are tracked). This results in anonymising the `network_userid` and `user_ipaddress` properties.
  * Decided to put it in the Emitter config and not Tracker config as it is handled by the Emitter. But if it makes more sense to put it in Tracker config, we can move it there.

# Documentation

Anonymous tracking enables anonymising various user and session identifiers. It affects the following user and session identifiers:

1. Client-side user identifiers: the `userId` in Session context entity and the IDFA identifiers (`openIdfa`, `appleIdfa`, and `androidIdfa`) in the Platform context entity.
2. Client-side session identifiers: `sessionId` in Session context.
3. Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.

There are several levels to the anonymisation depending on which of the three categories are affected:

## 1. Full client-side anonymisation

In this case, both the client-side user identifiers as well as the client-side session identifiers are anonymised. To enable it, disable session context and enable user anonymisation:

```swift
let config = TrackerConfiguration()
    .sessionContext(false)
    .userAnonymisation(true)
```

## 2. Client-side anonymisation with session tracking

This setting disables client-side user identifiers are but tracks session information. In practice, this means that events track the Session context entity but the `userId` property is a null UUID (`00000000-0000-0000-0000-000000000000`). In case Platform context is enabled, the IDFA identifiers will not be present.

```swift
let config = TrackerConfiguration()
    .sessionContext(true)
    .userAnonymisation(true)
```

## 3. Server-side anonymisation

Server-side anonymisation affects user identifiers set server-side. In particular, these are the `network_userid` property set in server-side cookie and the user IP address. You can anonymise the properties using the `serverAnonymisation` flag in `EmitterConfiguration`:

```java
let config = EmitterConfiguraiton()
    .serverAnonymisation(true)
```