### PR TITLE
Add tests using Micro for payload validation (close #736)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # -- Micro --
+      - name: Cache Micro
+        id: cache-micro
+        uses: actions/cache@v3
+        with:
+          path: micro.jar
+          key: ${{ runner.os }}-micro
+
+      - name: Get micro
+        if: steps.cache-micro.outputs.cache-hit != 'true'
+        run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.3.4/snowplow-micro-1.3.4.jar
+
+      - name: Run Micro in background
+        run: java -jar micro.jar &
+
+      - name: Wait on Micro endpoint
+        timeout-minutes: 2
+        run: while ! nc -z '0.0.0.0' 9090; do sleep 1; done
+      # -- Micro --
+
       - name: Select Xcode Version
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
 
@@ -68,7 +88,8 @@ jobs:
             -scheme SnowplowTracker \
             -sdk "${{ matrix.sdk }}" \
             -destination "${{ matrix.destination }}" \
-            clean test | xcpretty
+            -quiet \
+            clean test
 
   build_objc_demo_app:
     name: "ObjC demo (iOS ${{ matrix.version.ios }})"

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,4 +1,0 @@
-coverage_service: coveralls
-xcodeproj: Snowplow.xcodeproj
-workspace: Snowplow.xcworkspace
-scheme: Snowplow-iOS

--- a/Sources/Core/Tracker/StateFuture.swift
+++ b/Sources/Core/Tracker/StateFuture.swift
@@ -27,19 +27,6 @@ import Foundation
 /// For this reason, the StateFuture can be the head of StateFuture chain which will collapse once the StateFuture
 /// head is asked to get the real state value.
 class StateFuture: NSObject {
-    var state: State? {
-        objc_sync_enter(self)
-        defer { objc_sync_exit(self) }
-        if computedState == nil {
-            if let stateMachine = stateMachine, let event = event {
-                computedState = stateMachine.transition(from: event, state: previousState?.state)
-            }
-            event = nil
-            previousState = nil
-            stateMachine = nil
-        }
-        return computedState
-    }
     private var event: Event?
     private var previousState: StateFuture?
     private var stateMachine: StateMachineProtocol?
@@ -50,5 +37,19 @@ class StateFuture: NSObject {
         self.event = event
         self.previousState = previousState
         self.stateMachine = stateMachine
+    }
+    
+    func computeState() -> State? {
+        objc_sync_enter(self)
+        defer { objc_sync_exit(self) }
+        if computedState == nil {
+            if let stateMachine = stateMachine, let event = event {
+                computedState = stateMachine.transition(from: event, state: previousState?.computeState())
+                previousState = nil
+                self.event = nil
+                self.stateMachine = nil
+            }
+        }
+        return computedState
     }
 }

--- a/Sources/Core/Tracker/StateManager.swift
+++ b/Sources/Core/Tracker/StateManager.swift
@@ -100,7 +100,7 @@ class StateManager: NSObject {
                  externally)
                  Remove the early state-computation only when these two problems are fixed.
                  */
-                _ = currentStateFuture.state // Early state-computation
+                _ = currentStateFuture.computeState() // Early state-computation
             }
         }
         return trackerState.snapshot()

