### PR TITLE
Fix default session timeout values to 30 minutes everywhere (close #708)

### DIFF
--- a/Snowplow iOSTests/TestGeneratedJsons.m
+++ b/Snowplow iOSTests/TestGeneratedJsons.m
@@ -75,7 +75,7 @@ const NSString* IGLU_PATH = @"http://raw.githubusercontent.com/snowplow/iglu-cen
 }
 
 - (void)testClientSessionContextJson {
-    SPSession * session = [[SPSession alloc] init];
+    SPSession * session = [[SPSession alloc] initWithForegroundTimeout:1800 andBackgroundTimeout:1800];
     NSDictionary * data = [session getSessionDictWithEventId:@"first-event-id" eventTimestamp:1654496481346 userAnonymisation:NO];
     NSDictionary * json = [[[SPSelfDescribingJson alloc] initWithSchema:kSPSessionContextSchema andData:data] getAsDictionary];
     XCTAssertTrue([validator validateJson:json]);

--- a/Snowplow iOSTests/TestSession.m
+++ b/Snowplow iOSTests/TestSession.m
@@ -52,7 +52,7 @@
 
 
 - (void)testInit {
-    SPSession * session = [[SPSession alloc] init];
+    SPSession * session = [[SPSession alloc] initWithForegroundTimeout:600 andBackgroundTimeout:300];
     XCTAssertNil([session getTracker]);
     XCTAssertTrue(![session getInBackground]);
     XCTAssertNotNil([session getSessionDictWithEventId:@"eventid-1" eventTimestamp:1654496481346 userAnonymisation:NO]);

--- a/Snowplow/Internal/Session/SPSession.h
+++ b/Snowplow/Internal/Session/SPSession.h
@@ -34,19 +34,6 @@ NS_SWIFT_NAME(Session)
 
 /**
  * Initializes a newly allocated SnowplowSession
- * @return a SnowplowSession
- */
-- (id) init;
-
-/**
- * Initializes a newly allocated SnowplowSession
- * @param tracker reference to the associated tracker of the session
- * @return a SnowplowSession
- */
-- (id) initWithTracker:(SPTracker *)tracker;
-
-/**
- * Initializes a newly allocated SnowplowSession
  * @param foregroundTimeout the session timeout while it is in the foreground
  * @param backgroundTimeout the session timeout while it is in the background
  * @return a SnowplowSession

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -56,16 +56,8 @@
     NSInteger   _eventIndex;
 }
 
-- (id) init {
-    return [self initWithForegroundTimeout:600 andBackgroundTimeout:300 andTracker:nil];
-}
-
-- (id) initWithTracker:(SPTracker *)tracker {
-    return [self initWithForegroundTimeout:600 andBackgroundTimeout:300 andTracker:tracker];
-}
-
 - (instancetype)initWithForegroundTimeout:(NSInteger)foregroundTimeout andBackgroundTimeout:(NSInteger)backgroundTimeout {
-    return [self initWithForegroundTimeout:foregroundTimeout andBackgroundTimeout:backgroundTimeout];
+    return [self initWithForegroundTimeout:foregroundTimeout andBackgroundTimeout:backgroundTimeout andTracker:nil];
 }
 
 - (instancetype)initWithForegroundTimeout:(NSInteger)foregroundTimeout andBackgroundTimeout:(NSInteger)backgroundTimeout andTracker:(SPTracker *)tracker {

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -187,8 +187,8 @@ void uncaughtExceptionHandler(NSException *exception) {
         _screenContext = NO;
         _lifecycleEvents = NO;
         _autotrackScreenViews = NO;
-        _foregroundTimeout = 600;
-        _backgroundTimeout = 300;
+        _foregroundTimeout = 1800;
+        _backgroundTimeout = 1800;
         _builderFinished = NO;
         self.globalContextGenerators = [NSMutableDictionary dictionary];
         self.stateManager = [SPStateManager new];


### PR DESCRIPTION
This is a tiny change that removes old timeout configuration in `SPSession` and `SPTracker` to avoid confusion. Issue #708 

* In `SPSession`, I removed the `init` constructor without any arguments – it wasn't used anywhere except for the tests and unnecessarily caused duplication of the default values (the Android tracker doesn't have one). Hopefully this is not a breaking change as the class is internal.
* In `SPTracker`, I updated the session foreground and background timeouts to the 30 minute default.