### PR TITLE
Anonymise previous session ID and user identifiers in subject when user anonymisation is enabled (close #720)

### DIFF
--- a/Snowplow iOSTests/Configurations/TestTrackerController.m
+++ b/Snowplow iOSTests/Configurations/TestTrackerController.m
@@ -63,4 +63,24 @@
     XCTAssertEqualObjects([NSNumber numberWithFloat:0], tracker.subject.geoLatitude);
 }
 
+- (void)testStartsNewSessionWhenChangingAnonymousTracking {
+    id<SPTrackerController> tracker = [SPSnowplow createTrackerWithNamespace:@"namespace" endpoint:@"https://fake-url" method:SPHttpMethodPost];
+    [tracker.emitter pause];
+    
+    [tracker track:[[SPStructured alloc] initWithCategory:@"c" action:@"a"]];
+    NSString *sessionIdBefore = tracker.session.sessionId;
+    
+    tracker.userAnonymisation = true;
+    [tracker track:[[SPStructured alloc] initWithCategory:@"c" action:@"a"]];
+    NSString *sessionIdAnonymous = tracker.session.sessionId;
+    
+    XCTAssertFalse([sessionIdBefore isEqualToString:sessionIdAnonymous]);
+    
+    tracker.userAnonymisation = false;
+    [tracker track:[[SPStructured alloc] initWithCategory:@"c" action:@"a"]];
+    NSString *sessionIdNotAnonymous = tracker.session.sessionId;
+    
+    XCTAssertFalse([sessionIdAnonymous isEqualToString:sessionIdNotAnonymous]);
+}
+
 @end

--- a/Snowplow iOSTests/Legacy Tests/LegacyTestSubject.m
+++ b/Snowplow iOSTests/Legacy Tests/LegacyTestSubject.m
@@ -44,13 +44,13 @@
 
 - (void)testSubjectInit {
     SPSubject * subject = [[SPSubject alloc] init];
-    XCTAssertNotNil([subject getStandardDict]);
+    XCTAssertNotNil([subject getStandardDictWithUserAnonymisation:NO]);
 }
 
 - (void)testSubjectInitWithOptions {
     SPSubject * subject = [[SPSubject alloc] initWithPlatformContext:YES andGeoContext:NO];
     XCTAssertNotNil([subject getPlatformDictWithUserAnonymisation:NO]);
-    XCTAssertNotNil([subject getStandardDict]);
+    XCTAssertNotNil([subject getStandardDictWithUserAnonymisation:NO]);
 }
 
 - (void)testSubjectSetterFunctions {
@@ -66,7 +66,7 @@
     [subject setNetworkUserId:@"aNuid"];
     [subject setDomainUserId:@"aDuid"];
     
-    NSDictionary * values = [[subject getStandardDict] getAsDictionary];
+    NSDictionary * values = [[subject getStandardDictWithUserAnonymisation:NO] getAsDictionary];
     
     XCTAssertEqual([values valueForKey:kSPUid], @"aUserId");
     XCTAssertTrue([[values valueForKey:kSPResolution] isEqualToString:@"1920x1080" ]);

--- a/Snowplow iOSTests/TestSession.m
+++ b/Snowplow iOSTests/TestSession.m
@@ -502,7 +502,7 @@
     
     NSDictionary *withAnonymisation = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481347 userAnonymisation:YES];
     XCTAssertTrue([[withAnonymisation objectForKey:kSPSessionUserId] isEqualToString:@"00000000-0000-0000-0000-000000000000"]);
-    XCTAssertNil([withAnonymisation objectForKey:kSPSessionPreviousId]);
+    XCTAssertEqualObjects([NSNull null], [withAnonymisation objectForKey:kSPSessionPreviousId]);
 }
 
 // Service methods

--- a/Snowplow iOSTests/TestSession.m
+++ b/Snowplow iOSTests/TestSession.m
@@ -493,12 +493,16 @@
 
 - (void)testAnonymisesUserIdentifiers {
     SPSession *session = [[SPSession alloc] initWithForegroundTimeout:3 andBackgroundTimeout:3 andTracker:nil];
+    [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481345 userAnonymisation:NO];
+    [session startNewSession]; // create previous session ID reference
     
-    NSDictionary *withoutAnonymisation = [session getSessionDictWithEventId:@"event_1" eventTimestamp:1654496481346 userAnonymisation:NO];
+    NSDictionary *withoutAnonymisation = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481346 userAnonymisation:NO];
     XCTAssertFalse([[withoutAnonymisation objectForKey:kSPSessionUserId] isEqualToString:@"00000000-0000-0000-0000-000000000000"]);