--- a/Sources/Core/Tracker/TrackerState.swift
+++ b/Sources/Core/Tracker/TrackerState.swift
@@ -58,7 +58,7 @@ class TrackerState: NSObject, TrackerStateSnapshot {
     // Protocol SPTrackerStateSnapshot
 
     func state(withIdentifier stateIdentifier: String) -> State? {
-        return stateFuture(withIdentifier: stateIdentifier)?.state
+        return stateFuture(withIdentifier: stateIdentifier)?.computeState()
     }
 
     func state(withStateMachine stateMachine: StateMachineProtocol) -> State? {

--- a/Sources/Snowplow/Events/SelfDescribing.swift
+++ b/Sources/Snowplow/Events/SelfDescribing.swift
@@ -59,4 +59,9 @@ public class SelfDescribing: SelfDescribingAbstract {
         self._schema = schema
         self._payload = payload
     }
+    
+    public init(schema: String, payload: [String : String]) {
+        self._schema = schema
+        self._payload = payload as [String : NSObject]
+    }
 }

--- a/Tests/Configurations/TestRemoteConfiguration.swift
+++ b/Tests/Configurations/TestRemoteConfiguration.swift
@@ -24,6 +24,10 @@ import Mocker
 @testable import SnowplowTracker
 
 class TestRemoteConfiguration: XCTestCase {
+    override func tearDown() {
+        Mocker.removeAll()
+    }
+    
     func testJSONToConfigurations() {
         let config = """
             {"$schema":"http://iglucentral.com/schemas/com.snowplowanalytics.mobile/remote_config/jsonschema/1-0-0","configurationVersion":12,"configurationBundle": [\

--- a/Tests/Integration/TestTrackEventsToMicro.swift
+++ b/Tests/Integration/TestTrackEventsToMicro.swift
@@ -1,0 +1,199 @@
+//
+//  TestWithMicro.swift
+//  Snowplow-iOSTests
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Michael Hadam
+//  License: Apache License Version 2.0
+//
+
+import XCTest
+import SnowplowTracker
+
+class TestTrackEventsToMicro: XCTestCase {
+    var tracker: TrackerController?
+    
+    override func setUp() {
+        tracker = Snowplow.createTracker(namespace: "ns", network: NetworkConfiguration(endpoint: Micro.endpoint))!
+        
+        Micro.setUpMockerIgnores()
+        wait(for: [Micro.reset()], timeout: Micro.timeout)
+    }
+    
+    func testTrackStructuredEvent() {
+        let event = Structured(category: "shop", action: "add-to-basket")
+        event.label = "Add To Basket"
+        event.property = "pcs"
+        event.value = 2.0
+        track(event)
+        
+        wait(for: [
+            Micro.expectCounts(good: 1),
+            Micro.expectPrimitiveEvent() { actual in
+                XCTAssertEqual("shop", actual.se_category)
+                XCTAssertEqual("add-to-basket", actual.se_action)
+                XCTAssertEqual("Add To Basket", actual.se_label)
+                XCTAssertEqual("pcs", actual.se_property)
+                XCTAssertEqual(2.0, actual.se_value)
+            }
+        ], timeout: Micro.timeout)
+    }
+    
+    func testTrackSelfDescribing() {
+        let event = SelfDescribing(
+            schema: "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0",
+            payload: [
+                "name": "test", "id": "something else"
+            ]
+        )
+        track(event)
+        
+        wait(for: [
+            Micro.expectCounts(good: 1),
+            Micro.expectSelfDescribingEvent() { (actual: ScreenViewExpected) in
+                XCTAssertEqual("test", actual.name)
+                XCTAssertEqual("something else", actual.id)
+            }
+        ], timeout: Micro.timeout)
+    }
+    
+    func testTrackScreenViews() {
+        // track the first screen view
+        track(ScreenView(name: "screen1", screenId: UUID()))
+        wait(for: [Micro.expectCounts(good: 1)], timeout: Micro.timeout)
+        wait(for: [Micro.reset()], timeout: Micro.timeout)
+        
+        // track the second screen view and check reference to previous
+        track(ScreenView(name: "screen2", screenId: UUID()))
+        wait(for: [
+            Micro.expectCounts(good: 1),
+            Micro.expectSelfDescribingEvent() { (actual: ScreenViewExpected) in
+                XCTAssertEqual("screen2", actual.name)
+                XCTAssertEqual("screen1", actual.previousName)
+            }
+        ], timeout: Micro.timeout)
+        wait(for: [Micro.reset()], timeout: Micro.timeout)
+        
+        // track another event and check screen context
+        track(Timing(category: "cat", variable: "var", timing: 10))
+        wait(for: [
+            Micro.expectEventContext(
+                schema: "iglu:com.snowplowanalytics.mobile/screen/jsonschema/1-0-0"
+            ) { (actual: ScreenContextExpected) in
+                XCTAssertEqual("screen2", actual.name)
+            }
+        ], timeout: Micro.timeout)
+    }
+    
+    func testTrackDeepLink() {
+        // track the deep link received event
+        let deepLink = DeepLinkReceived(url: "https://snowplow.io")
+        deepLink.referrer = "https://plowsnow.io"
+        track(deepLink)
+        wait(for: [
+            Micro.expectSelfDescribingEvent() { (actual: DeepLinkExpected) in
+                XCTAssertEqual("https://snowplow.io", actual.url)
+                XCTAssertEqual("https://plowsnow.io", actual.referrer)
+            }
+        ], timeout: Micro.timeout)
+        wait(for: [Micro.reset()], timeout: Micro.timeout)
+        
+        // track a screen view and check references to the deep link
+        track(ScreenView(name: "screen", screenId: UUID()))
+        wait(for: [
+            // deep link info in payload
+            Micro.expectPrimitiveEvent() { actual in
+                XCTAssertEqual("https://snowplow.io", actual.page_url)
+                XCTAssertEqual("https://plowsnow.io", actual.page_referrer)
+            },
+            // deep link info in context entity
+            Micro.expectEventContext(
+                schema: "iglu:com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0"
+            ) { (actual: DeepLinkExpected) in
+                XCTAssertEqual("https://snowplow.io", actual.url)
+                XCTAssertEqual("https://plowsnow.io", actual.referrer)
+            }
+        ], timeout: Micro.timeout)
+    }
+    
+    func testSessionTracking() {
+        // track the first event
+        track(Structured(category: "cat", action: "act"))
+        var userId: String?, sessionId: String?
+        wait(for: [
+            Micro.expectEventContext(
+                schema: "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2"
+            ) { (actual: SessionExpected) in
+                userId = actual.userId
+                sessionId = actual.sessionId
+            }
+        ], timeout: Micro.timeout)
+        wait(for: [Micro.reset()], timeout: Micro.timeout)
+        
+        // track the second event in the same session
+        track(Structured(category: "cat", action: "act"))
+        wait(for: [
+            Micro.expectEventContext(
+                schema: "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2"
+            ) { (actual: SessionExpected) in
+                XCTAssertEqual(userId, actual.userId)
+                XCTAssertEqual(sessionId, actual.sessionId)
+            }
+        ], timeout: Micro.timeout)
+        wait(for: [Micro.reset()], timeout: Micro.timeout)
+        
+        // start a new session and track event
+        tracker!.session!.startNewSession()
+        track(Structured(category: "cat", action: "act"))
+        wait(for: [
+            Micro.expectEventContext(
+                schema: "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2"
+            ) { (actual: SessionExpected) in
+                XCTAssertEqual(userId, actual.userId)
+                XCTAssertNotEqual(sessionId, actual.sessionId)
+            }
+        ], timeout: Micro.timeout)
+    }
+    
+    private func track(_ event: Event) {
+        _ = tracker!.track(event)
+        tracker!.emitter!.flush()
+    }
+}
+
+struct ScreenViewExpected: Codable {
+    let name: String
+    let id: String
+    let type: String?
+    let previousName: String?
+    let previousId: String?
+    let previousType: String?
+    let transitionType: String?
+}
+
+struct ScreenContextExpected: Codable {
+    let name: String
+    let id: String
+}
+
+struct DeepLinkExpected: Codable {
+    let url: String
+    let referrer: String?
+}
+
+struct SessionExpected: Codable {
+    let sessionId: String
+    let userId: String
+}

--- a/Tests/TestNetworkConnection.swift
+++ b/Tests/TestNetworkConnection.swift
@@ -26,13 +26,9 @@ import XCTest
 let TEST_URL_ENDPOINT = "acme.test.url.com"
 
 class TestNetworkConnection: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        Mocker.removeAll()
-    }
-
     override func tearDown() {
         super.tearDown()
+        Mocker.removeAll()
     }
 
 #if !os(watchOS) // Mocker seems not to currently work on watchOS

--- a/Tests/Utils/Micro.swift
+++ b/Tests/Utils/Micro.swift
@@ -1,0 +1,211 @@
+//
+//  Micro.swift
+//  Snowplow-iOSTests
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Michael Hadam
+//  License: Apache License Version 2.0
+//
+
+import Foundation
+import XCTest
+import Mocker
+
+class Micro {
+    
+    static let timeout = 5.0
+    static let endpoint = "http://0.0.0.0:9090"
+    
+    class func setUpMockerIgnores() {
+        Mocker.ignore(URL(string: "\(endpoint)/micro/good")!)
+        Mocker.ignore(URL(string: "\(endpoint)/micro/reset")!)
+        Mocker.ignore(URL(string: "\(endpoint)/micro/all")!)
+        Mocker.ignore(URL(string: "\(endpoint)/com.snowplowanalytics.snowplow/tp2")!)
+        Mocker.ignore(URL(string: "\(endpoint)/i")!)
+    }
+    
+    class func reset() -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "Reset Micro")
+        let url = URLRequest(url: URL(string: "\(endpoint)/micro/reset")!)
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                XCTFail("Failed to reset Micro: \(error).")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        task.resume()
+        return expectation
+    }
+    
+    class func expectCounts(
+        good: Int = 0,
+        bad: Int = 0,
+        expectation: XCTestExpectation? = nil,
+        numberOfRetries: Int = 0) -> XCTestExpectation {
+        let expectation = expectation ?? XCTestExpectation(description: "Count of good and bad events")
+
+        let url = URLRequest(url: URL(string: "\(endpoint)/micro/all")!)
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                XCTFail("Failed to request Micro: \(error).")
+            } else if let data = data,
+                      let res = try? JSONDecoder().decode(AllResponse.self, from: data) {
+                if res.good == good && res.bad == bad {
+                    expectation.fulfill()
+                } else if numberOfRetries < 5 {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        _ = expectCounts(good: good,
+                                     bad: bad,
+                                     expectation: expectation,
+                                     numberOfRetries: numberOfRetries + 1)
+                    }
+                } else {
+                    XCTFail("Didn't find the expected event counts in Micro")
+                }
+            } else {
+                XCTFail("Failed to parse response from Micro")
+            }
+        }
+        task.resume()
+        
+        return expectation
+    }
+    
+    class func expectSelfDescribingEvent<T: Codable>(numberOfRetries: Int = 0,
+                                                     completion: @escaping (T)->()) -> XCTestExpectation {
+        return expectEvent() { (event: SelfDescribingResponse<T>) in
+            completion(event.unstruct_event.data.data)
+        }
+    }
+    
+    class func expectPrimitiveEvent(numberOfRetries: Int = 0,
+                                    completion: @escaping (PrimitiveResponse)->()) -> XCTestExpectation {
+        return expectEvent() { (event: PrimitiveResponse) in
+            completion(event)
+        }
+    }
+    
+    class func expectEventContext<T: Codable>(schema: String,
+                                              completion: @escaping (T)->()) -> XCTestExpectation {
+        return expectEvent() { (event: WithContextResponse<T>) in
+            if let entity = event.contexts.data.filter({ $0.schema == schema }).map({ $0.data! }).first {
+                completion(entity)
+            } else {
+                XCTFail("Failed to find the context entity in response")
+            }
+        }
+    }
+    
+    private class func expectEvent<T: Codable>(expectation: XCTestExpectation? = nil,
+                                               numberOfRetries: Int = 0,
+                                               completion: @escaping (T)->()) -> XCTestExpectation {
+        let expectation = expectation ?? XCTestExpectation(description: "Expected event")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let url = URLRequest(url: URL(string: "\(endpoint)/micro/good")!)
+            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+                if let error = error {
+                    XCTFail("Failed to request Micro: \(error).")
+                } else if let data = data {
+                    if let items = try? JSONDecoder().decode([GoodResponse<T>].self, from: data),
+                       let item = items.first {
+                        completion(item.event)
+                        expectation.fulfill()
+                    } else if numberOfRetries < 10 {
+                        _ = expectEvent(expectation: expectation,
+                                        numberOfRetries: numberOfRetries + 1,
+                                        completion: completion)
+                    } else {
+                        XCTFail("Didn't find the expected event in Micro")
+                    }
+                } else {
+                    XCTFail("Failed to parse response from Micro")
+                }
+            }
+            task.resume()
+        }
+        return expectation
+    }
+}
+
+struct AllResponse: Codable {
+    let good: Int
+    let bad: Int
+}
+
+struct PrimitiveResponse: Codable {
+    let se_category: String?
+    let se_action: String?
+    let se_label: String?
+    let se_property: String?
+    let se_value: Double?
+    let page_url: String?
+    let page_referrer: String?
+}
+
+struct SelfDescribingResponse<T: Codable>: Codable {
+    let unstruct_event: UnstructEventResponse<T>
+}
+
+struct UnstructEventResponse<T: Codable>: Codable {
+    let data: SelfDescribingDataResponse<T>
+}
+
+struct ContextEntityWrapper<T: Codable>: Decodable {
+    let entity: T?
+}
+
+extension ContextEntityWrapper {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        entity = try? container.decode(T.self)
+    }
+}
+
+struct ContextEntityResponse<T: Codable>: Codable {
+    let schema: String
+    let data: T?
+}
+
+extension ContextEntityResponse {
+    private enum CodingKeys: String, CodingKey {
+        case schema = "schema"
+        case data = "data"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        schema = try container.decode(String.self, forKey: .schema)
+        data = try? container.decode(T.self, forKey: .data)
+    }
+}
+
+struct ContextsResponse<T: Codable>: Codable {
+    let data: [ContextEntityResponse<T>]
+}
+
+struct WithContextResponse<T: Codable>: Codable {
+    let contexts: ContextsResponse<T>
+}
+
+struct SelfDescribingDataResponse<T: Codable>: Codable {
+    let data: T
+}
+
+struct GoodResponse<T: Codable>: Codable {
+    let event: T
+}


### PR DESCRIPTION
Issue #736 

This PR adds integration tests using Micro. After removing event payload schema validation using Iglu Client in the previous PR, Micro will enable us to validate event payloads against their schemas.

The main goal here is to set up the helpers and CI so that it is easy to write Micro tests. I implemented just a few tests, they don't cover all the main use cases yet, but they focus on some more scenarios that involve tracking multiple events (such as adding the previous screen view references or deep link information).

The helpers are in the `Micro` class which makes requests to Micro and also retries for a number of times to account for delays in updating Micro (the nice thing is that the actual tests don't need to worry about that and so are easier to read).