### PR TITLE
Fix too many events tracked by screen view autotracking (close #689)

### DIFF
--- a/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.m
+++ b/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.m
@@ -66,7 +66,13 @@
 
 - (void) SP_viewDidAppear:(BOOL)animated {
     [self SP_viewDidAppear:animated];
-
+    
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    if (bundle != [NSBundle mainBundle]) {
+        // Ignore non-main bundle view controllers
+        return;
+    }
+    
     // Construct userInfo
     NSMutableDictionary * userInfo = [[NSMutableDictionary alloc] init];
     userInfo[@"viewControllerClassName"] = NSStringFromClass([self class]);

--- a/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.m
+++ b/Snowplow/Internal/ScreenViewTracking/UIViewController+SPScreenView_SWIZZLE.m
@@ -68,8 +68,8 @@
     [self SP_viewDidAppear:animated];
     
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-    if (bundle != [NSBundle mainBundle]) {
-        // Ignore non-main bundle view controllers
+    if (![bundle.bundlePath hasPrefix:[NSBundle mainBundle].bundlePath]) {
+        // Ignore view controllers that don't start with the main bundle path
         return;
     }
     


### PR DESCRIPTION
This PR addresses issue #689.

The problem was that the screen view autotracking tracked too many events for non-relevant views (e.g., for the on-screen keyboard). I found a simple solution for it – just filter out views that are not in the main bundle.

Not sure if that condition is too strict. I don't expect users to have views in different bundles, but don't have much experience with UIKit, so correct me if I'm wrong.