### PR TITLE
Add a closure to tracker configuration that enables retrieving IDFA value and replaces the use of SNOWPLOW_IDFA_ENABLED macro (close #678)

### DIFF
--- a/Sources/Core/Subject/Subject.swift
+++ b/Sources/Core/Subject/Subject.swift
@@ -298,7 +298,7 @@ class Subject : NSObject {
 
     //#pragma clang diagnostic pop
 
-    func getStandardDict(withUserAnonymisation userAnonymisation: Bool) -> Payload? {
+    func getStandardDict(userAnonymisation: Bool) -> Payload? {
         if userAnonymisation {
             var copy = standardDict.dictionary ?? [:]
             copy.removeValue(forKey: kSPUid)
@@ -313,9 +313,11 @@ class Subject : NSObject {
     /// Gets all platform dictionary pairs to decorate event with. Returns nil if not enabled.
     /// - Parameter userAnonymisation: Whether to anonymise user identifiers
     /// - Returns: A SPPayload with all platform specific pairs.
-    func getPlatformDict(withUserAnonymisation userAnonymisation: Bool) -> Payload? {
+    func getPlatformDict(userAnonymisation: Bool, advertisingIdentifierRetriever: (() -> UUID?)?) -> Payload? {
         if platformContext {
-            return platformContextManager.fetchPlatformDict(withUserAnonymisation: userAnonymisation)
+            return platformContextManager.fetchPlatformDict(
+                userAnonymisation: userAnonymisation,
+                advertisingIdentifierRetriever: advertisingIdentifierRetriever)
         } else {
             return nil
         }

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -294,6 +294,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
             tracker.installEvent = trackerConfig.installAutotracking
             tracker.trackerDiagnostic = trackerConfig.diagnosticAutotracking
             tracker.userAnonymisation = trackerConfig.userAnonymisation
+            tracker.advertisingIdentifierRetriever = trackerConfig.advertisingIdentifierRetriever
             if let config = gcConfig {
                 tracker.globalContextGenerators = config.contextGenerators
             }

--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -297,6 +297,8 @@ class Tracker: NSObject {
     var isTracking: Bool {
         return dataCollection
     }
+    
+    var advertisingIdentifierRetriever: (() -> UUID?)?
 
     init(trackerNamespace: String,
          appId: String?,
@@ -539,7 +541,7 @@ class Tracker: NSObject {
             payload.addValueToPayload(String(format: "%lld", ttInMilliSeconds), forKey: kSPTrueTimestamp)
         }
         payload.addDictionaryToPayload(trackerData)
-        if let subjectDict = subject?.getStandardDict(withUserAnonymisation: userAnonymisation)?.dictionary {
+        if let subjectDict = subject?.getStandardDict(userAnonymisation: userAnonymisation)?.dictionary {
             payload.addDictionaryToPayload(subjectDict)
         }
         payload.addValueToPayload(devicePlatformToString(devicePlatform), forKey: kSPPlatform)
@@ -611,7 +613,9 @@ class Tracker: NSObject {
 
     func addBasicContexts(toContexts contexts: inout [SelfDescribingJson], eventId: String, eventTimestamp: Int64, isService: Bool) {
         if subject != nil {
-            if let platformDict = subject?.getPlatformDict(withUserAnonymisation: userAnonymisation)?.dictionary {
+            if let platformDict = subject?.getPlatformDict(
+                userAnonymisation: userAnonymisation,
+                advertisingIdentifierRetriever: advertisingIdentifierRetriever)?.dictionary {
                 contexts.append(SelfDescribingJson(schema: platformContextSchema, andDictionary: platformDict))
             }
             if let geoLocationDict = subject?.getGeoLocationDict() {

--- a/Sources/Core/Tracker/TrackerConfigurationUpdate.swift
+++ b/Sources/Core/Tracker/TrackerConfigurationUpdate.swift
@@ -22,26 +22,28 @@
 import Foundation
 
 class TrackerConfigurationUpdate: TrackerConfiguration {
+    private var appIdUpdated = false
+    private var devicePlatformUpdated = false
+    private var base64EncodingUpdated = false
+    private var logLevelUpdated = false
+    private var loggerDelegateUpdated = false
+    private var applicationContextUpdated = false
+    private var platformContextUpdated = false
+    private var geoLocationContextUpdated = false
+    private var deepLinkContextUpdated = false
+    private var sessionContextUpdated = false
+    private var screenContextUpdated = false
+    private var screenViewAutotrackingUpdated = false
+    private var lifecycleAutotrackingUpdated = false
+    private var installAutotrackingUpdated = false
+    private var exceptionAutotrackingUpdated = false
+    private var diagnosticAutotrackingUpdated = false
+    private var userAnonymisationUpdated = false
+    private var trackerVersionSuffixUpdated = false
+    private var advertisingIdentifierRetrieverUpdated = false
+    
     var sourceConfig: TrackerConfiguration?
     var isPaused = false
-    var appIdUpdated = false
-    var devicePlatformUpdated = false
-    var base64EncodingUpdated = false
-    var logLevelUpdated = false
-    var loggerDelegateUpdated = false
-    var applicationContextUpdated = false
-    var platformContextUpdated = false
-    var geoLocationContextUpdated = false
-    var deepLinkContextUpdated = false
-    var sessionContextUpdated = false
-    var screenContextUpdated = false
-    var screenViewAutotrackingUpdated = false
-    var lifecycleAutotrackingUpdated = false
-    var installAutotrackingUpdated = false
-    var exceptionAutotrackingUpdated = false
-    var diagnosticAutotrackingUpdated = false
-    var userAnonymisationUpdated = false
-    var trackerVersionSuffixUpdated = false
 
     override var appId: String {
         get {
@@ -217,6 +219,16 @@ class TrackerConfigurationUpdate: TrackerConfiguration {
         set {
             super.trackerVersionSuffix = newValue
             trackerVersionSuffixUpdated = true
+        }
+    }
+
+    override var advertisingIdentifierRetriever: (() -> UUID?)? {
+        get {
+            return ((sourceConfig == nil) || advertisingIdentifierRetrieverUpdated) ? super.advertisingIdentifierRetriever : sourceConfig?.advertisingIdentifierRetriever
+        }
+        set {
+            super.advertisingIdentifierRetriever = newValue
+            advertisingIdentifierRetrieverUpdated = true
         }
     }
 }

--- a/Sources/Core/Tracker/TrackerControllerImpl.swift
+++ b/Sources/Core/Tracker/TrackerControllerImpl.swift
@@ -78,7 +78,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.appId = newValue
-            dirtyConfig.appIdUpdated = true
             tracker.appId = newValue
         }
     }
@@ -93,7 +92,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.devicePlatform = newValue
-            dirtyConfig.devicePlatformUpdated = true
             tracker.devicePlatform = newValue
         }
     }
@@ -104,7 +102,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.base64Encoding = newValue
-            dirtyConfig.base64EncodingUpdated = true
             tracker.base64Encoded = newValue
         }
     }
@@ -115,7 +112,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.logLevel = newValue
-            dirtyConfig.logLevelUpdated = true
             tracker.logLevel = newValue
         }
     }
@@ -135,7 +131,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.applicationContext = newValue
-            dirtyConfig.applicationContextUpdated = true
             tracker.applicationContext = newValue
         }
     }
@@ -146,7 +141,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.platformContext = newValue
-            dirtyConfig.platformContextUpdated = true
             tracker.subject?.platformContext = newValue
         }
     }
@@ -157,7 +151,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.geoLocationContext = newValue
-            dirtyConfig.geoLocationContextUpdated = true
             tracker.subject?.geoLocationContext = newValue
         }
     }
@@ -168,7 +161,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.diagnosticAutotracking = newValue
-            dirtyConfig.diagnosticAutotrackingUpdated = true
             tracker.trackerDiagnostic = newValue
         }
     }
@@ -179,7 +171,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.exceptionAutotracking = newValue
-            dirtyConfig.exceptionAutotrackingUpdated = true
             tracker.exceptionEvents = newValue
         }
     }
