### PR TITLE
Update API comments for Swift-DocC and add missing comments (close #740)

### DIFF
--- a/Sources/Core/Utils/Utilities.swift
+++ b/Sources/Core/Utils/Utilities.swift
@@ -119,10 +119,11 @@ class Utilities {
         return Bundle.main.bundleIdentifier
     }
     
-    /// @brief URL encodes a dictionary as key=value pairs separated by &, so that it can be used in a query-string.
+    /// URL encodes a dictionary as key=value pairs separated by &, so that it can be used in a query-string.
+    ///
     /// This method can encode string, numbers, and bool values, and not embedded arrays or dictionaries.
     /// It encodes bool as 1 and 0.
-    /// @return The url encoded string of the dictionary.
+    /// - Returns: The url encoded string of the dictionary.
     class func urlEncode(_ dictionary: [String : NSObject]) -> String {
         return dictionary.map { (key: String, value: NSObject) in
             "\(self.urlEncode(key))=\(self.urlEncode(value.description))"

--- a/Sources/Core/Utils/Utilities.swift
+++ b/Sources/Core/Utils/Utilities.swift
@@ -121,7 +121,7 @@ class Utilities {
     
     /// URL encodes a dictionary as key=value pairs separated by &, so that it can be used in a query-string.
     ///
-    /// This method can encode string, numbers, and bool values, and not embedded arrays or dictionaries.
+    /// This method can encode string, numbers, and bool values, but not embedded arrays or dictionaries.
     /// It encodes bool as 1 and 0.
     /// - Returns: The url encoded string of the dictionary.
     class func urlEncode(_ dictionary: [String : NSObject]) -> String {

--- a/Sources/Snowplow/Configurations/Configuration.swift
+++ b/Sources/Snowplow/Configurations/Configuration.swift
@@ -20,6 +20,7 @@
 
 import Foundation
 
+/// Common parent class for configuration classes.
 @objc(SPConfiguration)
 public class Configuration: NSObject, NSCopying, NSSecureCoding {
     @objc

--- a/Sources/Snowplow/Configurations/NetworkConfiguration.swift
+++ b/Sources/Snowplow/Configurations/NetworkConfiguration.swift
@@ -20,8 +20,7 @@
 
 import Foundation
 
-/// Represents the network communication configuration
-/// allowing the tracker to be able to send events to the Snowplow collector.
+/// Represents the network communication configuration allowing the tracker to be able to send events to the Snowplow collector.
 @objc(SPNetworkConfiguration)
 public class NetworkConfiguration: Configuration {
     /// URL (without schema/protocol) used to send events to the collector.

--- a/Sources/Snowplow/Configurations/SessionConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SessionConfiguration.swift
@@ -20,6 +20,7 @@
 
 import Foundation
 
+/// Configuration for session management.
 @objc(SPSessionConfigurationProtocol)
 public protocol SessionConfigurationProtocol: AnyObject {
     /// The amount of time that can elapse before the

--- a/Sources/Snowplow/Configurations/SubjectConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SubjectConfiguration.swift
@@ -21,6 +21,7 @@
 import CoreGraphics
 import Foundation
 
+/// Configuration for the current user and device information that is tracked along with events.
 @objc(SPSubjectConfigurationProtocol)
 public protocol SubjectConfigurationProtocol: AnyObject {
     /// The custom UserID.

--- a/Sources/Snowplow/Configurations/TrackerConfiguration.swift
+++ b/Sources/Snowplow/Configurations/TrackerConfiguration.swift
@@ -21,6 +21,7 @@
 
 import Foundation
 
+/// Configuration of tracker properties.
 @objc(SPTrackerConfigurationProtocol)
 public protocol TrackerConfigurationProtocol: AnyObject {
     /// Identifer of the app.

--- a/Sources/Snowplow/Emitter/EventStore.swift
+++ b/Sources/Snowplow/Emitter/EventStore.swift
@@ -21,6 +21,7 @@
 
 import Foundation
 
+/// Protocol to implement storage for events that are queued to be sent.
 @objc(SPEventStore)
 public protocol EventStore: NSObjectProtocol {
     /// Adds an event to the store.

--- a/Sources/Snowplow/Entities/DeepLinkEntity.swift
+++ b/Sources/Snowplow/Entities/DeepLinkEntity.swift
@@ -21,17 +21,21 @@
 import Foundation
 
 /// Entity that indicates a deep-link has been received and processed.
+///
+/// Schema: `iglu:com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0`
 @objc(SPDeepLinkEntity)
 public class DeepLinkEntity: SelfDescribingJson {
     @objc
-    public static let schema = "iglu:com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0"
+    static let schema = "iglu:com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0"
     @objc
-    public static let paramReferrer = "referrer"
+    static let paramReferrer = "referrer"
     @objc
-    public static let paramUrl = "url"
+    static let paramUrl = "url"
     
+    /// URL in the received deep-link
     @objc
     public var url: String
+    /// Referrer URL, source of this deep-link
     @objc
     public var referrer: String?
 

--- a/Sources/Snowplow/Entities/LifecycleEntity.swift
+++ b/Sources/Snowplow/Entities/LifecycleEntity.swift
@@ -20,11 +20,13 @@
 
 import Foundation
 
-/// Entity that indicates the state of the app is visible (foreground) when the event is tracked.
 let kSPLifecycleEntitySchema = "iglu:com.snowplowanalytics.mobile/application_lifecycle/jsonschema/1-0-0"
 let kSPLifecycleEntityParamIndex = "index"
 let kSPLifecycleEntityParamIsVisible = "isVisible"
 
+/// Entity that indicates the state of the app is visible (foreground) when the event is tracked.
+///
+/// Schema: `iglu:com.snowplowanalytics.mobile/application_lifecycle/jsonschema/1-0-0`
 @objc(SPLifecycleEntity)
 public class LifecycleEntity: SelfDescribingJson {
 

--- a/Sources/Snowplow/Events/Background.swift
+++ b/Sources/Snowplow/Events/Background.swift
@@ -22,6 +22,8 @@
 import Foundation
 
 /// A background transition event.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0`
 @objc(SPBackground)
 public class Background: SelfDescribingAbstract {
     /// Index indicating the current transition.
@@ -35,11 +37,11 @@ public class Background: SelfDescribingAbstract {
         self.index = index
     }
 
-    override public var schema: String {
+    override var schema: String {
         return kSPBackgroundSchema
     }
 
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [AnyHashable : Any] = [:]
         payload[kSPBackgroundIndex] = NSNumber(value: index)
         return payload as? [String : NSObject] ?? [:]

--- a/Sources/Snowplow/Events/ConsentDocument.swift
+++ b/Sources/Snowplow/Events/ConsentDocument.swift
@@ -48,7 +48,7 @@ public class ConsentDocument: NSObject {
     }
 
     /// Returns the payload.
-    public var payload: SelfDescribingJson {
+    var payload: SelfDescribingJson {
         var event: [String : String] = [:]
         event[kSPCdId] = documentId
         event[kSPCdVersion] = version

--- a/Sources/Snowplow/Events/ConsentDocument.swift
+++ b/Sources/Snowplow/Events/ConsentDocument.swift
@@ -22,6 +22,8 @@
 import Foundation
 
 /// A consent document event.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0`
 @objc(SPConsentDocument)
 public class ConsentDocument: NSObject {
     /// Identifier of the document.

--- a/Sources/Snowplow/Events/ConsentGranted.swift
+++ b/Sources/Snowplow/Events/ConsentGranted.swift
@@ -42,6 +42,8 @@ public class ConsentGranted: SelfDescribingAbstract {
     @objc
     public var documentDescription: String?
     /// Other attached documents.
+    ///
+    /// Schema for the documents: `iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0`
     @objc
     public var documents: [SelfDescribingJson]?
 

--- a/Sources/Snowplow/Events/ConsentGranted.swift
+++ b/Sources/Snowplow/Events/ConsentGranted.swift
@@ -22,6 +22,8 @@
 import Foundation
 
 /// A consent granted event.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/consent_granted/jsonschema/1-0-0`
 @objc(SPConsentGranted)
 public class ConsentGranted: SelfDescribingAbstract {
     /// Expiration of the consent.
@@ -55,16 +57,6 @@ public class ConsentGranted: SelfDescribingAbstract {
         self.version = version
     }
 
-    override public var schema: String {
-        return kSPConsentGrantedSchema
-    }
-
-    override public var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[KSPCgExpiry] = expiry as NSObject
-        return payload
-    }
-
     /// Retuns the full list of attached documents.
     @objc
     public var allDocuments: [SelfDescribingJson] {
@@ -83,6 +75,16 @@ public class ConsentGranted: SelfDescribingAbstract {
             results.append(contentsOf: documents)
         }
         return results
+    }
+
+    override var schema: String {
+        return kSPConsentGrantedSchema
+    }
+
+    override var payload: [String : NSObject] {
+        var payload: [String : NSObject] = [:]
+        payload[KSPCgExpiry] = expiry as NSObject
+        return payload
     }
 
     override func beginProcessing(withTracker tracker: Tracker) {

--- a/Sources/Snowplow/Events/ConsentWithdrawn.swift
+++ b/Sources/Snowplow/Events/ConsentWithdrawn.swift
@@ -22,6 +22,8 @@
 import Foundation
 
 /// A consent withdrawn event.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/consent_withdrawn/jsonschema/1-0-0`
 @objc(SPConsentWithdrawn)
 public class ConsentWithdrawn: SelfDescribingAbstract {
     /// Consent to all.
@@ -43,18 +45,18 @@ public class ConsentWithdrawn: SelfDescribingAbstract {
     @objc
     public var documents: [SelfDescribingJson]?
 
-    public override var schema: String {
+    override var schema: String {
         return kSPConsentWithdrawnSchema
     }
 
-    public override var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         return [
             KSPCwAll: all ? NSNumber(value: true) : NSNumber(value: false)
         ]
     }
 
     @objc
-    public var allDocuments: [SelfDescribingJson] {
+    var allDocuments: [SelfDescribingJson] {
         var results: [SelfDescribingJson] = []
         guard let documentId = documentId, let version = version else { return results }
 

--- a/Sources/Snowplow/Events/ConsentWithdrawn.swift
+++ b/Sources/Snowplow/Events/ConsentWithdrawn.swift
@@ -42,6 +42,8 @@ public class ConsentWithdrawn: SelfDescribingAbstract {
     @objc
     public var documentDescription: String?
     /// Other documents.
+    ///
+    /// Schema for the documents: `iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0`
     @objc
     public var documents: [SelfDescribingJson]?
 

--- a/Sources/Snowplow/Events/DeepLinkReceived.swift
+++ b/Sources/Snowplow/Events/DeepLinkReceived.swift
@@ -21,6 +21,8 @@
 import Foundation
 
 /// A deep-link received in the app.
+///
+/// Schema: `iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0`
 @objc(SPDeepLinkReceived)
 public class DeepLinkReceived: SelfDescribingAbstract {
     /// Referrer URL, source of this deep-link.
@@ -31,32 +33,32 @@ public class DeepLinkReceived: SelfDescribingAbstract {
     public var url: String
 
     /// Creates a deep-link received event.
-    /// @param url URL in the received deep-link.
+    /// - Parameter url: URL in the received deep-link.
     @objc
     public init(url: String) {
         self.url = url
     }
     
     @objc
-    public class var schema: String {
+    class var schema: String {
         return "iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0"
     }
 
     @objc
-    public class var paramUrl: String {
+    class var paramUrl: String {
         return "url"
     }
 
     @objc
-    public class var paramReferrer: String {
+    class var paramReferrer: String {
         return "referrer"
     }
 
-    public override var schema: String {
+    override var schema: String {
         return DeepLinkReceived.schema
     }
 
-    public override var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         if let referrer = referrer {
             payload[DeepLinkReceived.paramReferrer] = referrer as NSObject

--- a/Sources/Snowplow/Events/Ecommerce.swift
+++ b/Sources/Snowplow/Events/Ecommerce.swift
@@ -61,12 +61,11 @@ public class Ecommerce : PrimitiveAbstract {
         self.items = items ?? []
     }
 
-    @objc
-    override public var eventName: String {
+    override var eventName: String {
         return kSPEventEcomm
     }
 
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPEcommTotal] = String(format: "%.02f", totalValue) as NSObject
         if let taxValue = taxValue {

--- a/Sources/Snowplow/Events/EcommerceItem.swift
+++ b/Sources/Snowplow/Events/EcommerceItem.swift
@@ -52,12 +52,11 @@ public class EcommerceItem : PrimitiveAbstract {
         self.quantity = quantity
     }
 
-    @objc
-    override public var eventName: String {
+    override var eventName: String {
         return kSPEventEcommItem
     }
 
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPEcommItemId] = orderId as NSObject?
         payload[kSPEcommItemSku] = sku as NSObject

--- a/Sources/Snowplow/Events/EventBase.swift
+++ b/Sources/Snowplow/Events/EventBase.swift
@@ -27,11 +27,13 @@ public class Event: NSObject {
     /// The user event timestamp in milliseconds (epoch time).
     @objc
     public var trueTimestamp: Date?
+    
     /// The contexts attached to the event.
     @objc
     public var contexts: [SelfDescribingJson] = []
+    
     /// The payload of the event.
-    public var payload: [String : NSObject] {
+    var payload: [String : NSObject] {
         NSException(
             name: .internalInconsistencyException,
             reason: "You must override \(NSStringFromSelector(#function)) in a subclass",
@@ -55,7 +57,7 @@ public class Event: NSObject {
 public class SelfDescribingAbstract: Event {
     /// The schema of the event.
     @objc
-    public var schema: String {
+    var schema: String {
         NSException(
             name: .internalInconsistencyException,
             reason: "You must override \(NSStringFromSelector(#function)) in a subclass",

--- a/Sources/Snowplow/Events/Foreground.swift
+++ b/Sources/Snowplow/Events/Foreground.swift
@@ -22,6 +22,8 @@
 import Foundation
 
 /// A foreground transition event.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/application_foreground/jsonschema/1-0-0`
 @objc(SPForeground)
 public class Foreground: SelfDescribingAbstract {
     /// Indicate the current transition.
@@ -35,11 +37,11 @@ public class Foreground: SelfDescribingAbstract {
         self.index = index
     }
 
-    override public var schema: String {
+    override var schema: String {
         return kSPForegroundSchema
     }
 
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPForegroundIndex] = NSNumber(value: index)
         return payload

--- a/Sources/Snowplow/Events/MessageNotification.swift
+++ b/Sources/Snowplow/Events/MessageNotification.swift
@@ -57,6 +57,8 @@ func triggerToString(_ trigger: MessageNotificationTrigger) -> String {
 }
 
 /// An event that represents the reception of a push notification (or a locally generated one).
+///
+/// Schema: `iglu:com.snowplowanalytics.mobile/message_notification/jsonschema/1-0-0`
 @objc(SPMessageNotification)
 public class MessageNotification : SelfDescribingAbstract {
     /// The action associated with the notification.
@@ -117,9 +119,9 @@ public class MessageNotification : SelfDescribingAbstract {
     
     /// Creates a Message Notification event that represents a push notification or a local notification.
     /// @note The custom data of the push notification have to be tracked separately in custom entities that can be attached to this event.
-    /// @param title Title of message notification.
-    /// @param body Body content of the message notification.
-    /// @param trigger The trigger that raised this notification: remote notification (push), position related (location), date-time related (calendar, timeInterval) or app generated (other).
+    /// - Parameter title: Title of message notification.
+    /// - Parameter body: Body content of the message notification.
+    /// - Parameter trigger: The trigger that raised this notification: remote notification (push), position related (location), date-time related (calendar, timeInterval) or app generated (other).
     @objc
     public init(title: String, body: String, trigger: MessageNotificationTrigger) {
         self.title = title
@@ -127,8 +129,7 @@ public class MessageNotification : SelfDescribingAbstract {
         self.trigger = trigger
     }
     
-    @objc
-    public class func messageNotification(userInfo: [String: NSObject], defaultTitle: String?, defaultBody: String?) -> MessageNotification? {
+    class func messageNotification(userInfo: [String: NSObject], defaultTitle: String?, defaultBody: String?) -> MessageNotification? {
         guard let aps = userInfo["aps"] as? [String : NSObject] else {
             return nil
         }
@@ -156,11 +157,11 @@ public class MessageNotification : SelfDescribingAbstract {
         return event
     }
     
-    public override var schema: String {
+    override var schema: String {
         return kSPMessageNotificationSchema
     }
     
-    public override var payload: [String: NSObject] {
+    override var payload: [String: NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPMessageNotificationParamAction] = action as NSObject?
         if let attachments = attachments {

--- a/Sources/Snowplow/Events/MessageNotificationAttachment.swift
+++ b/Sources/Snowplow/Events/MessageNotificationAttachment.swift
@@ -42,8 +42,7 @@ public class MessageNotificationAttachment : NSObject {
         self.url = url
     }
     
-    @objc
-    public var data: [String : NSObject] {
+    var data: [String : NSObject] {
         return [
             kSPMessageNotificationAttachmentParamIdentifier: identifer as NSObject,
             kSPMessageNotificationAttachmentParamType: type as NSObject,

--- a/Sources/Snowplow/Events/PageView.swift
+++ b/Sources/Snowplow/Events/PageView.swift
@@ -36,20 +36,19 @@ public class PageView : PrimitiveAbstract {
     public var referrer: String?
 
     /// Creates a Page View event
-    /// @param pageUrl Page URL
-    /// @param pageTitle Page title
-    /// @param referrer Page referrer URL
+    /// - Parameter pageUrl: Page URL
+    /// - Parameter pageTitle: Page title
+    /// - Parameter referrer: Page referrer URL
     @objc
     public init(pageUrl: String) {
         self.pageUrl = pageUrl
     }
     
-    @objc
-    override public var eventName: String {
+    override var eventName: String {
         return kSPEventPageView
     }
     
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String: NSObject] = [
             kSPPageUrl: pageUrl as NSObject
         ]

--- a/Sources/Snowplow/Events/PushNotification.swift
+++ b/Sources/Snowplow/Events/PushNotification.swift
@@ -23,21 +23,37 @@ import Foundation
 import UserNotifications
 #endif
 
+/// Push notification event.
+///
+/// Schema: `iglu:com.apple/notification_event/jsonschema/1-0-1`
 @objc(SPPushNotification)
 public class PushNotification : SelfDescribingAbstract {
+    /// The delivery date of the notification.
     @objc
     public var date: String
+    /// The action associated with the notification.
     @objc
     public var action: String
+    /// The trigger that raised this notification: remote notification (`PUSH`), position related (`LOCATION`), date-time related (`CALENDAR`, `TIME_INTERVAL`).
     @objc
     public var trigger: String
+    /// The category associated to the notification.
     @objc
     public var category: String
+    /// An identifier for the thread.
     @objc
     public var thread: String
+    /// Notification content
     @objc
     public var notification: NotificationContent?
 
+    /// Creates a notification event
+    /// - Parameter date: The delivery date of the notification.
+    /// - Parameter action: The action associated with the notification.
+    /// - Parameter trigger: The trigger that raised this notification: remote notification (`PUSH`), position related (`LOCATION`), date-time related (`CALENDAR`, `TIME_INTERVAL`).
+    /// - Parameter category: The category associated to the notification.
+    /// - Parameter thread: An identifier for the thread.
+    /// - Parameter notification: Notification content.
     @objc
     public init(date: String, action: String, trigger: String, category: String, thread: String, notification: NotificationContent?) {
         self.date = date
@@ -50,6 +66,13 @@ public class PushNotification : SelfDescribingAbstract {
 
     #if os(iOS)
 
+    /// Creates a notification event
+    /// - Parameter date: The delivery date of the notification.
+    /// - Parameter action: The action associated with the notification.
+    /// - Parameter notificationTrigger: The trigger that raised this notification: remote notification (`PUSH`), position related (`LOCATION`), date-time related (`CALENDAR`, `TIME_INTERVAL`).
+    /// - Parameter category: The category associated to the notification.
+    /// - Parameter thread: An identifier for the thread.
+    /// - Parameter notification: Notification content.
     @objc
     public init(date: String, action: String, notificationTrigger trigger: UNNotificationTrigger?, category: String, thread: String, notification: NotificationContent?) {
         self.date = date
@@ -60,8 +83,7 @@ public class PushNotification : SelfDescribingAbstract {
         self.notification = notification
     }
 
-    @objc
-    public class func string(from trigger: UNNotificationTrigger?) -> String {
+    class func string(from trigger: UNNotificationTrigger?) -> String {
         var triggerType = "UNKNOWN"
         if let trigger = trigger {
             let triggerClass = NSStringFromClass(type(of: trigger).self)
@@ -80,11 +102,11 @@ public class PushNotification : SelfDescribingAbstract {
 
     #endif
 
-    public override var schema: String {
+    override var schema: String {
         return kSPPushNotificationSchema
     }
 
-    public override var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var data: [String: NSObject] = [
             kSPPushTrigger: trigger as NSObject,
             kSPPushAction: action as NSObject,
@@ -99,25 +121,38 @@ public class PushNotification : SelfDescribingAbstract {
 
 // MARK:- SPNotificationContent
 
+/// Content for a notification.
 @objc(SPNotificationContent)
 public class NotificationContent : NSObject {
+    /// Title of message notification.
     @objc
     public var title: String
+    /// Body content of the message notification.
     @objc
     public var body: String
+    /// The number that the app’s icon displays.
     @objc
     public var badge: NSNumber?
+    /// The notification's subtitle.
     @objc
     public var subtitle: String?
+    /// The sound played when the device receives the notification.
     @objc
     public var sound: String?
+    /// The name of the image or storyboard to use when your app launches because of the notification.
     @objc
     public var launchImageName: String?
+    /// The custom data associated with the notification.
     @objc
     public var userInfo: [String : NSObject]?
+    /// Attachments added to the notification (they can be part of the data object).
     @objc
     public var attachments: [NSObject]?
 
+    /// Creates a notification content
+    /// - Parameter title: Title of message notification.
+    /// - Parameter body: Body content of the message notification.
+    /// - Parameter badge: The number that the app’s icon displays.
     @objc
     public init(title: String, body: String, badge: NSNumber?) {
         self.title = title
@@ -125,8 +160,7 @@ public class NotificationContent : NSObject {
         self.badge = badge
     }
 
-    @objc
-    public var payload: [String : NSObject] {
+    var payload: [String : NSObject] {
         var event: [String : NSObject] = [:]
         event[kSPPnTitle] = title as NSObject
         event[kSPPnBody] = body as NSObject

--- a/Sources/Snowplow/Events/SNOWError.swift
+++ b/Sources/Snowplow/Events/SNOWError.swift
@@ -21,25 +21,33 @@
 
 import Foundation
 
+/// Error event tracked by exception autotracking.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-2`
 @objc(SPSNOWError)
 public class SNOWError: SelfDescribingAbstract {
+    /// Error message
     @objc
     public var message: String
+    /// Error name
     @objc
     public var name: String?
+    /// Stacktrace for the error
     @objc
     public var stackTrace: String?
     
+    /// Creates a SNOWError event.
+    /// - Parameter message: Error message
     @objc
     public init(message: String) {
         self.message = message
     }
     
-    override public var schema: String {
+    override var schema: String {
         return kSPErrorSchema
     }
 
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPErrorMessage] = message as NSObject
         payload[kSPErrorStackTrace] = stackTrace as NSObject?

--- a/Sources/Snowplow/Events/ScreenView.swift
+++ b/Sources/Snowplow/Events/ScreenView.swift
@@ -36,6 +36,8 @@ public enum ScreenType : Int {
 }
 
 /// A screenview event.
+///
+/// Schema: `iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0`
 @objc(SPScreenView)
 public class ScreenView: SelfDescribingAbstract {
     /// Name of the screen.
@@ -67,19 +69,19 @@ public class ScreenView: SelfDescribingAbstract {
     public var topViewControllerClassName: String?
 
     /// Creates a screenview event.
-    /// @param name Name of the screen.
-    /// @param screenId Identifier of the screen.
+    /// - Parameter name: Name of the screen.
+    /// - Parameter screenId: Identifier of the screen.
     @objc
     public init(name: String, screenId: UUID?) {
         self.screenId = screenId ?? UUID()
         self.name = name
     }
 
-    public override var schema: String {
+    override var schema: String {
         return kSPScreenViewSchema
     }
 
-    public override var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPSvName] = name as NSObject
         payload[kSPSvScreenId] = screenId.uuidString as NSObject
@@ -91,8 +93,7 @@ public class ScreenView: SelfDescribingAbstract {
         return payload
     }
 
-    @objc
-    public class func stringWithScreenType(_ screenType: ScreenType) -> String? {
+    class func stringWithScreenType(_ screenType: ScreenType) -> String? {
         let arr = [
             "Default",
             "Navigation",

--- a/Sources/Snowplow/Events/SelfDescribing.swift
+++ b/Sources/Snowplow/Events/SelfDescribing.swift
@@ -25,31 +25,6 @@ import Foundation
 @objc(SPSelfDescribing)
 public class SelfDescribing: SelfDescribingAbstract {
     @objc
-    public var eventData: SelfDescribingJson {
-        set {
-            schema = newValue.schema
-            payload = newValue.data as! [String : NSObject]
-        }
-        get {
-            return SelfDescribingJson(schema: schema, andDictionary: payload)
-        }
-    }
-    private var _schema: String
-    @objc
-    override public var schema: String {
-        get { return _schema }
-        set { _schema = newValue }
-    }
-    private var _payload: [String: NSObject]
-    @objc
-    override public var payload: [String : NSObject] {
-        get { return _payload }
-        set {
-            _payload = newValue
-        }
-    }
-
-    @objc
     public convenience init(eventData: SelfDescribingJson) {
         self.init(schema: eventData.schema, payload: eventData.data as! [String : NSObject])
     }
@@ -63,5 +38,29 @@ public class SelfDescribing: SelfDescribingAbstract {
     public init(schema: String, payload: [String : String]) {
         self._schema = schema
         self._payload = payload as [String : NSObject]
+    }
+    
+    private var _schema: String
+    override var schema: String {
+        get { return _schema }
+        set { _schema = newValue }
+    }
+    
+    private var _payload: [String: NSObject]
+    override var payload: [String : NSObject] {
+        get { return _payload }
+        set {
+            _payload = newValue
+        }
+    }
+    
+    var eventData: SelfDescribingJson {
+        set {
+            schema = newValue.schema
+            payload = newValue.data as! [String : NSObject]
+        }
+        get {
+            return SelfDescribingJson(schema: schema, andDictionary: payload)
+        }
     }
 }

--- a/Sources/Snowplow/Events/Structured.swift
+++ b/Sources/Snowplow/Events/Structured.swift
@@ -24,14 +24,27 @@ import Foundation
 /// A structured event.
 @objc(SPStructured)
 public class Structured: PrimitiveAbstract {
+    /// Name you for the group of objects you want to track e.g. "media", "ecomm".
     @objc
     public var category: String
+    /// Defines the type of user interaction for the web object.
+    ///
+    /// E.g., "play-video", "add-to-basket".
     @objc
     public var action: String
+    /// Identifies the specific object being actioned.
+    ///
+    /// E.g., ID of the video being played, or the SKU or the product added-to-basket.
     @objc
     public var label: String?
+    /// Describes the object or the action performed on it.
+    ///
+    /// This might be the quantity of an item added to basket
     @objc
     public var property: String?
+    /// Quantifies or further describes the user action.
+    ///
+    /// This might be the price of an item added-to-basket, or the starting time of the video where play was just pressed.
     @objc
     public var value: NSNumber?
 
@@ -42,11 +55,11 @@ public class Structured: PrimitiveAbstract {
     }
 
     @objc
-    override public var eventName: String {
+    override var eventName: String {
         return kSPEventStructured
     }
 
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPStuctCategory] = category as NSObject
         payload[kSPStuctAction] = action as NSObject

--- a/Sources/Snowplow/Events/Structured.swift
+++ b/Sources/Snowplow/Events/Structured.swift
@@ -24,7 +24,7 @@ import Foundation
 /// A structured event.
 @objc(SPStructured)
 public class Structured: PrimitiveAbstract {
-    /// Name you for the group of objects you want to track e.g. "media", "ecomm".
+    /// Name for the group of objects you want to track e.g. "media", "ecomm".
     @objc
     public var category: String
     /// Defines the type of user interaction for the web object.

--- a/Sources/Snowplow/Events/Timing.swift
+++ b/Sources/Snowplow/Events/Timing.swift
@@ -22,6 +22,8 @@
 import Foundation
 
 /// A timing event.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0`
 @objc(SPTiming)
 public class Timing: SelfDescribingAbstract {
     /// The timing category
@@ -38,9 +40,9 @@ public class Timing: SelfDescribingAbstract {
     public var label: String?
 
     /// Creates a timing event
-    /// @param category The timing category
-    /// @param variable The timing variable
-    /// @param timing The time
+    /// - Parameter category: The timing category
+    /// - Parameter variable: The timing variable
+    /// - Parameter timing: The time
     @objc
     public init(category: String, variable: String, timing: Int) {
         self.category = category
@@ -48,11 +50,11 @@ public class Timing: SelfDescribingAbstract {
         self.timing = timing
     }
 
-    public override var schema: String {
+    override var schema: String {
         return kSPUserTimingsSchema
     }
 
-    public override var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPUtCategory] = category as NSObject
         payload[kSPUtVariable] = variable as NSObject

--- a/Sources/Snowplow/Events/TrackerError.swift
+++ b/Sources/Snowplow/Events/TrackerError.swift
@@ -25,17 +25,29 @@ let kMaxExceptionNameLength = 1024
 
 import Foundation
 
+/// Tracker error event used in diagnostic autotracking.
+///
+/// Schema: `iglu:com.snowplowanalytics.snowplow/diagnostic_error/jsonschema/1-0-0`
 @objc(SPTrackerError)
 public class TrackerError : SelfDescribingAbstract {
+    /// Class name or source where the error appeared.
     @objc
     public var source: String
+    /// Message of the error.
     @objc
     public var message: String
+    /// Error involved in the error.
     @objc
     public var error: Error?
+    /// Exception involved in the error.
     @objc
     public var exception: NSException?
     
+    /// Create tracker error.
+    /// - Parameter source: Class name or source where the error appeared.
+    /// - Parameter message: Message of the error.
+    /// - Parameter error: Error involved in the error.
+    /// - Parameter exception: Exception involved in the error.
     @objc
     public init(source: String, message: String, error: Error? = nil, exception: NSException? = nil) {
         self.source = source
@@ -44,11 +56,11 @@ public class TrackerError : SelfDescribingAbstract {
         self.exception = exception
     }
     
-    override public var schema: String {
+    override var schema: String {
         return kSPDiagnosticErrorSchema
     }
     
-    override public var payload: [String : NSObject] {
+    override var payload: [String : NSObject] {
         var payload: [String : NSObject] = [:]
         payload[kSPDiagnosticErrorClassName] = source as NSObject
         payload[kSPDiagnosticErrorMessage] = truncate(message, maxLength: kMaxMessageLength) as NSObject

--- a/Sources/Snowplow/Snowplow.swift
+++ b/Sources/Snowplow/Snowplow.swift
@@ -25,6 +25,20 @@ import WebKit
 #endif
 
 /// Entry point to instance a new Snowplow tracker.
+///
+/// The following example initializes a tracker instance using the ``createTracker(namespace:network:)`` method and tracks a ``SelfDescribing`` event:
+///
+/// ```swift
+/// let tracker = Snowplow.createTracker(
+///     namespace: "ns1",
+///     endpoint: "https://collector.example.com"
+/// )
+/// let event = SelfDescribing(
+///     schema: "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
+///     payload: ["targetUrl": "http://a-target-url.com"]
+/// )
+/// tracker?.track(event)
+/// ```
 @objc(SPSnowplow)
 public class Snowplow: NSObject {
     private static var serviceProviderInstances: [String : ServiceProvider] = [:]
@@ -34,6 +48,7 @@ public class Snowplow: NSObject {
     /// Remote Configuration
 
     /// Setup a single or a set of tracker instances which will be used inside the app to track events.
+    ///
     /// The app can run multiple tracker instances which will be identified by string `namespaces`.
     /// The trackers configuration is automatically download from the endpoint indicated in the `RemoteConfiguration`
     /// passed as argument. For more details see `RemoteConfiguration`.
@@ -68,6 +83,7 @@ public class Snowplow: NSObject {
     }
 
     /// Reconfigure, create or delete the trackers based on the configuration downloaded remotely.
+    ///
     /// The trackers configuration is automatically download from the endpoint indicated in the `RemoteConfiguration`
     /// previously used to setup the trackers.
     ///
@@ -96,6 +112,7 @@ public class Snowplow: NSObject {
     /// Standard Configuration
 
     /// Create a new tracker instance which will be used inside the app to track events.
+    ///
     /// The app can run multiple tracker instances which will be identified by string `namespaces`.
     /// The tracker will be configured with default setting and only the collector endpoint URL need
     /// to be passed for the configuration.
@@ -118,12 +135,13 @@ public class Snowplow: NSObject {
     ///   - method: The method for the requests to the collector (GET or POST).
     /// - Returns: The tracker instance created.
     @objc
-    public class func createTracker(namespace: String, endpoint: String, method: HttpMethodOptions) -> TrackerController? {
+    public class func createTracker(namespace: String, endpoint: String, method: HttpMethodOptions = .post) -> TrackerController? {
         let networkConfiguration = NetworkConfiguration(endpoint: endpoint, method: method)
         return createTracker(namespace: namespace, network: networkConfiguration, configurations: [])
     }
 
     /// Create a new tracker instance which will be used inside the app to track events.
+    ///
     /// The app can run multiple tracker instances which will be identified by string `namespaces`.
     /// The tracker will be configured with default setting and only the collector endpoint URL need
     /// to be passed for the configuration.
@@ -151,6 +169,7 @@ public class Snowplow: NSObject {
     }
 
     /// Create a new tracker instance which will be used inside the app to track events.
+    ///
     /// The app can run multiple tracker instances which will be identified by string `namespaces`.
     /// The tracker will be configured with default setting and only the collector endpoint URL need
     /// to be passed for the configuration.
@@ -186,6 +205,8 @@ public class Snowplow: NSObject {
         }
     }
 
+    /// Get the default tracker instance.
+    ///
     /// The default tracker instance is the first created in the app, but that can be overridden programmatically
     /// calling `setTrackerAsDefault(TrackerController)`.
     @objc
@@ -203,6 +224,7 @@ public class Snowplow: NSObject {
     }
 
     /// Set the passed tracker as default tracker if it's registered as an active tracker in the app.
+    ///
     /// If the passed instance is of a tracker which is already removed (see `removeTracker`) then it can't become the new default tracker
     /// and the operation fails.
     ///
@@ -221,7 +243,8 @@ public class Snowplow: NSObject {
         return false
     }
 
-    /// A tracker can be removed from the active trackers of the app.
+    /// Remove a tracker from the active trackers of the app.
+    ///
     /// Once it has been removed it can't be added again or set as default.
     /// The unique way to resume a removed tracker is creating a new tracker with same namespace and
     /// same configurations.
@@ -246,8 +269,10 @@ public class Snowplow: NSObject {
     }
 
     /// Remove all the trackers.
+    ///
     /// The removed tracker is always stopped.
-    /// See `removeTracker(TrackerController)`
+    ///
+    /// See ``remove(tracker:)`` to remove  a specific tracker.
     @objc
     public class func removeAllTrackers() {
         objc_sync_enter(self)
@@ -269,6 +294,7 @@ public class Snowplow: NSObject {
     #if os(iOS) || os(macOS)
 
     /// Subscribe to events tracked in a Web view using the Snowplow WebView tracker JavaScript library.
+    ///
     /// - Parameter webViewConfiguration: Configuration of the Web view to subscribe to events from
     @objc
     public class func subscribeToWebViewEvents(with webViewConfiguration: WKWebViewConfiguration) {

--- a/Sources/Snowplow/Tracker/InspectableEvent.swift
+++ b/Sources/Snowplow/Tracker/InspectableEvent.swift
@@ -37,8 +37,8 @@ public protocol InspectableEvent {
     @objc
     var state: TrackerStateSnapshot { get }
     /// Add payload values to the event.
-    /// @param payload Map of values to add to the event payload.
-    /// @return Whether or not the values have been successfully added to the event payload.
+    /// - Parameter payload: Map of values to add to the event payload.
+    /// - Returns: Whether or not the values have been successfully added to the event payload.
     @objc
     func addPayloadValues(_ payload: [String : NSObject]) -> Bool
 }


### PR DESCRIPTION
Issue #740 

* Update API comments for the Swift-DocC format.
* Add missing comments for several classes where they were missing.
* Remove `public` from methods and properties that should not be published.

API docs deployed here: http://snowplow.github.io/snowplow-objc-tracker/documentation/snowplowtracker/snowplow/