### PR TITLE
Log an error when recreating tracker after being removed (close #716)

### DIFF
--- a/Snowplow iOSTests/Utils/SPMockLoggerDelegate.h
+++ b/Snowplow iOSTests/Utils/SPMockLoggerDelegate.h
@@ -1,0 +1,35 @@
+//
+//  SPMockLoggerDelegate.h
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini, Matus Tomlein
+//  License: Apache License Version 2.0
+//
+
+#import <Foundation/Foundation.h>
+#import "SPLoggerDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPMockLoggerDelegate : NSObject <SPLoggerDelegate>
+
+@property (nonatomic) NSMutableArray<NSString *> *errorLogs;
+@property (nonatomic) NSMutableArray<NSString *> *debugLogs;
+@property (nonatomic) NSMutableArray<NSString *> *verboseLogs;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snowplow iOSTests/Utils/SPMockLoggerDelegate.m
+++ b/Snowplow iOSTests/Utils/SPMockLoggerDelegate.m
@@ -1,0 +1,47 @@
+//
+//  SPMockLoggerDelegate.m
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini, Matus Tomlein
+//  License: Apache License Version 2.0
+//
+
+#import "SPMockLoggerDelegate.h"
+
+@implementation SPMockLoggerDelegate
+
+- (instancetype)init {
+    if (self = [super init]) {
+        self.errorLogs = [NSMutableArray new];
+        self.debugLogs = [NSMutableArray new];
+        self.verboseLogs = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (void)debug:(nonnull NSString *)tag message:(nonnull NSString *)message {
+    [self.debugLogs addObject:message];
+}
+
+- (void)error:(nonnull NSString *)tag message:(nonnull NSString *)message {
+    [self.errorLogs addObject:message];
+}
+
+- (void)verbose:(nonnull NSString *)tag message:(nonnull NSString *)message {
+    [self.verboseLogs addObject:message];
+}
+
+@end

--- a/Snowplow.xcodeproj/project.pbxproj
+++ b/Snowplow.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		6B871F6727C3976C00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
 		6B871F6827C3976C00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
 		6B871F6927C3976D00BCF742 /* SPMockNetworkConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */; };
+		6BA149392900607C00407200 /* SPMockLoggerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BA1493029005EF700407200 /* SPMockLoggerDelegate.m */; };
 		6BABC50E270B40450043BB5C /* TestSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BF15D1227035A480048F376 /* TestSubject.m */; };
 		6BACDF922897C2580013276E /* SPConfigurationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BACDF912897C2580013276E /* SPConfigurationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6BACDF932897C2580013276E /* SPConfigurationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BACDF912897C2580013276E /* SPConfigurationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -956,6 +957,8 @@
 		6B871F6027C3913300BCF742 /* TestEmitterConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestEmitterConfiguration.m; sourceTree = "<group>"; };
 		6B871F6227C3928900BCF742 /* SPMockNetworkConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockNetworkConnection.h; sourceTree = "<group>"; };
 		6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMockNetworkConnection.m; sourceTree = "<group>"; };
+		6BA1492F29005EF700407200 /* SPMockLoggerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMockLoggerDelegate.h; sourceTree = "<group>"; };
+		6BA1493029005EF700407200 /* SPMockLoggerDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPMockLoggerDelegate.m; sourceTree = "<group>"; };
 		6BACDF912897C2580013276E /* SPConfigurationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPConfigurationState.h; sourceTree = "<group>"; };
 		6BBDCD4027019AF4001B547F /* SPPlatformContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPPlatformContext.h; path = Snowplow/Internal/Subject/SPPlatformContext.h; sourceTree = SOURCE_ROOT; };
 		6BBDCD4127019AF4001B547F /* SPPlatformContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPPlatformContext.m; path = Snowplow/Internal/Subject/SPPlatformContext.m; sourceTree = SOURCE_ROOT; };
@@ -1501,6 +1504,8 @@
 				6B871F6327C3928900BCF742 /* SPMockNetworkConnection.m */,
 				6BD6A6AA288719C7002D6D40 /* SPMockWKScriptMessage.h */,
 				6BD6A6AB288719C7002D6D40 /* SPMockWKScriptMessage.m */,
+				6BA1492F29005EF700407200 /* SPMockLoggerDelegate.h */,
+				6BA1493029005EF700407200 /* SPMockLoggerDelegate.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2678,6 +2683,7 @@
 				D99BDC6D2834F89A00F6A14F /* TestLifecycleState.m in Sources */,
 				6BF15D0C2702ECD70048F376 /* TestPlatformContext.m in Sources */,
 				75CAC40821F2955100271FB3 /* LegacyTestSubject.m in Sources */,
+				6BA149392900607C00407200 /* SPMockLoggerDelegate.m in Sources */,
 				ED8BF8ED2570FB2F001DFDD9 /* TestTrackerConfiguration.m in Sources */,
 				75CAC41221F2955100271FB3 /* TestRequest.m in Sources */,
 				75CAC40621F2955100271FB3 /* TestSQLiteEventStore.m in Sources */,

