### PR TITLE
Add DeepLink entity referrer and url to atomic properties in ScreenView events (close #718)

### DIFF
--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -642,6 +642,7 @@ void uncaughtExceptionHandler(NSException *exception) {
                 NSDictionary *data = (NSDictionary *)[entity data];
                 url = (NSString *)[data valueForKey:kSPDeepLinkReceivedParamUrl];
                 referrer = (NSString *)[data valueForKey:kSPDeepLinkParamReferrer];
+                break;
             }
         }
     }

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -623,7 +623,7 @@ void uncaughtExceptionHandler(NSException *exception) {
 /*
  This is needed because the campaign-attribution-enrichment (in the pipeline) is able to parse
  the `url` and `referrer` only if they are part of a PageView event.
- The PageView event is an atomic event but the DeepLinkReceived is a SelfDescribing event.
+ The PageView event is an atomic event but the DeepLinkReceived and ScreenView are SelfDescribing events.
  For this reason we copy these two fields in the atomic fields in order to let the enrichment
  to process correctly the fields even if the event is not a PageView and it's a SelfDescribing event.
  This is a hack that should be removed once the atomic event table is dismissed and all the events

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -44,6 +44,7 @@
 #import "SPBackground.h"
 #import "SPPushNotification.h"
 #import "SPDeepLinkReceived.h"
+#import "SPDeepLinkEntity.h"
 #import "SPTrackerEvent.h"
 #import "SPTrackerError.h"
 #import "SPLogger.h"
@@ -579,6 +580,10 @@ void uncaughtExceptionHandler(NSException *exception) {
     [self addGlobalContextsToContexts:contexts event:event];
     [self addStateMachineEntitiesToContexts:contexts event:event];
     [self wrapContexts:contexts toPayload:payload];
+    if (!event.isPrimitive) {
+        // TODO: To remove when Atomic table refactoring is finished
+        [self workaroundForCampaignAttributionEnrichment:payload event:event contexts:contexts];
+    }
     return payload;
 }
 
@@ -604,8 +609,6 @@ void uncaughtExceptionHandler(NSException *exception) {
 - (void)addSelfDescribingPropertiesToPayload:(SPPayload *)payload event:(SPTrackerEvent *)event {
     [payload addValueToPayload:kSPEventUnstructured forKey:kSPEvent];
 
-    [self workaroundForCampaignAttributionEnrichment:payload event:event]; // TODO: To remove when Atomic table refactoring is finished
-    
     SPSelfDescribingJson *data = [[SPSelfDescribingJson alloc] initWithSchema:event.schema andData:event.payload];
     NSDictionary *unstructuredEventPayload = @{
         kSPSchema: kSPUnstructSchema,
@@ -626,11 +629,27 @@ void uncaughtExceptionHandler(NSException *exception) {
  This is a hack that should be removed once the atomic event table is dismissed and all the events
  will be SelfDescribing.
  */
-- (void)workaroundForCampaignAttributionEnrichment:(SPPayload *)payload event:(SPTrackerEvent *)event {
+- (void)workaroundForCampaignAttributionEnrichment:(SPPayload *)payload event:(SPTrackerEvent *)event contexts:(NSMutableArray<SPSelfDescribingJson *> *)contexts {
+    NSString *url = nil;
+    NSString *referrer = nil;
+    
     if ([event.schema isEqualToString:kSPDeepLinkReceivedSchema]) {
-        NSString *url = (NSString *)[event.payload objectForKey:kSPDeepLinkReceivedParamUrl];
-        NSString *referrer = (NSString *)[event.payload objectForKey:kSPDeepLinkReceivedParamReferrer];
+        url = (NSString *)[event.payload objectForKey:kSPDeepLinkReceivedParamUrl];
+        referrer = (NSString *)[event.payload objectForKey:kSPDeepLinkReceivedParamReferrer];
+    } else if ([event.schema isEqualToString:kSPScreenViewSchema]) {
+        for (SPSelfDescribingJson *entity in contexts) {
+            if ([[entity schema] isEqualToString:kSPDeepLinkSchema]) {
+                NSDictionary *data = (NSDictionary *)[entity data];
+                url = (NSString *)[data valueForKey:kSPDeepLinkReceivedParamUrl];
+                referrer = (NSString *)[data valueForKey:kSPDeepLinkParamReferrer];
+            }
+        }
+    }
+    
+    if (url != nil) {
         [payload addValueToPayload:url forKey:kSPPageUrl];
+    }
+    if (referrer != nil) {
         [payload addValueToPayload:referrer forKey:kSPPageRefr];
     }
 }


### PR DESCRIPTION
Issue #718  

This PR extends the workaround in the tracker which sets the page referrer and page URL atomic properties in events – previously it only set them for deep link events based on their properties. Now, it also sets them for screen view events based on the deep link context entities.

I had to move the workaround to a different place. Previously it was called in `addSelfDescribingPropertiesToPayload()` in Tracker but at that point the events do not contain context entities assigned using state machines. Since the deep link entity is added in a state machine, I moved the call to after state machine context entities are added to events.