+    XCTAssertNotNil([withoutAnonymisation objectForKey:kSPSessionPreviousId]);
     
-    NSDictionary *withAnonymisation = [session getSessionDictWithEventId:@"event_2" eventTimestamp:1654496481347 userAnonymisation:YES];
+    NSDictionary *withAnonymisation = [session getSessionDictWithEventId:@"event_3" eventTimestamp:1654496481347 userAnonymisation:YES];
     XCTAssertTrue([[withAnonymisation objectForKey:kSPSessionUserId] isEqualToString:@"00000000-0000-0000-0000-000000000000"]);
+    XCTAssertNil([withAnonymisation objectForKey:kSPSessionPreviousId]);
 }
 
 // Service methods

--- a/Snowplow iOSTests/TestSubject.m
+++ b/Snowplow iOSTests/TestSubject.m
@@ -59,4 +59,19 @@
     XCTAssertNil(geoLocationDict);
 }
 
+- (void)testAnonymisesUserIdentifiers {
+    SPSubject *subject = [[SPSubject alloc] initWithPlatformContext:NO andGeoContext:NO];
+    [subject setUserId:@"aUserId"];
+    [subject setIpAddress:@"127.0.0.1"];
+    [subject setNetworkUserId:@"aNuid"];
+    [subject setDomainUserId:@"aDuid"];
+    [subject setLanguage:@"EN"];
+
+    NSDictionary *values = [[subject getStandardDictWithUserAnonymisation:YES] getAsDictionary];
+    XCTAssertNil([values valueForKey:kSPUid]);
+    XCTAssertNil([values valueForKey:kSPIpAddress]);
+    XCTAssertNil([values valueForKey:kSPNetworkUid]);
+    XCTAssertNil([values valueForKey:kSPDomainUid]);
+    XCTAssertEqual([values valueForKey:kSPLanguage], @"EN");
+}
 @end

--- a/Snowplow/Internal/Configurations/SPTrackerConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPTrackerConfiguration.h
@@ -102,7 +102,7 @@ NS_SWIFT_NAME(TrackerConfigurationProtocol)
  */
 @property (nonatomic, nullable) NSString *trackerVersionSuffix;
 /**
- * Whether to anonymise client-side user identifiers in session and platform context entities.
+ * Whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
  */
 @property () BOOL userAnonymisation;
 
@@ -207,7 +207,7 @@ SP_BUILDER_DECLARE(BOOL, diagnosticAutotracking)
  */
 SP_BUILDER_DECLARE(NSString *, trackerVersionSuffix)
 /**
- * Whether to anonymise client-side user identifiers in session and platform context entities
+ * Whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
  */
 SP_BUILDER_DECLARE(BOOL, userAnonymisation)
 

--- a/Snowplow/Internal/Configurations/SPTrackerConfiguration.h
+++ b/Snowplow/Internal/Configurations/SPTrackerConfiguration.h
@@ -103,6 +103,7 @@ NS_SWIFT_NAME(TrackerConfigurationProtocol)
 @property (nonatomic, nullable) NSString *trackerVersionSuffix;
 /**
  * Whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
+ * Setting this property on a running tracker instance starts a new session (if sessions are tracked).
  */
 @property () BOOL userAnonymisation;
 