@@ -190,7 +181,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.installAutotracking = newValue
-            dirtyConfig.installAutotrackingUpdated = true
             tracker.installEvent = newValue
         }
     }
@@ -201,7 +191,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.lifecycleAutotracking = newValue
-            dirtyConfig.lifecycleAutotrackingUpdated = true
             tracker.lifecycleEvents = newValue
         }
     }
@@ -212,7 +201,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.deepLinkContext = newValue
-            dirtyConfig.deepLinkContextUpdated = true
             tracker.deepLinkContext = newValue
         }
     }
@@ -223,7 +211,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.screenContext = newValue
-            dirtyConfig.screenContextUpdated = true
             tracker.screenContext = newValue
         }
     }
@@ -234,7 +221,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.screenViewAutotracking = newValue
-            dirtyConfig.screenViewAutotrackingUpdated = true
             tracker.autotrackScreenViews = newValue
         }
     }
@@ -245,7 +231,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.trackerVersionSuffix = newValue
-            dirtyConfig.trackerVersionSuffixUpdated = true
             if let value = newValue {
                 tracker.trackerVersionSuffix = value
             }
@@ -258,7 +243,6 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.sessionContext = newValue
-            dirtyConfig.sessionContextUpdated = true
             tracker.sessionContext = newValue
         }
     }