--- a/Snowplow/Internal/Emitter/SPEmitter.m
+++ b/Snowplow/Internal/Emitter/SPEmitter.m
@@ -101,7 +101,7 @@ const NSUInteger POST_WRAPPER_BYTES = 88;
     _networkConnection = [SPDefaultNetworkConnection build:^(id<SPDefaultNetworkConnectionBuilder> builder) {
         __typeof__(self) strongSelf = weakSelf;
         if (!strongSelf) return;
-        NSString *endpoint = strongSelf->_url;
+        NSString *endpoint = strongSelf->_url ? strongSelf->_url : @""; // use empty string in case nil to avoid crashing
         if (![endpoint hasPrefix:@"http"]) {
             NSString *protocol = strongSelf->_protocol == SPProtocolHttps ? @"https://" : @"http://";
             endpoint = [protocol stringByAppendingString:endpoint];

--- a/Snowplow/Internal/Tracker/SPServiceProvider.m
+++ b/Snowplow/Internal/Tracker/SPServiceProvider.m
@@ -194,6 +194,10 @@
 
 // MARK: - Getters
 
+- (BOOL)isTrackerInitialized {
+    return _tracker != nil;
+}
+
 - (SPSubject *)subject {
     if (_subject) return _subject;
     _subject = [self makeSubject];

--- a/Snowplow/Internal/Tracker/SPServiceProviderProtocol.h
+++ b/Snowplow/Internal/Tracker/SPServiceProviderProtocol.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nonnull, readonly) NSString *namespace;
 
+- (BOOL)isTrackerInitialized;
+
 - (SPTracker *)tracker;
 - (SPEmitter *)emitter;
 - (SPSubject *)subject;

--- a/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
+++ b/Snowplow/Internal/Tracker/SPTrackerControllerImpl.m
@@ -285,6 +285,9 @@
 // MARK: - Private methods
 
 - (SPTracker *)tracker {
+    if (![self.serviceProvider isTrackerInitialized]) {
+        SPLogError(@"Recreating tracker instance after it was removed. This will not be supported in future versions.");
+    }
     return self.serviceProvider.tracker;
 }
 

--- a/TestServiceProvider.m
+++ b/TestServiceProvider.m
@@ -32,6 +32,7 @@
 #import "SPEmitterControllerImpl.h"
 #import "SPEmitterConfigurationUpdate.h"
 #import "SPTrackerController.h"
+#import "SPMockLoggerDelegate.h"
 
 
 @interface TestServiceProvider : XCTestCase
@@ -82,5 +83,26 @@
     XCTAssertEqual(0, [[serviceProvider emitter] getDbCount]);
 }
 
+- (void)testLogsErrorWhenAccessingShutDownTracker {
+    SPMockNetworkConnection *networkConnection = [[SPMockNetworkConnection alloc] initWithRequestOption:SPHttpMethodPost statusCode:200];
+    SPEmitterConfiguration *emitterConfig = [[SPEmitterConfiguration alloc] init];
+    emitterConfig.eventStore = [SPMockEventStore new];
+    emitterConfig.bufferOption = SPBufferOptionSingle;
+    SPNetworkConfiguration *networkConfig = [[SPNetworkConfiguration alloc] initWithEndpoint:@"" method:SPHttpMethodPost];
+    networkConfig.networkConnection = networkConnection;
+    SPServiceProvider *serviceProvider = [[SPServiceProvider alloc] initWithNamespace:@"ns" network:networkConfig configurations:@[emitterConfig]];
+    XCTAssertNotNil(serviceProvider);
+    
+    // listen for the error log
+    id<SPTrackerController> trackerController = [serviceProvider trackerController];
+    SPMockLoggerDelegate *logger = [SPMockLoggerDelegate new];
+    [trackerController setLoggerDelegate:logger];
+    
+    // shutting down and accessing the tracker should log the error
+    [serviceProvider shutdown];
+    [trackerController namespace];
+    XCTAssertEqual(1, [[logger errorLogs] count]);
+    XCTAssertTrue([[[logger errorLogs] objectAtIndex:0] containsString:@"Recreating tracker instance"]);
+}
 
 @end


### PR DESCRIPTION
Issue #716 

The problem that we are dealing with here is that users got confusing behaviour after having code that did something similar to this:

```swift
let tracker = Snowplow.createTracker(...);
Snowplow.removeTracker(tracker);
print("Tracker removed: " + tracker.namespace);
```

In this case the tracker was removed on the second line but it was reinitialized on the third line, which is not obvious based on the snippet. Reinitializing the tracker also means that various autotracking features may be reactivated and unexpected events tracked.

I would like to prevent this behaviour and just return NULL from the `getNamespace()` and other functions from the `TrackerController` but I realized that this would be a breaking change. We would need to change the signature of the `TrackerController` functions.

So in order to prevent making the breaking change, this PR logs an error when a tracker that was previously removed is accessed. This should make it easier for users to debug the weird behaviour.

**Note:**
There is another small change in `SPEmitter` which sets the endpoint to an empty string in case it is nil, [see here](https://github.com/snowplow/snowplow-objc-tracker/pull/717/files#diff-36e5044550173b6bcefd47c61875ab64aecdb795604dc11bfed4b484a7f9ca67R104). What was happening was that after the tracker is removed, the configuration objects in `SPServiceProvider` are cleared and so when the tracker is later recreated, a nil URL endpoint is used for the network connection. This was raising errors each time the tracker was initialized after being removed. Since the Android tracker doesn't raise any errors and this error is quite unintuitive, I decided to handle that case.