### PR TITLE
Fix compiler warning in SPEmitterControllerImpl to synthesize customRetryForStatusCodes (close #722)

### DIFF
--- a/Snowplow/Internal/Emitter/SPEmitterControllerImpl.m
+++ b/Snowplow/Internal/Emitter/SPEmitterControllerImpl.m
@@ -34,6 +34,7 @@
 @synthesize byteLimitPost;
 @synthesize emitRange;
 @synthesize threadPoolSize;
+@synthesize customRetryForStatusCodes;
 
 // MARK: - Properties
 


### PR DESCRIPTION
Issue #722 

Add missing `@synthesize` directive for the `customRetryForStatusCodes` property in `SPEmitterControllerImpl`.