@@ -269,8 +253,17 @@ class TrackerControllerImpl: Controller, TrackerController {
         }
         set {
             dirtyConfig.userAnonymisation = newValue
-            dirtyConfig.userAnonymisationUpdated = true
             tracker.userAnonymisation = newValue
+        }
+    }
+
+    var advertisingIdentifierRetriever: (() -> UUID?)? {
+        get {
+            return tracker.advertisingIdentifierRetriever
+        }
+        set {
+            dirtyConfig.advertisingIdentifierRetriever = newValue
+            tracker.advertisingIdentifierRetriever = newValue
         }
     }
 

--- a/Sources/Core/Utils/DeviceInfoMonitor.swift
+++ b/Sources/Core/Utils/DeviceInfoMonitor.swift
@@ -32,94 +32,14 @@ import UIKit
 #endif
 
 class DeviceInfoMonitor {
-    /// Returns a generated string unique to each device, used only for serving advertisements. This works only if you have the AdSupport library in your project and you enable the compiler flag <code>SNOWPLOW_IDFA_ENABLED</code> to your build settings.
-    /// - Returns: A string containing a formatted UUID for example E621E1F8-C36C-495A-93FC-0C247A3E6E5F.
-    /*
-     The IDFA can be retrieved using selectors rather than proper instance methods because
-     the compiler would complain about the missing AdSupport framework.
-     As stated in the header file, this only works if you have the AdSupport library in your project.
-     If you have it and you want to use IDFA, add the compiler flag <code>SNOWPLOW_IDFA_ENABLED</code> to your build settings.
-     If you haven't AdSupport framework in your project or SNOWPLOW_IDFA_ENABLED it's not set, it just compiles returning a nil advertisingIdentifier.
 
-     Note that `advertisingIdentifier` returns a sequence of 0s when used in the simulator.
-     Use a real device if you want a proper IDFA.
-     */
-    var appleIdfa: String? {
-        #if os(iOS) || os(tvOS)
-        #if SNOWPLOW_IDFA_ENABLED
-        var errorMsg = "ASIdentifierManager not found. Please, add the AdSupport.framework if you want to use it."
-        let identifierManagerClass: AnyClass? = NSClassFromString("ASIdentifierManager")
-        if identifierManagerClass == nil {
-            logError(message: errorMsg)
-            return nil
-        }
-
-        let sharedManagerSelector = NSSelectorFromString("sharedManager")
-        if !(identifierManagerClass?.responds(to: sharedManagerSelector) ?? false) {
-            logError(message: errorMsg)
-            return nil
-        }
-
-        let identifierManager = (identifierManagerClass?.method(for: sharedManagerSelector))(identifierManagerClass, sharedManagerSelector)
-
-        if #available(iOS 14.0, *) {
-            errorMsg = "ATTrackingManager not found. Please, add the AppTrackingTransparency.framework if you want to use it."
-            let trackingManagerClass: AnyClass? = NSClassFromString("ATTrackingManager")
-            if trackingManagerClass == nil {
-                logError(message: errorMsg)
-                return nil
-            }
-
-            let trackingStatusSelector = NSSelectorFromString("trackingAuthorizationStatus")
-            if !(trackingManagerClass?.responds(to: trackingStatusSelector) ?? false) {
-                logError(message: errorMsg)
-                return nil
-            }
-
-            //notDetermined = 0, restricted = 1, denied = 2, authorized = 3
-            let authorizationStatus = (Int(trackingManagerClass?.method(for: trackingStatusSelector) ?? 0))(trackingManagerClass, trackingStatusSelector)
-
-            if authorizationStatus != 3 {
-                logDebug(message: String(format: "The user didn't let tracking of IDFA. Authorization status is: %d", authorizationStatus))
-                return nil
-            }
-        } else {
-            let isAdvertisingTrackingEnabledSelector = NSSelectorFromString("isAdvertisingTrackingEnabled")
-            if !(identifierManager?.responds(to: isAdvertisingTrackingEnabledSelector) ?? false) {
-                logError(message: errorMsg)
-                return nil
-            }
-
-            let isAdvertisingTrackingEnabled = (Bool(identifierManager?.method(for: isAdvertisingTrackingEnabledSelector) ?? false))(identifierManager, isAdvertisingTrackingEnabledSelector)
-            if !isAdvertisingTrackingEnabled {
-                logError(message: "The user didn't let tracking of IDFA.")
-                return nil
-            }
-        }
-
-        let advertisingIdentifierSelector = NSSelectorFromString("advertisingIdentifier")
-        if !(identifierManager?.responds(to: advertisingIdentifierSelector) ?? false) {
-            logError(message: "ASIdentifierManager doesn't respond to selector `advertisingIdentifier`.")
-            return nil
-        }
-
-        if let uuid = (identifierManager?.method(for: advertisingIdentifierSelector) as? UUID)(identifierManager, advertisingIdentifierSelector) {
-            return uuid.uuidString
-        }
-        #endif
-        #endif
-        return nil
-    }
-
-    /// Returns the generated identifier for vendors. More info can be found in UIDevice's identifierForVendor documentation. If you do not want to use IDFV, add the comiler flag <code>SNOWPLOW_NO_IDFV</code> to your build settings.
+    /// Returns the generated identifier for vendors. More info can be found in UIDevice's identifierForVendor documentation.
     /// - Returns: A string containing a formatted UUID for example E621E1F8-C36C-495A-93FC-0C247A3E6E5F.
     var appleIdfv: String? {
         #if os(iOS) || os(tvOS)
-        #if !SNOWPLOW_NO_IDFV
         if let idfv = UIDevice.current.identifierForVendor?.uuidString {
             return idfv
         }
-        #endif
         #endif
         return nil
     }

