### PR TITLE
Return tracked event ID from the track method (close #710)

### DIFF
--- a/Snowplow iOSTests/Legacy Tests/LegacyTestTracker.m
+++ b/Snowplow iOSTests/Legacy Tests/LegacyTestTracker.m
@@ -101,6 +101,7 @@ NSString *const TEST_SERVER_TRACKER = @"http://www.notarealurl.com";
     
     [tracker pauseEventTracking];
     XCTAssertEqual([tracker getIsTracking], NO);
+    XCTAssertNil([tracker track:[[SPStructured alloc] initWithCategory:@"c" action:@"a"]]);
     [tracker resumeEventTracking];
     XCTAssertEqual([tracker getIsTracking], YES);
     

--- a/Snowplow/Internal/Tracker/SPTracker.h
+++ b/Snowplow/Internal/Tracker/SPTracker.h
@@ -343,8 +343,9 @@ NS_SWIFT_NAME(TrackerBuilder)
 /*!
  @brief Tracks an event despite its specific type.
  @param event The event to track
+ @return The event ID or nil in case tracking is paused
  */
-- (void)track:(SPEvent *)event;
+- (NSUUID *)track:(SPEvent *)event;
 
 @end
 

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -532,16 +532,17 @@ void uncaughtExceptionHandler(NSException *exception) {
 
 #pragma mark - Event Tracking Functions
 
-- (void)track:(SPEvent *)event {
-    if (!event || !_dataCollection) return;
+- (NSUUID *)track:(SPEvent *)event {
+    if (!event || !_dataCollection) return nil;
     [event beginProcessingWithTracker:self];
-    [self processEvent:event];
+    NSUUID *eventId = [self processEvent:event];
     [event endProcessingWithTracker:self];
+    return eventId;
 }
 
 #pragma mark - Event Decoration
 
-- (void)processEvent:(SPEvent *)event {
+- (NSUUID *)processEvent:(SPEvent *)event {
     SPTrackerState *stateSnapshot;
     @synchronized (self) {
         stateSnapshot = [self.stateManager trackerStateForProcessedEvent:event];
@@ -550,6 +551,7 @@ void uncaughtExceptionHandler(NSException *exception) {
     [self transformEvent:trackerEvent];
     SPPayload *payload = [self payloadWithEvent:trackerEvent];
     [_emitter addPayloadToBuffer:payload];
+    return [trackerEvent eventId];
 }
 
 - (void)transformEvent:(SPTrackerEvent *)event {

--- a/Snowplow/Internal/Tracker/SPTrackerController.h
+++ b/Snowplow/Internal/Tracker/SPTrackerController.h
@@ -85,8 +85,9 @@ NS_SWIFT_NAME(TrackerController)
  * Track the event.
  * The tracker will take care to process and send the event assigning `event_id` and `device_timestamp`.
  * @param event The event to track.
+ * @return The event ID or nil in case tracking is paused
  */
-- (void)track:(SPEvent *)event;
+- (NSUUID *)track:(SPEvent *)event;
 /**
  * Pause the tracker.
  * The tracker will stop any new activity tracking but it will continue to send remaining events

--- a/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
+++ b/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
@@ -82,8 +82,8 @@
     [self.tracker resumeEventTracking];
 }
 
-- (void)track:(nonnull SPEvent *)event {
-    [self.tracker track:event];
+- (NSUUID *)track:(nonnull SPEvent *)event {
+    return [self.tracker track:event];
 }
 
 // MARK: - Properties' setters and getters


### PR DESCRIPTION
Addresses issue #710 and makes the track method return the event ID as a `NSUUID *`. The change is quite small as the ID was already present in the method, it was only necessary to return it.