### PR TITLE
Add nullable modifier to prevent crashes in track function (close #713)

### DIFF
--- a/Snowplow/Internal/Tracker/SPTracker.h
+++ b/Snowplow/Internal/Tracker/SPTracker.h
@@ -345,7 +345,7 @@ NS_SWIFT_NAME(TrackerBuilder)
  @param event The event to track
  @return The event ID or nil in case tracking is paused
  */
-- (NSUUID *)track:(SPEvent *)event;
+- (nullable NSUUID *)track:(SPEvent *)event;
 
 @end
 

--- a/Snowplow/Internal/Tracker/SPTrackerController.h
+++ b/Snowplow/Internal/Tracker/SPTrackerController.h
@@ -87,7 +87,7 @@ NS_SWIFT_NAME(TrackerController)
  * @param event The event to track.
  * @return The event ID or nil in case tracking is paused
  */
-- (NSUUID *)track:(SPEvent *)event;
+- (nullable NSUUID *)track:(SPEvent *)event;
 /**
  * Pause the tracker.
  * The tracker will stop any new activity tracking but it will continue to send remaining events


### PR DESCRIPTION
Addresses issue https://github.com/snowplow/snowplow-objc-tracker/issues/713 By making the UUID returned by the track function nullable, which was previously assumed to be non-null by `NS_ASSUME_NONNULL`. This will prevent crashes when calling track after event tracking has been paused.