--- a/Sources/Snowplow/Configurations/TrackerConfiguration.swift
+++ b/Sources/Snowplow/Configurations/TrackerConfiguration.swift
@@ -79,6 +79,10 @@ public protocol TrackerConfigurationProtocol: AnyObject {
     /// @note Do not use. Internal use only.
     @objc
     var trackerVersionSuffix: String? { get set }
+    /// Closure called to retrieve the Identifier for Advertisers (IDFA) from AdSupport module
+    /// It is called repeatedly (on each tracked event) until a UUID is returned.
+    @objc
+    var advertisingIdentifierRetriever: (() -> UUID?)? { get set }
 }
 
 /// This class represents the configuration of the tracker and the core tracker properties.
@@ -142,6 +146,10 @@ public class TrackerConfiguration: Configuration, TrackerConfigurationProtocol {
     /// @note Do not use. Internal use only.
     @objc
     public var trackerVersionSuffix: String?
+    /// Closure called to retrieve the Identifier for Advertisers (IDFA) from AdSupport module
+    /// It is called repeatedly (on each tracked event) until a UUID is returned.
+    @objc
+    public var advertisingIdentifierRetriever: (() -> UUID?)?
 
     @objc
     public override init() {
@@ -233,6 +241,7 @@ public class TrackerConfiguration: Configuration, TrackerConfigurationProtocol {
         copy.diagnosticAutotracking = diagnosticAutotracking
         copy.trackerVersionSuffix = trackerVersionSuffix
         copy.userAnonymisation = userAnonymisation
+        copy.advertisingIdentifierRetriever = advertisingIdentifierRetriever
         return copy
     }
 

--- a/Tests/Legacy Tests/LegacyTestSubject.swift
+++ b/Tests/Legacy Tests/LegacyTestSubject.swift
@@ -36,13 +36,13 @@ class LegacyTestSubject: XCTestCase {
 
     func testSubjectInit() {
         let subject = Subject()
-        XCTAssertNotNil(subject.getStandardDict(withUserAnonymisation: false))
+        XCTAssertNotNil(subject.getStandardDict(userAnonymisation: false))
     }
 
     func testSubjectInitWithOptions() {
         let subject = Subject(platformContext: true, andGeoContext: false)
-        XCTAssertNotNil(subject.getPlatformDict(withUserAnonymisation: false))
-        XCTAssertNotNil(subject.getStandardDict(withUserAnonymisation: false))
+        XCTAssertNotNil(subject.getPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil))
+        XCTAssertNotNil(subject.getStandardDict(userAnonymisation: false))
     }
 
     func testSubjectSetterFunctions() {
@@ -58,7 +58,7 @@ class LegacyTestSubject: XCTestCase {
         subject.networkUserId = "aNuid"
         subject.domainUserId = "aDuid"
 
-        guard var values = subject.getStandardDict(withUserAnonymisation: false)?.dictionary else {
+        guard var values = subject.getStandardDict(userAnonymisation: false)?.dictionary else {
             return XCTFail()
         }
 

--- a/Tests/TestPlatformContext.swift
+++ b/Tests/TestPlatformContext.swift
@@ -26,14 +26,14 @@ import XCTest
 class TestPlatformContext: XCTestCase {
     func testContainsPlatformInfo() {
         let context = PlatformContext(deviceInfoMonitor: MockDeviceInfoMonitor())
-        let platformDict = context.fetchPlatformDict(withUserAnonymisation: false).dictionary
+        let platformDict = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil).dictionary
         XCTAssertNotNil(platformDict)
         XCTAssertNotNil(platformDict)
     }
 
     func testContainsMobileInfo() {
         let context = PlatformContext(deviceInfoMonitor: MockDeviceInfoMonitor())
-        let platformDict = context.fetchPlatformDict(withUserAnonymisation: false).dictionary
+        let platformDict = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil).dictionary
         XCTAssertNotNil(platformDict)
         XCTAssertNotNil(platformDict)
     }
@@ -41,10 +41,11 @@ class TestPlatformContext: XCTestCase {
     func testAddsAllMockedInfo() {
         let deviceInfoMonitor = MockDeviceInfoMonitor()
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
-        guard let platformDict = context.fetchPlatformDict(withUserAnonymisation: false).dictionary else {
+        let idfa = UUID()
+        guard let platformDict = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: { idfa }).dictionary else {
             return XCTFail()
         }
-        XCTAssertEqual("appleIdfa" as NSObject, platformDict[kSPMobileAppleIdfa])
+        XCTAssertEqual(idfa.uuidString as NSObject, platformDict[kSPMobileAppleIdfa])
         XCTAssertEqual("appleIdfv" as NSObject, platformDict[kSPMobileAppleIdfv])
         XCTAssertEqual("Apple Inc." as NSObject, platformDict[kSPPlatformDeviceManu])
         XCTAssertEqual("deviceModel" as NSObject, platformDict[kSPPlatformDeviceModel])
@@ -62,10 +63,10 @@ class TestPlatformContext: XCTestCase {
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("batteryLevel"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("appAvailableMemory"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(2, deviceInfoMonitor.accessCount("batteryLevel"))
         XCTAssertEqual(2, deviceInfoMonitor.accessCount("appAvailableMemory"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(3, deviceInfoMonitor.accessCount("batteryLevel"))
         XCTAssertEqual(3, deviceInfoMonitor.accessCount("appAvailableMemory"))
     }
@@ -75,10 +76,10 @@ class TestPlatformContext: XCTestCase {
         let context = PlatformContext(mobileDictUpdateFrequency: 1000, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("batteryLevel"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("appAvailableMemory"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("batteryLevel"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("appAvailableMemory"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("batteryLevel"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("appAvailableMemory"))
     }
@@ -88,10 +89,10 @@ class TestPlatformContext: XCTestCase {
         let context = PlatformContext(mobileDictUpdateFrequency: 1, networkDictUpdateFrequency: 0, deviceInfoMonitor: deviceInfoMonitor)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkTechnology"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkType"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(2, deviceInfoMonitor.accessCount("networkTechnology"))
         XCTAssertEqual(2, deviceInfoMonitor.accessCount("networkType"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(3, deviceInfoMonitor.accessCount("networkTechnology"))
         XCTAssertEqual(3, deviceInfoMonitor.accessCount("networkType"))
     }
@@ -101,10 +102,10 @@ class TestPlatformContext: XCTestCase {
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1000, deviceInfoMonitor: deviceInfoMonitor)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkTechnology"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkType"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkTechnology"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkType"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkTechnology"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("networkType"))
     }
@@ -114,40 +115,82 @@ class TestPlatformContext: XCTestCase {
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 0, deviceInfoMonitor: deviceInfoMonitor)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("physicalMemory"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("totalStorage"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("physicalMemory"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("totalStorage"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("physicalMemory"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("totalStorage"))
     }
 
-    func testDoesntUpdateIdfaAndIdfvIfNotNil() {
+    func testDoesntUpdateIdfvIfNotNil() {
         let deviceInfoMonitor = MockDeviceInfoMonitor()
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
-        XCTAssertEqual(1, deviceInfoMonitor.accessCount("appleIdfa"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("appleIdfv"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
-        XCTAssertEqual(1, deviceInfoMonitor.accessCount("appleIdfa"))
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("appleIdfv"))
     }
 
-    func testUpdatesIdfaAndIdfvIfNil() {
+    func testUpdatesIdfvIfNil() {
         let deviceInfoMonitor = MockDeviceInfoMonitor()
-        deviceInfoMonitor.customAppleIdfa = nil
         deviceInfoMonitor.customAppleIdfv = nil
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
-        XCTAssertEqual(1, deviceInfoMonitor.accessCount("appleIdfa"))
         XCTAssertEqual(1, deviceInfoMonitor.accessCount("appleIdfv"))
-        _ = context.fetchPlatformDict(withUserAnonymisation: false)
-        XCTAssertEqual(2, deviceInfoMonitor.accessCount("appleIdfa"))
+        _ = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertEqual(2, deviceInfoMonitor.accessCount("appleIdfv"))
+    }
+    
+    func testUpdatesIdfaIfNil() {
+        let deviceInfoMonitor = MockDeviceInfoMonitor()
+        let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
+        
+        guard let platformDict1 = context.fetchPlatformDict(
+            userAnonymisation: false,
+            advertisingIdentifierRetriever: { nil }
+        ).dictionary else {
+            return XCTFail()
+        }
+        XCTAssertNil(platformDict1[kSPMobileAppleIdfa])
+        
+        let idfa = UUID()
+        guard let platformDict2 = context.fetchPlatformDict(
+            userAnonymisation: false,
+            advertisingIdentifierRetriever: { idfa }
+        ).dictionary else {
+            return XCTFail()
+        }
+        XCTAssertEqual(idfa.uuidString as NSObject, platformDict2[kSPMobileAppleIdfa])
+    }
+
+    func testDoesntUpdateIdfaIfAlreadyRetrieved() {
+        let deviceInfoMonitor = MockDeviceInfoMonitor()
+        let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
+        
+        let idfa1 = UUID()
+        guard let platformDict1 = context.fetchPlatformDict(
+            userAnonymisation: false,
+            advertisingIdentifierRetriever: { idfa1 }
+        ).dictionary else {
+            return XCTFail()
+        }
+        XCTAssertEqual(idfa1.uuidString as NSObject, platformDict1[kSPMobileAppleIdfa])
+        
+        guard let platformDict2 = context.fetchPlatformDict(
+            userAnonymisation: false,
+            advertisingIdentifierRetriever: { UUID() }
+        ).dictionary else {
+            return XCTFail()
+        }
+        XCTAssertEqual(idfa1.uuidString as NSObject, platformDict2[kSPMobileAppleIdfa])
     }
 
     func testAnonymisesUserIdentifiers() {
         let deviceInfoMonitor = MockDeviceInfoMonitor()
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
-        guard let platformDict = context.fetchPlatformDict(withUserAnonymisation: true).dictionary else {
+        guard let platformDict = context.fetchPlatformDict(
+            userAnonymisation: true,
+            advertisingIdentifierRetriever: { UUID() }
+        ).dictionary else {
             return XCTFail()
         }
         XCTAssertNil(platformDict[kSPMobileAppleIdfa])

--- a/Tests/TestSubject.swift
+++ b/Tests/TestSubject.swift
@@ -25,14 +25,14 @@ import XCTest
 class TestSubject: XCTestCase {
     func testReturnsPlatformContextIfEnabled() {
         let subject = Subject(platformContext: true, andGeoContext: false)
-        let platformDict = subject.getPlatformDict(withUserAnonymisation: false)
+        let platformDict = subject.getPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertNotNil(platformDict)
         XCTAssertNotNil(platformDict?.dictionary?[kSPPlatformOsType])
     }
 
     func testDoesntReturnPlatformContextIfDisabled() {
         let subject = Subject(platformContext: false, andGeoContext: false)
-        let platformDict = subject.getPlatformDict(withUserAnonymisation: false)
+        let platformDict = subject.getPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertNil(platformDict)
     }
 
@@ -61,7 +61,7 @@ class TestSubject: XCTestCase {
         subject.domainUserId = "aDuid"
         subject.language = "EN"
 
-        guard let values = subject.getStandardDict(withUserAnonymisation: true)?.dictionary else {
+        guard let values = subject.getStandardDict(userAnonymisation: true)?.dictionary else {
             return XCTFail()
         }
         XCTAssertNil(values[kSPUid])

--- a/Tests/Utils/MockDeviceInfoMonitor.swift
+++ b/Tests/Utils/MockDeviceInfoMonitor.swift
@@ -24,13 +24,7 @@ import Foundation
 
 class MockDeviceInfoMonitor: DeviceInfoMonitor {
     var methodAccessCounts: [String : Int] = [:]
-    var customAppleIdfa: String? = "appleIdfa"
     var customAppleIdfv: String? = "appleIdfv"
-
-    override var appleIdfa: String? {
-        increaseMethodAccessCount("appleIdfa")
-        return customAppleIdfa
-    }
 
     override var appleIdfv: String? {
         increaseMethodAccessCount("appleIdfv")


### PR DESCRIPTION
Issue #678 

This PR deals addresses the issue present in both v4 and v5 versions of the tracker where it is not possible to enable the IDFA identifier in platform context when using Swift Package Manager. Previously it was enabled by a preprocessor macro which is currently not possible to add through SPM.

There was a suggestion in the issue to solve this by adding a secondary target and library in the SPM package – something like `SnowplowTrackerWithIDFA`. So one would choose whether to include or not the IDFA by using a different library. This might work but is a bit unintuitive to have a completely separate package just because of the configuration. Also when I tried it, I ran into an issue that SPM does not support having multiple targets using the same source code.

I decided to implement a solution where the user passes a callback to `TrackerConfiguration` which returns the IDFA. So retrieving the value is handled in user code:

```swift
import AdSupport

let trackerConfig = TrackerConfiguration()
trackerConfig.advertisingIdentifierRetriever = {
    ASIdentifierManager.shared().advertisingIdentifier
}
let tracker = Snowplow.createTracker(namespace: "ns", network: networkConfig, configurations: [trackerConfig])
```

Also created [a PR on the examples repo](https://github.com/snowplow-incubator/snowplow-objc-tracker-examples/pull/23) that uses the new API.