--- a/Snowplow/Internal/Session/SPSession.m
+++ b/Snowplow/Internal/Session/SPSession.m
@@ -145,6 +145,7 @@
     if (userAnonymisation) { // mask the user identifier
         NSMutableDictionary *copy = [[NSMutableDictionary alloc] initWithDictionary:context];
         [copy setValue:kSPSessionAnonymousUserId forKey:kSPSessionUserId];
+        [copy setValue:[NSNull null] forKey:kSPSessionPreviousId];
         return copy;
     } else {
         return context;

--- a/Snowplow/Internal/Subject/SPSubject.h
+++ b/Snowplow/Internal/Subject/SPSubject.h
@@ -67,9 +67,10 @@ NS_SWIFT_NAME(Subject)
 
 /*!
  @brief Gets all standard dictionary pairs to decorate the event with.
+ @param userAnonymisation Whether to anonymise user identifiers
  @return A SPPayload with all standard pairs.
  */
-- (SPPayload *) getStandardDict;
+- (SPPayload *) getStandardDictWithUserAnonymisation:(BOOL)userAnonymisation;
 
 /*!
  @brief Gets all platform dictionary pairs to decorate event with. Returns nil if not enabled.

--- a/Snowplow/Internal/Subject/SPSubject.m
+++ b/Snowplow/Internal/Subject/SPSubject.m
@@ -105,7 +105,15 @@
 
 #pragma clang diagnostic pop
 
-- (SPPayload *) getStandardDict {
+- (SPPayload *) getStandardDictWithUserAnonymisation:(BOOL)userAnonymisation {
+    if (userAnonymisation) {
+        NSMutableDictionary *copy = [[NSMutableDictionary alloc] initWithDictionary:[_standardDict getAsDictionary]];
+        [copy removeObjectForKey:kSPUid];
+        [copy removeObjectForKey:kSPDomainUid];
+        [copy removeObjectForKey:kSPNetworkUid];
+        [copy removeObjectForKey:kSPIpAddress];
+        return [[SPPayload alloc] initWithNSDictionary:copy];
+    }
     return _standardDict;
 }
 

--- a/Snowplow/Internal/Tracker/SPTracker.h
+++ b/Snowplow/Internal/Tracker/SPTracker.h
@@ -213,8 +213,8 @@ NS_SWIFT_NAME(TrackerBuilder)
             documentDescription:(nullable NSString *)documentDescription;
 
 /*!
- @brief Tracker builder method to set whether to anonymise client-side user identifiers in session and platform context entities.
- @param userAnonymisation Whether to anonymise client-side user identifiers in session and platform context entities
+ @brief Tracker builder method to set whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
+ @param userAnonymisation Whether to anonymise client-side user identifiers
  */
 - (void) setUserAnonymisation:(BOOL)userAnonymisation;
 

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -399,7 +399,12 @@ void uncaughtExceptionHandler(NSException *exception) {
 }
 
 - (void)setUserAnonymisation:(BOOL)userAnonymisation {
-    _userAnonymisation = userAnonymisation;
+    if (_userAnonymisation != userAnonymisation) {
+        _userAnonymisation = userAnonymisation;
+        if (_session != nil) {
+            [_session startNewSession];
+        }
+    }
 }
 
 #pragma mark - Global Contexts methods

--- a/Snowplow/Internal/Tracker/SPTracker.m
+++ b/Snowplow/Internal/Tracker/SPTracker.m
@@ -591,7 +591,7 @@ void uncaughtExceptionHandler(NSException *exception) {
     }
     [payload addDictionaryToPayload:_trackerData];
     if (_subject != nil) {
-        [payload addDictionaryToPayload:[[_subject getStandardDict] getAsDictionary]];
+        [payload addDictionaryToPayload:[[_subject getStandardDictWithUserAnonymisation:self.userAnonymisation] getAsDictionary]];
     }
     [payload addValueToPayload:SPDevicePlatformToString(_devicePlatform) forKey:kSPPlatform];
 }


### PR DESCRIPTION
Issue #720 

Anonymises additional properties when `TrackerConfiguration.userAnonymisation` is enabled. In particular, the following additional properties are anonymised:

* Session context entity
   * `previousSessionId` – otherwise one could recreate the whole user journey from the chain of sessions and basically recreate a user id
* Subject
   * `userId` – also anonymised in the JavaScript tracker
   * `domainUserId` – also anonymised in the JavaScript tracker
   * `networkUserId` – anonymised when server anonymisation is enabled, I think it makes sense to also anonymise if it is set client-side
   * `ipAddress` – anonymised when server anonymisation is enabled, I think it makes sense to also anonymise if it is set client-side

## Documentation

Anonymous tracking is a tracker feature that enables anonymising various user and session identifiers to support user privacy in case consent for tracking the identifiers is not given.

On mobile, the following user and session identifiers can be anonymised:

* Client-side user identifiers:
   * `userId` in the [Session](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2) context entity
   * IDFA identifiers (`appleIdfa` and `appleIdfv` for iOS, `androidIdfa` for Android) in the [Platform](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2) context entity
   * `userId`, `domainUserId`, `networkUserId`, `ipAddress` if they are set in `Subject`
* Client-side session identifiers: `sessionId` and `previousSessionId` in Session entity.
* Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.