### PR TITLE
Refactor APIs to replace usage of NSObject in dictionaries with the Any type (close #748)

### DIFF
--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -406,7 +406,7 @@ class Emitter: NSObject, EmitterEventProcessing {
         var successCount = 0
         var failedWillRetryCount = 0
         var failedWontRetryCount = 0
-        var removableEvents: [NSNumber] = []
+        var removableEvents: [Int64] = []
 
         for result in sendResults ?? [] {
             let resultIndexArray = result.storeIds
@@ -469,18 +469,18 @@ class Emitter: NSObject, EmitterEventProcessing {
             var i = 0
             while i < events.count {
                 var eventArray: [Payload] = []
-                var indexArray: [NSNumber] = []
+                var indexArray: [Int64] = []
 
                 let iUntil = min(i + bufferOption.rawValue, events.count)
                 for j in i..<iUntil {
                     let event = events[j]
 
                     let payload = event.payload
-                    let emitterEventId = NSNumber(value: event.storeId)
+                    let emitterEventId = event.storeId
                     addSendingTime(to: payload, timestamp: sendingTime)
 
                     if isOversize(payload) {
-                        let request = Request(payload: payload, emitterEventId: emitterEventId.int64Value, oversize: true)
+                        let request = Request(payload: payload, emitterEventId: emitterEventId, oversize: true)
                         requests.append(request)
                     } else if isOversize(payload, previousPayloads: eventArray) {
                         let request = Request(payloads: eventArray, emitterEventIds: indexArray)

--- a/Sources/Core/Logger/Logger.swift
+++ b/Sources/Core/Logger/Logger.swift
@@ -129,11 +129,11 @@ class Logger: NSObject {
         }
 
         // Construct userInfo
-        var userInfo: [String : NSObject] = [:]
-        userInfo["tag"] = tag as NSObject
-        userInfo["message"] = message as NSObject
-        userInfo["error"] = error as NSObject?
-        userInfo["exception"] = exception as NSObject?
+        var userInfo: [String : Any] = [:]
+        userInfo["tag"] = tag
+        userInfo["message"] = message
+        userInfo["error"] = error
+        userInfo["exception"] = exception
 
         // Send notification to tracker
         NotificationCenter.default.post(

--- a/Sources/Core/RemoteConfiguration/ConfigurationFetcher.swift
+++ b/Sources/Core/RemoteConfiguration/ConfigurationFetcher.swift
@@ -49,7 +49,7 @@ class ConfigurationFetcher: NSObject {
     }
 
     func resolveRequest(with data: Data) {
-        if let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String : NSObject],
+        if let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String : Any],
            let fetchedConfigurationBundle = FetchedConfigurationBundle(dictionary: jsonObject) {
             onFetchCallback(fetchedConfigurationBundle, ConfigurationState.fetched)
         }

--- a/Sources/Core/RemoteConfiguration/FetchedConfigurationBundle.swift
+++ b/Sources/Core/RemoteConfiguration/FetchedConfigurationBundle.swift
@@ -31,7 +31,7 @@ class FetchedConfigurationBundle: Configuration {
         self.configurationVersion = configurationVersion
     }
     
-    init?(dictionary: [String : NSObject]) {
+    init?(dictionary: [String : Any]) {
         guard let schema = dictionary["$schema"] as? String else {
             logDebug(message: "Error assigning: schema")
             return nil
@@ -42,7 +42,7 @@ class FetchedConfigurationBundle: Configuration {
             return nil
         }
         self.configurationVersion = configurationVersion
-        guard let bundles = dictionary["configurationBundle"] as? [[String : NSObject]] else {
+        guard let bundles = dictionary["configurationBundle"] as? [[String : Any]] else {
             logDebug(message: "Error assigning: configurationBundle")
             return nil
         }

--- a/Sources/Core/ScreenViewTracking/ScreenState.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenState.swift
@@ -47,7 +47,7 @@ class ScreenState: NSObject, State, NSCopying {
     ///   - theTopControllerName: The top view controller class name
     ///   - theControllerName: The view controller class name
     required init(name theName: String, type theType: String?, screenId theScreenId: String?, transitionType theTransitionType: String?, topViewControllerClassName theTopControllerName: String?, viewControllerClassName theControllerName: String?) {
-            name = theName
+        name = theName
         if theScreenId == nil {
             screenId = UUID().uuidString
         } else {

--- a/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
@@ -54,13 +54,13 @@ class ScreenStateMachine: StateMachineProtocol {
         return nil
     }
 
-    func payloadValues(from event: InspectableEvent, state: State?) -> [String : NSObject]? {
+    func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]? {
         if let state = state as? ScreenState {
             let previousState = state.previousState
-            var addedValues: [String : NSObject] = [:]
-            addedValues[kSPSvPreviousName] = previousState?.name as NSObject?
-            addedValues[kSPSvPreviousType] = previousState?.type as NSObject?
-            addedValues[kSPSvPreviousScreenId] = previousState?.screenId as NSObject?
+            var addedValues: [String : Any] = [:]
+            addedValues[kSPSvPreviousName] = previousState?.name
+            addedValues[kSPSvPreviousType] = previousState?.type
+            addedValues[kSPSvPreviousScreenId] = previousState?.screenId
             return addedValues
         }
         return nil

--- a/Sources/Core/ScreenViewTracking/ScreenViewModifier.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenViewModifier.swift
@@ -33,13 +33,8 @@ internal struct ScreenViewModifier: ViewModifier {
     /// Transform the context entity definitions to self-describing objects
     private var processedContexts: [SelfDescribingJson] {
         return contexts.map({ entity in
-            if let data = entity.data as? [String : NSObject] {
-                return SelfDescribingJson(schema: entity.schema, andDictionary: data)
-            } else {
-                logError(message: "Failed to process context entity for screen view.")
-            }
-            return nil
-        }).filter({ $0 != nil }).map({ $0! })
+            return SelfDescribingJson(schema: entity.schema, andDictionary: entity.data)
+        })
     }
     
     /// Get tracker by namespace if configured, otherwise return the default tracker

--- a/Sources/Core/Storage/MemoryEventStore.swift
+++ b/Sources/Core/Storage/MemoryEventStore.swift
@@ -86,10 +86,10 @@ class MemoryEventStore: NSObject, EventStore {
     }
 
     func removeEvent(withId storeId: Int64) -> Bool {
-        return removeEvents(withIds: [NSNumber(value: storeId)])
+        return removeEvents(withIds: [storeId])
     }
 
-    func removeEvents(withIds storeIds: [NSNumber]) -> Bool {
+    func removeEvents(withIds storeIds: [Int64]) -> Bool {
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
         var itemsToRemove: [EmitterEvent] = []
@@ -97,7 +97,7 @@ class MemoryEventStore: NSObject, EventStore {
             guard let item = item as? EmitterEvent else {
                 continue
             }
-            if storeIds.contains(NSNumber(value: item.storeId)) {
+            if storeIds.contains(item.storeId) {
                 itemsToRemove.append(item)
             }
         }

--- a/Sources/Core/Storage/SQLiteEventStore.swift
+++ b/Sources/Core/Storage/SQLiteEventStore.swift
@@ -143,11 +143,11 @@ class SQLiteEventStore: NSObject, EventStore {
         return res
     }
 
-    func removeEvents(withIds storeIds: [NSNumber]) -> Bool {
+    func removeEvents(withIds storeIds: [Int64]) -> Bool {
         var res = false
         queue?.inDatabase({ db in
             if db.open() && storeIds.count != 0 {
-                let ids = storeIds.map { $0.stringValue }.joined(separator: ",")
+                let ids = storeIds.map { String(describing: $0) }.joined(separator: ",")
                 logDebug(message: String(format: "Removing [%@] from database now.", ids))
                 let query = String(format: _queryDeleteIds, ids)
                 res = db.executeUpdate(query, withArgumentsIn: [])
@@ -232,7 +232,7 @@ class SQLiteEventStore: NSObject, EventStore {
                 if let s = try? db.executeQuery(_querySelectId, values: [id_]) {
                     while s.next() {
                         if let data = s.data(forColumn: "eventData"),
-                           let dict = try? JSONSerialization.jsonObject(with: data) as? [String: NSObject] {
+                           let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                             let payload = Payload(dictionary: dict)
                             event = EmitterEvent(payload: payload, storeId: id_)
                         }
@@ -265,7 +265,7 @@ class SQLiteEventStore: NSObject, EventStore {
                     while s.next() {
                         let index = s.longLongInt(forColumn: "ID")
                         if let data = s.data(forColumn: "eventData"),
-                           let dict = try? JSONSerialization.jsonObject(with: data) as? [String: NSObject] {
+                           let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                             let payload = Payload(dictionary: dict)
                             let event = EmitterEvent(payload: payload, storeId: index)
                             res.append(event)

--- a/Sources/Core/Subject/PlatformContext.swift
+++ b/Sources/Core/Subject/PlatformContext.swift
@@ -66,14 +66,14 @@ class PlatformContext {
         #endif
         if userAnonymisation {
             // mask user identifiers
-            let copy = Payload(dictionary: platformDict.dictionary ?? [:])
-            copy.addValueToPayload(nil, forKey: kSPMobileAppleIdfa)
-            copy.addValueToPayload(nil, forKey: kSPMobileAppleIdfv)
+            let copy = Payload(dictionary: platformDict.dictionary)
+            copy[kSPMobileAppleIdfa] = nil
+            copy[kSPMobileAppleIdfv] = nil
             return copy
         } else {
             if let retriever = advertisingIdentifierRetriever {
-                if platformDict.dictionary?[kSPMobileAppleIdfa] == nil {
-                    platformDict.addValueToPayload(retriever()?.uuidString, forKey: kSPMobileAppleIdfa)
+                if platformDict.dictionary[kSPMobileAppleIdfa] == nil {
+                    platformDict[kSPMobileAppleIdfa] = retriever()?.uuidString
                 }
             }
             return platformDict
@@ -84,10 +84,10 @@ class PlatformContext {
 
     func setPlatformDict() {
         platformDict = Payload()
-        platformDict.addValueToPayload(deviceInfoMonitor.osType, forKey: kSPPlatformOsType)
-        platformDict.addValueToPayload(deviceInfoMonitor.osVersion, forKey: kSPPlatformOsVersion)
-        platformDict.addValueToPayload(deviceInfoMonitor.deviceVendor, forKey: kSPPlatformDeviceManu)
-        platformDict.addValueToPayload(deviceInfoMonitor.deviceModel, forKey: kSPPlatformDeviceModel)
+        platformDict[kSPPlatformOsType] = deviceInfoMonitor.osType
+        platformDict[kSPPlatformOsVersion] = deviceInfoMonitor.osVersion
+        platformDict[kSPPlatformDeviceManu] = deviceInfoMonitor.deviceVendor
+        platformDict[kSPPlatformDeviceModel] = deviceInfoMonitor.deviceModel
 
         #if os(iOS)
         setMobileDict()
@@ -95,11 +95,11 @@ class PlatformContext {
     }
 
     func setMobileDict() {
-        platformDict.addValueToPayload(deviceInfoMonitor.carrierName, forKey: kSPMobileCarrier)
+        platformDict[kSPMobileCarrier] = deviceInfoMonitor.carrierName
         if let totalStorage = deviceInfoMonitor.totalStorage {
-            platformDict.addNumericValueToPayload(NSNumber(value: totalStorage), forKey: kSPMobileTotalStorage)
+            platformDict[kSPMobileTotalStorage] = totalStorage
         }
-        platformDict.addNumericValueToPayload(NSNumber(value: deviceInfoMonitor.physicalMemory), forKey: kSPMobilePhysicalMemory)
+        platformDict[kSPMobilePhysicalMemory] = deviceInfoMonitor.physicalMemory
         
         setEphemeralMobileDict()
         setEphemeralNetworkDict()
@@ -108,31 +108,29 @@ class PlatformContext {
     func setEphemeralMobileDict() {
         lastUpdatedEphemeralMobileDict = Date().timeIntervalSince1970
 
-        if let currentDict = platformDict.dictionary {
-            if currentDict[kSPMobileAppleIdfv] == nil {
-                platformDict.addValueToPayload(deviceInfoMonitor.appleIdfv, forKey: kSPMobileAppleIdfv)
-            }
-            
-            if let batteryLevel = deviceInfoMonitor.batteryLevel {
-                platformDict.addNumericValueToPayload(NSNumber(value: batteryLevel), forKey: kSPMobileBatteryLevel)
-            }
-            platformDict.addValueToPayload(deviceInfoMonitor.batteryState, forKey: kSPMobileBatteryState)
-            if let isLowPowerModeEnabled = deviceInfoMonitor.isLowPowerModeEnabled {
-                platformDict.addNumericValueToPayload(NSNumber(value: isLowPowerModeEnabled), forKey: kSPMobileLowPowerMode)
-            }
-            if let availableStorage = deviceInfoMonitor.availableStorage {
-                platformDict.addNumericValueToPayload(NSNumber(value: availableStorage), forKey: kSPMobileAvailableStorage)
-            }
-            if let appAvailableMemory = deviceInfoMonitor.appAvailableMemory {
-                platformDict.addNumericValueToPayload(NSNumber(value: appAvailableMemory), forKey: kSPMobileAppAvailableMemory)
-            }
+        if platformDict[kSPMobileAppleIdfv] == nil {
+            platformDict[kSPMobileAppleIdfv] = deviceInfoMonitor.appleIdfv
+        }
+        
+        if let batteryLevel = deviceInfoMonitor.batteryLevel {
+            platformDict[kSPMobileBatteryLevel] = batteryLevel
+        }
+        platformDict[kSPMobileBatteryState] = deviceInfoMonitor.batteryState
+        if let isLowPowerModeEnabled = deviceInfoMonitor.isLowPowerModeEnabled {
+            platformDict[kSPMobileLowPowerMode] = isLowPowerModeEnabled
+        }
+        if let availableStorage = deviceInfoMonitor.availableStorage {
+            platformDict[kSPMobileAvailableStorage] = availableStorage
+        }
+        if let appAvailableMemory = deviceInfoMonitor.appAvailableMemory {
+            platformDict[kSPMobileAppAvailableMemory] = appAvailableMemory
         }
     }
 
     func setEphemeralNetworkDict() {
         lastUpdatedEphemeralNetworkDict = Date().timeIntervalSince1970
 
-        platformDict.addValueToPayload(deviceInfoMonitor.networkTechnology, forKey: kSPMobileNetworkTech)
-        platformDict.addValueToPayload(deviceInfoMonitor.networkType, forKey: kSPMobileNetworkType)
+        platformDict[kSPMobileNetworkTech] = deviceInfoMonitor.networkTechnology
+        platformDict[kSPMobileNetworkType] = deviceInfoMonitor.networkType
     }
 }

--- a/Sources/Core/Subject/Subject.swift
+++ b/Sources/Core/Subject/Subject.swift
@@ -24,9 +24,9 @@ import Foundation
 /// @class Subject
 /// This class is used to access and persist user information, it represents the current user being tracked.
 class Subject : NSObject {
-    private var standardDict = Payload()
+    private var standardDict: [String : String] = [:]
     private var platformContextManager = PlatformContext()
-    private var geoLocationDict: [String : NSObject] = [:]
+    private var geoDict: [String : NSObject] = [:]
 
     var platformContext = false
     var geoLocationContext = false
@@ -43,7 +43,7 @@ class Subject : NSObject {
         }
         set(uid) {
             _userId = uid
-            standardDict.addValueToPayload(uid, forKey: kSPUid)
+            standardDict[kSPUid] = uid
         }
     }
 
@@ -54,7 +54,7 @@ class Subject : NSObject {
         }
         set(nuid) {
             _networkUserId = nuid
-            standardDict.addValueToPayload(nuid, forKey: kSPNetworkUid)
+            standardDict[kSPNetworkUid] = nuid
         }
     }
 
@@ -66,7 +66,7 @@ class Subject : NSObject {
         }
         set(duid) {
             _domainUserId = duid
-            standardDict.addValueToPayload(duid, forKey: kSPDomainUid)
+            standardDict[kSPDomainUid] = duid
         }
     }
 
@@ -78,7 +78,7 @@ class Subject : NSObject {
         }
         set(useragent) {
             _useragent = useragent
-            standardDict.addValueToPayload(useragent, forKey: kSPUseragent)
+            standardDict[kSPUseragent] = useragent
         }
     }
 
@@ -90,7 +90,7 @@ class Subject : NSObject {
         }
         set(ip) {
             _ipAddress = ip
-            standardDict.addValueToPayload(ip, forKey: kSPIpAddress)
+            standardDict[kSPIpAddress] = ip
         }
     }
 
@@ -102,7 +102,7 @@ class Subject : NSObject {
         }
         set(timezone) {
             _timezone = timezone
-            standardDict.addValueToPayload(timezone, forKey: kSPTimezone)
+            standardDict[kSPTimezone] = timezone
         }
     }
 
@@ -114,7 +114,7 @@ class Subject : NSObject {
         }
         set(lang) {
             _language = lang
-            standardDict.addValueToPayload(lang, forKey: kSPLanguage)
+            standardDict[kSPLanguage] = lang
         }
     }
 
@@ -127,7 +127,7 @@ class Subject : NSObject {
         set(depth) {
             _colorDepth = depth
             let res = "\(depth?.stringValue ?? "")"
-            standardDict.addValueToPayload(res, forKey: kSPColorDepth)
+            standardDict[kSPColorDepth] = res
         }
     }
 
@@ -140,9 +140,9 @@ class Subject : NSObject {
             _screenResolution = newValue
             if let size = newValue {
                 let res = "\((NSNumber(value: size.width)).stringValue)x\((NSNumber(value: size.height)).stringValue)"
-                standardDict.addValueToPayload(res, forKey: kSPResolution)
+                standardDict[kSPResolution] = res
             } else {
-                standardDict.addValueToPayload(nil, forKey: kSPResolution)
+                standardDict.removeValue(forKey: kSPResolution)
             }
         }
     }
@@ -156,9 +156,9 @@ class Subject : NSObject {
             _screenViewPort = newValue
             if let size = newValue {
                 let res = "\((NSNumber(value: size.width)).stringValue)x\((NSNumber(value: size.height)).stringValue)"
-                standardDict.addValueToPayload(res, forKey: kSPViewPort)
+                standardDict[kSPViewPort] = res
             } else {
-                standardDict.addValueToPayload(nil, forKey: kSPViewPort)
+                standardDict.removeValue(forKey: kSPViewPort)
             }
             
         }
@@ -171,79 +171,79 @@ class Subject : NSObject {
     /// Latitude value for the geolocation context.
     var geoLatitude: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoLatitude] as? NSNumber
+            return geoDict[kSPGeoLatitude] as? NSNumber
         }
         set(latitude) {
-            geoLocationDict[kSPGeoLatitude] = latitude
+            geoDict[kSPGeoLatitude] = latitude
         }
     }
 
     /// Longitude value for the geo context.
     var geoLongitude: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoLongitude] as? NSNumber
+            return geoDict[kSPGeoLongitude] as? NSNumber
         }
         set(longitude) {
-            geoLocationDict[kSPGeoLongitude] = longitude
+            geoDict[kSPGeoLongitude] = longitude
         }
     }
 
     /// LatitudeLongitudeAccuracy value for the geolocation context.
     var geoLatitudeLongitudeAccuracy: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoLatLongAccuracy] as? NSNumber
+            return geoDict[kSPGeoLatLongAccuracy] as? NSNumber
         }
         set(latitudeLongitudeAccuracy) {
-            geoLocationDict[kSPGeoLatLongAccuracy] = latitudeLongitudeAccuracy
+            geoDict[kSPGeoLatLongAccuracy] = latitudeLongitudeAccuracy
         }
     }
 
     /// Altitude value for the geolocation context.
     var geoAltitude: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoAltitude] as? NSNumber
+            return geoDict[kSPGeoAltitude] as? NSNumber
         }
         set(altitude) {
-            geoLocationDict[kSPGeoAltitude] = altitude
+            geoDict[kSPGeoAltitude] = altitude
         }
     }
 
     /// AltitudeAccuracy value for the geolocation context.
     var geoAltitudeAccuracy: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoAltitudeAccuracy] as? NSNumber
+            return geoDict[kSPGeoAltitudeAccuracy] as? NSNumber
         }
         set(altitudeAccuracy) {
-            geoLocationDict[kSPGeoAltitudeAccuracy] = altitudeAccuracy
+            geoDict[kSPGeoAltitudeAccuracy] = altitudeAccuracy
         }
     }
 
     var geoBearing: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoBearing] as? NSNumber
+            return geoDict[kSPGeoBearing] as? NSNumber
         }
         set(bearing) {
-            geoLocationDict[kSPGeoBearing] = bearing
+            geoDict[kSPGeoBearing] = bearing
         }
     }
 
     /// Speed value for the geolocation context.
     var geoSpeed: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoSpeed] as? NSNumber
+            return geoDict[kSPGeoSpeed] as? NSNumber
         }
         set(speed) {
-            geoLocationDict[kSPGeoSpeed] = speed
+            geoDict[kSPGeoSpeed] = speed
         }
     }
 
     /// Timestamp value for the geolocation context.
     var geoTimestamp: NSNumber? {
         get {
-            return geoLocationDict[kSPGeoTimestamp] as? NSNumber
+            return geoDict[kSPGeoTimestamp] as? NSNumber
         }
         set(timestamp) {
-            geoLocationDict[kSPGeoTimestamp] = timestamp
+            geoDict[kSPGeoTimestamp] = timestamp
         }
     }
 
@@ -298,14 +298,14 @@ class Subject : NSObject {
 
     //#pragma clang diagnostic pop
 
-    func getStandardDict(userAnonymisation: Bool) -> Payload? {
+    func standardDict(userAnonymisation: Bool) -> [String : String] {
         if userAnonymisation {
-            var copy = standardDict.dictionary ?? [:]
+            var copy = standardDict
             copy.removeValue(forKey: kSPUid)
             copy.removeValue(forKey: kSPDomainUid)
             copy.removeValue(forKey: kSPNetworkUid)
             copy.removeValue(forKey: kSPIpAddress)
-            return Payload(dictionary: copy)
+            return copy
         }
         return standardDict
     }
@@ -313,7 +313,7 @@ class Subject : NSObject {
     /// Gets all platform dictionary pairs to decorate event with. Returns nil if not enabled.
     /// - Parameter userAnonymisation: Whether to anonymise user identifiers
     /// - Returns: A SPPayload with all platform specific pairs.
-    func getPlatformDict(userAnonymisation: Bool, advertisingIdentifierRetriever: (() -> UUID?)?) -> Payload? {
+    func platformDict(userAnonymisation: Bool, advertisingIdentifierRetriever: (() -> UUID?)?) -> Payload? {
         if platformContext {
             return platformContextManager.fetchPlatformDict(
                 userAnonymisation: userAnonymisation,
@@ -325,10 +325,10 @@ class Subject : NSObject {
 
     /// Gets the geolocation dictionary if the required keys are available. Returns nil if not enabled.
     /// - Returns: A dictionary with key-value pairs of the geolocation context.
-    func getGeoLocationDict() -> [String : NSObject]? {
+    public var geoLocationDict: [String : NSObject]? {
         if geoLocationContext {
-            if geoLocationDict[kSPGeoLatitude] != nil && geoLocationDict[kSPGeoLongitude] != nil {
-                return geoLocationDict
+            if geoDict[kSPGeoLatitude] != nil && geoDict[kSPGeoLongitude] != nil {
+                return geoDict
             } else {
                 logDebug(message: "GeoLocation missing required fields; cannot get.")
                 return nil

--- a/Sources/Core/Tracker/DeepLinkStateMachine.swift
+++ b/Sources/Core/Tracker/DeepLinkStateMachine.swift
@@ -77,7 +77,7 @@ class DeepLinkStateMachine: StateMachineProtocol {
         return nil
     }
 
-    func payloadValues(from event: InspectableEvent, state: State?) -> [String : NSObject]? {
+    func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]? {
         return nil
     }
 }

--- a/Sources/Core/Tracker/LifecycleState.swift
+++ b/Sources/Core/Tracker/LifecycleState.swift
@@ -22,16 +22,14 @@ import Foundation
 
 class LifecycleState: NSObject, State {
     private(set) var isForeground = false
-    private(set) var index: NSNumber?
+    private(set) var index: Int
 
-    init(asForegroundWithIndex index: NSNumber?) {
-        super.init()
+    init(asForegroundWithIndex index: Int) {
         isForeground = true
         self.index = index
     }
 
-    init(asBackgroundWithIndex index: NSNumber?) {
-        super.init()
+    init(asBackgroundWithIndex index: Int) {
         isForeground = false
         self.index = index
     }

--- a/Sources/Core/Tracker/LifecycleStateMachine.swift
+++ b/Sources/Core/Tracker/LifecycleStateMachine.swift
@@ -30,10 +30,10 @@ class LifecycleStateMachine: StateMachineProtocol {
 
     func transition(from event: Event, state currentState: State?) -> State? {
         if let e = event as? Foreground {
-            return LifecycleState(asForegroundWithIndex: NSNumber(value: e.index))
+            return LifecycleState(asForegroundWithIndex: e.index)
         }
         if let e = event as? Background {
-            return LifecycleState(asBackgroundWithIndex: NSNumber(value: e.index))
+            return LifecycleState(asBackgroundWithIndex: e.index)
         }
         return nil
     }
@@ -50,7 +50,7 @@ class LifecycleStateMachine: StateMachineProtocol {
         }
         if let s = state as? LifecycleState {
             let entity = LifecycleEntity(isVisible: s.isForeground)
-            entity.index = s.index
+            entity.index = NSNumber(value: s.index)
             return [entity]
         }
         return nil
@@ -60,7 +60,7 @@ class LifecycleStateMachine: StateMachineProtocol {
         return []
     }
 
-    func payloadValues(from event: InspectableEvent, state: State?) -> [String : NSObject]? {
+    func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]? {
         return nil
     }
 }

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -136,7 +136,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
         let _ = tracker // Build tracker to initialize NotificationCenter receivers
     }
 
-    func reset(withConfigurations configurations: [Configuration]) {
+    func reset(configurations: [Configuration]) {
         stopServices()
         resetConfigurationUpdates()
         processConfigurations(configurations)

--- a/Sources/Core/Tracker/TrackerEvent.swift
+++ b/Sources/Core/Tracker/TrackerEvent.swift
@@ -23,8 +23,8 @@ import Foundation
 
 class TrackerEvent : InspectableEvent {
     
-    private var _payload: [String: NSObject]
-    var payload: [String: NSObject] {
+    private var _payload: [String: Any]
+    var payload: [String: Any] {
         get { return _payload }
         set { _payload = newValue }
     }
@@ -69,7 +69,7 @@ class TrackerEvent : InspectableEvent {
         }
     }
 
-    func addPayloadValues(_ payload: [String : NSObject]) -> Bool {
+    func addPayloadValues(_ payload: [String : Any]) -> Bool {
         var result = true
         for (key, obj) in payload {
             if self.payload[key] == nil {

--- a/Sources/Core/Tracker/WebViewMessageHandler.swift
+++ b/Sources/Core/Tracker/WebViewMessageHandler.swift
@@ -62,7 +62,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandler {
 
     func trackSelfDescribing(_ event: [AnyHashable : Any], withContext context: [[AnyHashable : Any]], andTrackers trackers: [String]) {
         if let schema = event["schema"] as? String,
-           let payload = event["data"] as? [String : NSObject] {
+           let payload = event["data"] as? [String : Any] {
             let selfDescribing = SelfDescribing(schema: schema, payload: payload)
             track(selfDescribing, withContext: context, andTrackers: trackers)
         }
@@ -156,7 +156,7 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandler {
 
         for entityJson in context {
             if let schema = entityJson["schema"] as? String,
-               let payload = entityJson["data"] as? [String : NSObject] {
+               let payload = entityJson["data"] as? [String : Any] {
                 let entity = SelfDescribingJson(schema: schema, andDictionary: payload)
                 contextEntities.append(entity)
             }

--- a/Sources/Core/Utils/DataPersistence.swift
+++ b/Sources/Core/Utils/DataPersistence.swift
@@ -30,27 +30,27 @@ let kSessionFilenamePrefixV2_2 = "session"
 var sessionKey = "session"
 
 class DataPersistence: NSObject {
-    var data: [String : [String : NSObject]] {
+    var data: [String : [String : Any]] {
         get {
             objc_sync_enter(self)
             defer { objc_sync_exit(self) }
             if !isStoredOnFile {
-                return ((UserDefaults.standard.dictionary(forKey: userDefaultsKey) ?? [:]) as? [String : [String : NSObject]]) ?? [:]
+                return ((UserDefaults.standard.dictionary(forKey: userDefaultsKey) ?? [:]) as? [String : [String : Any]]) ?? [:]
             }
-            var result: [String : [String : NSObject]]? = nil
+            var result: [String : [String : Any]]? = nil
             if let fileUrl = fileUrl {
-                result = NSDictionary(contentsOf: fileUrl) as Dictionary? as? [String : [String : NSObject]]
+                result = NSDictionary(contentsOf: fileUrl) as? [String : [String : Any]]
             }
 
             if result == nil {
                 // Initialise
                 result = [:]
-                var sessionDict: [AnyHashable : Any] = [:]
+                var sessionDict: [String : Any] = [:]
                 // Add missing fields
                 sessionDict[kSPSessionFirstEventId] = ""
                 sessionDict[kSPSessionStorage] = "LOCAL_STORAGE"
                 // Wrap up
-                result?[sessionKey] = sessionDict as? [String : NSObject]
+                result?[sessionKey] = sessionDict
                 if let result = result, let fileUrl = fileUrl {
                     let _ = storeDictionary(result, fileURL: fileUrl)
                 }
@@ -69,7 +69,7 @@ class DataPersistence: NSObject {
         }
     }
 
-    var session: [String : NSObject]? {
+    var session: [String : Any]? {
         get {
             return (data)[sessionKey]
         }

--- a/Sources/Core/Utils/DataPersistence.swift
+++ b/Sources/Core/Utils/DataPersistence.swift
@@ -29,7 +29,7 @@ let kSessionFilenameV1 = "session.dict"
 let kSessionFilenamePrefixV2_2 = "session"
 var sessionKey = "session"
 
-class DataPersistence: NSObject {
+class DataPersistence {
     var data: [String : [String : Any]] {
         get {
             objc_sync_enter(self)
@@ -91,7 +91,6 @@ class DataPersistence: NSObject {
     private var fileUrl: URL?
 
     init(namespace escapedNamespace: String, storedOnFile isStoredOnFile: Bool) {
-        super.init()
         self.escapedNamespace = escapedNamespace
         userDefaultsKey = "\(kSPSessionDictionaryPrefix)_\(escapedNamespace)"
 #if !(os(tvOS) || os(watchOS))

--- a/Sources/Core/Utils/DeviceInfoMonitor.swift
+++ b/Sources/Core/Utils/DeviceInfoMonitor.swift
@@ -184,7 +184,7 @@ class DeviceInfoMonitor {
 
     /// Returns battery state for the device.
     /// - Returns: One of "charging", "full", "unplugged" or NULL
-    var batteryState: String {
+    var batteryState: String? {
         #if os(iOS)
         switch UIDevice.current.batteryState {
         case .charging:
@@ -194,10 +194,10 @@ class DeviceInfoMonitor {
         case .unplugged:
             return "unplugged"
         default:
-            return ""
+            return nil
         }
         #else
-        return ""
+        return nil
         #endif
     }
 

--- a/Sources/Core/Utils/Utilities.swift
+++ b/Sources/Core/Utils/Utilities.swift
@@ -124,9 +124,9 @@ class Utilities {
     /// This method can encode string, numbers, and bool values, but not embedded arrays or dictionaries.
     /// It encodes bool as 1 and 0.
     /// - Returns: The url encoded string of the dictionary.
-    class func urlEncode(_ dictionary: [String : NSObject]) -> String {
-        return dictionary.map { (key: String, value: NSObject) in
-            "\(self.urlEncode(key))=\(self.urlEncode(value.description))"
+    class func urlEncode(_ dictionary: [String : Any]) -> String {
+        return dictionary.map { (key: String, value: Any) in
+            "\(self.urlEncode(key))=\(self.urlEncode(String(describing: value)))"
         }.joined(separator: "&")
     }
 

--- a/Sources/Snowplow/Configurations/Configuration.swift
+++ b/Sources/Snowplow/Configurations/Configuration.swift
@@ -24,7 +24,7 @@ import Foundation
 @objc(SPConfiguration)
 public class Configuration: NSObject, NSCopying, NSSecureCoding {
     @objc
-    public convenience init?(dictionary: [String : NSObject]) {
+    public convenience init?(dictionary: [String : Any]) {
         self.init()
     }
 

--- a/Sources/Snowplow/Configurations/ConfigurationBundle.swift
+++ b/Sources/Snowplow/Configurations/ConfigurationBundle.swift
@@ -64,23 +64,23 @@ public class ConfigurationBundle: Configuration {
     }
 
     @objc
-    public init?(dictionary: [String : NSObject]) {
+    public init?(dictionary: [String : Any]) {
         if let namespace = dictionary["namespace"] as? String {
             self.namespace = namespace
         } else {
             logDebug(message: "Error assigning: namespace")
             return nil
         }
-        if let config = dictionary["networkConfiguration"] as? [String : NSObject] {
+        if let config = dictionary["networkConfiguration"] as? [String : Any] {
             networkConfiguration = NetworkConfiguration(dictionary: config)
         }
-        if let config = dictionary["trackerConfiguration"] as? [String : NSObject] {
+        if let config = dictionary["trackerConfiguration"] as? [String : Any] {
             trackerConfiguration = TrackerConfiguration(dictionary: config)
         }
-        if let config = dictionary["subjectConfiguration"] as? [String : NSObject] {
+        if let config = dictionary["subjectConfiguration"] as? [String : Any] {
             subjectConfiguration = SubjectConfiguration(dictionary: config)
         }
-        if let config = dictionary["sessionConfiguration"] as? [String: NSObject] {
+        if let config = dictionary["sessionConfiguration"] as? [String: Any] {
             sessionConfiguration = SessionConfiguration(dictionary: config)
         }
     }

--- a/Sources/Snowplow/Configurations/NetworkConfiguration.swift
+++ b/Sources/Snowplow/Configurations/NetworkConfiguration.swift
@@ -48,7 +48,7 @@ public class NetworkConfiguration: Configuration {
 
     /// Allow endpoint and method only.
     @objc
-    public convenience init?(dictionary: [String : NSObject]) {
+    public convenience init?(dictionary: [String : Any]) {
         if let endpoint = dictionary["endpoint"] as? String {
             let method = dictionary["method"] as? String
             let httpMethod = (method == "get") ? HttpMethodOptions.get : HttpMethodOptions.post

--- a/Sources/Snowplow/Configurations/SessionConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SessionConfiguration.swift
@@ -73,7 +73,7 @@ public class SessionConfiguration: Configuration, SessionConfigurationProtocol {
     }
 
     @objc
-    public convenience init?(dictionary: [String : NSObject]) {
+    public convenience init?(dictionary: [String : Any]) {
         let foregroundTimeout = dictionary["foregroundTimeout"] as? Int ?? TrackerDefaults.foregroundTimeout
         let backgroundTimeout = dictionary["backgroundTimeout"] as? Int ?? TrackerDefaults.backgroundTimeout
         self.init(foregroundTimeoutInSeconds: foregroundTimeout, backgroundTimeoutInSeconds: backgroundTimeout)

--- a/Sources/Snowplow/Configurations/SubjectConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SubjectConfiguration.swift
@@ -95,7 +95,7 @@ public protocol SubjectConfigurationProtocol: AnyObject {
 /// The contexts to track can be enabled in the `TrackerConfiguration` class.
 @objc(SPSubjectConfiguration)
 public class SubjectConfiguration: Configuration, SubjectConfigurationProtocol {
-    convenience init(dictionary: [String : NSObject]) {
+    convenience init(dictionary: [String : Any]) {
         self.init()
         if let userId = dictionary["userId"] as? String { self.userId = userId }
         if let networkUserId = dictionary["networkUserId"] as? String { self.networkUserId = networkUserId }

--- a/Sources/Snowplow/Configurations/TrackerConfiguration.swift
+++ b/Sources/Snowplow/Configurations/TrackerConfiguration.swift
@@ -164,7 +164,7 @@ public class TrackerConfiguration: Configuration, TrackerConfigurationProtocol {
     }
 
     @objc
-    public convenience init?(dictionary: [String : NSObject]) {
+    public convenience init?(dictionary: [String : Any]) {
         self.init()
         if let appId = dictionary["appId"] as? String {
             self.appId = appId

--- a/Sources/Snowplow/Emitter/EventStore.swift
+++ b/Sources/Snowplow/Emitter/EventStore.swift
@@ -37,7 +37,7 @@ public protocol EventStore: NSObjectProtocol {
     /// - Parameter storeIds: the events' identifiers in the store.
     /// - Returns: a boolean of success to remove.
     @objc
-    func removeEvents(withIds storeIds: [NSNumber]) -> Bool
+    func removeEvents(withIds storeIds: [Int64]) -> Bool
     /// Empties the store of all the events.
     /// - Returns: a boolean of success to remove.
     @objc

--- a/Sources/Snowplow/Entities/DeepLinkEntity.swift
+++ b/Sources/Snowplow/Entities/DeepLinkEntity.swift
@@ -42,16 +42,16 @@ public class DeepLinkEntity: SelfDescribingJson {
     @objc
     public init(url: String) {
         self.url = url
-        super.init(schema: DeepLinkEntity.schema, andData: nil)
+        super.init(schema: DeepLinkEntity.schema, andData: [:])
     }
 
     @objc
-    override public var data: NSObject? {
+    override public var data: [String : Any] {
         get {
-            var data: [String: NSObject] = [:]
-            data[DeepLinkEntity.paramUrl] = url as NSObject
-            data[DeepLinkEntity.paramReferrer] = referrer as NSObject?
-            return data as NSObject
+            var data: [String: Any] = [:]
+            data[DeepLinkEntity.paramUrl] = url
+            data[DeepLinkEntity.paramReferrer] = referrer
+            return data
         }
         set {}
     }

--- a/Sources/Snowplow/Entities/LifecycleEntity.swift
+++ b/Sources/Snowplow/Entities/LifecycleEntity.swift
@@ -32,23 +32,19 @@ public class LifecycleEntity: SelfDescribingJson {
 
     @objc
     public init(isVisible: Bool) {
-        var parameters: [String : NSObject] = [:]
-        parameters[kSPLifecycleEntityParamIsVisible] = NSNumber(value: isVisible)
-        super.init(schema: kSPLifecycleEntitySchema, andData: parameters as NSObject)
+        var parameters: [String : Any] = [:]
+        parameters[kSPLifecycleEntityParamIsVisible] = isVisible
+        super.init(schema: kSPLifecycleEntitySchema, andData: parameters)
     }
 
     @objc
     public var index: NSNumber? {
         set {
-            if let data = data,
-               var parameters = data as? [String : NSObject] {
-                parameters[kSPLifecycleEntityParamIndex] = newValue
-            }
+            data[kSPLifecycleEntityParamIndex] = newValue?.intValue
         }
         get {
-            if let data = data,
-               let parameters = data as? [String : NSObject] {
-                return parameters[kSPLifecycleEntityParamIndex] as? NSNumber
+            if let value = data[kSPLifecycleEntityParamIndex] as? Int {
+                return NSNumber(value: value)
             }
             return nil
         }

--- a/Sources/Snowplow/Events/Background.swift
+++ b/Sources/Snowplow/Events/Background.swift
@@ -41,9 +41,9 @@ public class Background: SelfDescribingAbstract {
         return kSPBackgroundSchema
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [AnyHashable : Any] = [:]
-        payload[kSPBackgroundIndex] = NSNumber(value: index)
-        return payload as? [String : NSObject] ?? [:]
+    override var payload: [String : Any] {
+        return [
+            kSPBackgroundIndex: index
+        ]
     }
 }

--- a/Sources/Snowplow/Events/ConsentGranted.swift
+++ b/Sources/Snowplow/Events/ConsentGranted.swift
@@ -83,10 +83,10 @@ public class ConsentGranted: SelfDescribingAbstract {
         return kSPConsentGrantedSchema
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[KSPCgExpiry] = expiry as NSObject
-        return payload
+    override var payload: [String : Any] {
+        return [
+            KSPCgExpiry: expiry
+        ]
     }
 
     override func beginProcessing(withTracker tracker: Tracker) {

--- a/Sources/Snowplow/Events/ConsentWithdrawn.swift
+++ b/Sources/Snowplow/Events/ConsentWithdrawn.swift
@@ -51,9 +51,9 @@ public class ConsentWithdrawn: SelfDescribingAbstract {
         return kSPConsentWithdrawnSchema
     }
 
-    override var payload: [String : NSObject] {
+    override var payload: [String : Any] {
         return [
-            KSPCwAll: all ? NSNumber(value: true) : NSNumber(value: false)
+            KSPCwAll: all
         ]
     }
 

--- a/Sources/Snowplow/Events/DeepLinkReceived.swift
+++ b/Sources/Snowplow/Events/DeepLinkReceived.swift
@@ -38,7 +38,7 @@ public class DeepLinkReceived: SelfDescribingAbstract {
     public init(url: String) {
         self.url = url
     }
-    
+
     @objc
     class var schema: String {
         return "iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0"
@@ -58,12 +58,12 @@ public class DeepLinkReceived: SelfDescribingAbstract {
         return DeepLinkReceived.schema
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
         if let referrer = referrer {
-            payload[DeepLinkReceived.paramReferrer] = referrer as NSObject
+            payload[DeepLinkReceived.paramReferrer] = referrer
         }
-        payload[DeepLinkReceived.paramUrl] = url as NSObject
+        payload[DeepLinkReceived.paramUrl] = url
         return payload
     }
 }

--- a/Sources/Snowplow/Events/Ecommerce.swift
+++ b/Sources/Snowplow/Events/Ecommerce.swift
@@ -65,21 +65,21 @@ public class Ecommerce : PrimitiveAbstract {
         return kSPEventEcomm
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPEcommTotal] = String(format: "%.02f", totalValue) as NSObject
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPEcommTotal] = String(format: "%.02f", totalValue)
         if let taxValue = taxValue {
-            payload[kSPEcommTax] = String(format: "%.02f", taxValue.doubleValue) as NSObject
+            payload[kSPEcommTax] = String(format: "%.02f", taxValue.doubleValue)
         }
         if let shipping = shipping {
-            payload[kSPEcommShipping] = String(format: "%.02f", shipping.doubleValue) as NSObject
+            payload[kSPEcommShipping] = String(format: "%.02f", shipping.doubleValue)
         }
-        payload[kSPEcommId] = orderId as NSObject
-        payload[kSPEcommAffiliation] = affiliation as NSObject?
-        payload[kSPEcommCity] = city as NSObject?
-        payload[kSPEcommState] = state as NSObject?
-        payload[kSPEcommCountry] = country as NSObject?
-        payload[kSPEcommCurrency] = currency as NSObject?
+        payload[kSPEcommId] = orderId
+        payload[kSPEcommAffiliation] = affiliation
+        payload[kSPEcommCity] = city
+        payload[kSPEcommState] = state
+        payload[kSPEcommCountry] = country
+        payload[kSPEcommCurrency] = currency
         return payload
     }
 

--- a/Sources/Snowplow/Events/EcommerceItem.swift
+++ b/Sources/Snowplow/Events/EcommerceItem.swift
@@ -56,15 +56,15 @@ public class EcommerceItem : PrimitiveAbstract {
         return kSPEventEcommItem
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPEcommItemId] = orderId as NSObject?
-        payload[kSPEcommItemSku] = sku as NSObject
-        payload[kSPEcommItemName] = name as NSObject?
-        payload[kSPEcommItemCategory] = category as NSObject?
-        payload[kSPEcommItemCurrency] = currency as NSObject?
-        payload[kSPEcommItemPrice] = String(format: "%.02f", price) as NSObject
-        payload[kSPEcommItemQuantity] = String(format: "%ld", quantity) as NSObject
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPEcommItemId] = orderId
+        payload[kSPEcommItemSku] = sku
+        payload[kSPEcommItemName] = name
+        payload[kSPEcommItemCategory] = category
+        payload[kSPEcommItemCurrency] = currency
+        payload[kSPEcommItemPrice] = String(format: "%.02f", price)
+        payload[kSPEcommItemQuantity] = String(format: "%ld", quantity)
         return payload
     }
 }

--- a/Sources/Snowplow/Events/EventBase.swift
+++ b/Sources/Snowplow/Events/EventBase.swift
@@ -33,7 +33,7 @@ public class Event: NSObject {
     public var contexts: [SelfDescribingJson] = []
     
     /// The payload of the event.
-    var payload: [String : NSObject] {
+    var payload: [String : Any] {
         NSException(
             name: .internalInconsistencyException,
             reason: "You must override \(NSStringFromSelector(#function)) in a subclass",

--- a/Sources/Snowplow/Events/Foreground.swift
+++ b/Sources/Snowplow/Events/Foreground.swift
@@ -41,9 +41,9 @@ public class Foreground: SelfDescribingAbstract {
         return kSPForegroundSchema
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPForegroundIndex] = NSNumber(value: index)
-        return payload
+    override var payload: [String : Any] {
+        return [
+            kSPForegroundIndex: index
+        ]
     }
 }

--- a/Sources/Snowplow/Events/MessageNotification.swift
+++ b/Sources/Snowplow/Events/MessageNotification.swift
@@ -129,11 +129,11 @@ public class MessageNotification : SelfDescribingAbstract {
         self.trigger = trigger
     }
     
-    class func messageNotification(userInfo: [String: NSObject], defaultTitle: String?, defaultBody: String?) -> MessageNotification? {
-        guard let aps = userInfo["aps"] as? [String : NSObject] else {
+    class func messageNotification(userInfo: [String: Any], defaultTitle: String?, defaultBody: String?) -> MessageNotification? {
+        guard let aps = userInfo["aps"] as? [String : Any] else {
             return nil
         }
-        guard let alert = aps["alert"] as? [String : NSObject] else {
+        guard let alert = aps["alert"] as? [String : Any] else {
             return nil
         }
         // alert fields
@@ -151,7 +151,11 @@ public class MessageNotification : SelfDescribingAbstract {
         // aps fields
         event.notificationCount = aps["badge"] as? Int
         event.sound = aps["sound"] as? String
-        event.contentAvailable = aps["content-available"] as? Bool
+        if let contentAvailable = aps["content-available"] as? Bool {
+            event.contentAvailable = contentAvailable
+        } else if let contentAvailable = aps["content-available"] as? Int {
+            event.contentAvailable = contentAvailable > 0
+        }
         event.category = aps["category"] as? String
         event.threadIdentifier = aps["thread-id"] as? String
         return event
@@ -161,35 +165,35 @@ public class MessageNotification : SelfDescribingAbstract {
         return kSPMessageNotificationSchema
     }
     
-    override var payload: [String: NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPMessageNotificationParamAction] = action as NSObject?
+    override var payload: [String: Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPMessageNotificationParamAction] = action
         if let attachments = attachments {
-            payload[kSPMessageNotificationParamMessageNotificationAttachments] = attachments.map { $0.data } as NSObject
+            payload[kSPMessageNotificationParamMessageNotificationAttachments] = attachments.map { $0.data }
         }
-        payload[kSPMessageNotificationParamBody] = body as NSObject?
+        payload[kSPMessageNotificationParamBody] = body
         if let bodyLocArgs = bodyLocArgs {
-            payload[kSPMessageNotificationParamBodyLocArgs] = bodyLocArgs as NSObject
+            payload[kSPMessageNotificationParamBodyLocArgs] = bodyLocArgs
         }
-        payload[kSPMessageNotificationParamBodyLocKey] = bodyLocKey as NSObject?
-        payload[kSPMessageNotificationParamCategory] = category as NSObject?
+        payload[kSPMessageNotificationParamBodyLocKey] = bodyLocKey
+        payload[kSPMessageNotificationParamCategory] = category
         if let contentAvailable = contentAvailable {
-            payload[kSPMessageNotificationParamContentAvailable] = NSNumber(value: contentAvailable)
+            payload[kSPMessageNotificationParamContentAvailable] = contentAvailable
         }
-        payload[kSPMessageNotificationParamGroup] = group as NSObject?
-        payload[kSPMessageNotificationParamIcon] = icon as NSObject?
-        payload[kSPMessageNotificationParamNotificationCount] = notificationCount as NSObject?
-        payload[kSPMessageNotificationParamNotificationTimestamp] = notificationTimestamp as NSObject?
-        payload[kSPMessageNotificationParamSound] = sound as NSObject?
-        payload[kSPMessageNotificationParamSubtitle] = subtitle as NSObject?
-        payload[kSPMessageNotificationParamTag] = tag as NSObject?
-        payload[kSPMessageNotificationParamThreadIdentifier] = threadIdentifier as NSObject?
-        payload[kSPMessageNotificationParamTitle] = title as NSObject?
+        payload[kSPMessageNotificationParamGroup] = group
+        payload[kSPMessageNotificationParamIcon] = icon
+        payload[kSPMessageNotificationParamNotificationCount] = notificationCount
+        payload[kSPMessageNotificationParamNotificationTimestamp] = notificationTimestamp
+        payload[kSPMessageNotificationParamSound] = sound
+        payload[kSPMessageNotificationParamSubtitle] = subtitle
+        payload[kSPMessageNotificationParamTag] = tag
+        payload[kSPMessageNotificationParamThreadIdentifier] = threadIdentifier
+        payload[kSPMessageNotificationParamTitle] = title
         if let titleLocArgs = titleLocArgs {
-            payload[kSPMessageNotificationParamTitleLocArgs] = titleLocArgs as NSObject
+            payload[kSPMessageNotificationParamTitleLocArgs] = titleLocArgs
         }
-        payload[kSPMessageNotificationParamTitleLocKey] = titleLocKey as NSObject?
-        payload[kSPMessageNotificationParamTrigger] = triggerToString(trigger) as NSObject
+        payload[kSPMessageNotificationParamTitleLocKey] = titleLocKey
+        payload[kSPMessageNotificationParamTrigger] = triggerToString(trigger)
         return payload
     }
 }

--- a/Sources/Snowplow/Events/MessageNotificationAttachment.swift
+++ b/Sources/Snowplow/Events/MessageNotificationAttachment.swift
@@ -42,11 +42,11 @@ public class MessageNotificationAttachment : NSObject {
         self.url = url
     }
     
-    var data: [String : NSObject] {
+    var data: [String : Any] {
         return [
-            kSPMessageNotificationAttachmentParamIdentifier: identifer as NSObject,
-            kSPMessageNotificationAttachmentParamType: type as NSObject,
-            kSPMessageNotificationAttachmentParamUrl: url as NSObject
+            kSPMessageNotificationAttachmentParamIdentifier: identifer,
+            kSPMessageNotificationAttachmentParamType: type,
+            kSPMessageNotificationAttachmentParamUrl: url
         ]
     }
 }

--- a/Sources/Snowplow/Events/PageView.swift
+++ b/Sources/Snowplow/Events/PageView.swift
@@ -48,12 +48,12 @@ public class PageView : PrimitiveAbstract {
         return kSPEventPageView
     }
     
-    override var payload: [String : NSObject] {
-        var payload: [String: NSObject] = [
-            kSPPageUrl: pageUrl as NSObject
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [
+            kSPPageUrl: pageUrl
         ]
-        payload[kSPPageTitle] = pageTitle as NSObject?
-        payload[kSPPageRefr] = referrer as NSObject?
+        payload[kSPPageTitle] = pageTitle
+        payload[kSPPageRefr] = referrer
         return payload
     }
 }

--- a/Sources/Snowplow/Events/SNOWError.swift
+++ b/Sources/Snowplow/Events/SNOWError.swift
@@ -47,12 +47,12 @@ public class SNOWError: SelfDescribingAbstract {
         return kSPErrorSchema
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPErrorMessage] = message as NSObject
-        payload[kSPErrorStackTrace] = stackTrace as NSObject?
-        payload[kSPErrorName] = name as NSObject?
-        payload[kSPErrorLanguage] = "SWIFT" as NSObject
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPErrorMessage] = message
+        payload[kSPErrorStackTrace] = stackTrace
+        payload[kSPErrorName] = name
+        payload[kSPErrorLanguage] = "SWIFT"
         return payload
     }
 }

--- a/Sources/Snowplow/Events/ScreenView.swift
+++ b/Sources/Snowplow/Events/ScreenView.swift
@@ -81,15 +81,15 @@ public class ScreenView: SelfDescribingAbstract {
         return kSPScreenViewSchema
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPSvName] = name as NSObject
-        payload[kSPSvScreenId] = screenId.uuidString as NSObject
-        if let type = type { payload[kSPSvType] = type as NSObject }
-        if let previousName = previousName { payload[kSPSvPreviousName] = previousName as NSObject }
-        if let previousType = previousType { payload[kSPSvPreviousType] = previousType as NSObject }
-        if let previousId = previousId { payload[kSPSvPreviousScreenId] = previousId as NSObject }
-        if let transitionType = transitionType { payload[kSPSvTransitionType] = transitionType as NSObject }
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPSvName] = name
+        payload[kSPSvScreenId] = screenId.uuidString
+        if let type = type { payload[kSPSvType] = type }
+        if let previousName = previousName { payload[kSPSvPreviousName] = previousName }
+        if let previousType = previousType { payload[kSPSvPreviousType] = previousType }
+        if let previousId = previousId { payload[kSPSvPreviousScreenId] = previousId }
+        if let transitionType = transitionType { payload[kSPSvTransitionType] = transitionType }
         return payload
     }
 

--- a/Sources/Snowplow/Events/SelfDescribing.swift
+++ b/Sources/Snowplow/Events/SelfDescribing.swift
@@ -26,18 +26,13 @@ import Foundation
 public class SelfDescribing: SelfDescribingAbstract {
     @objc
     public convenience init(eventData: SelfDescribingJson) {
-        self.init(schema: eventData.schema, payload: eventData.data as! [String : NSObject])
+        self.init(schema: eventData.schema, payload: eventData.data)
     }
 
     @objc
-    public init(schema: String, payload: [String : NSObject]) {
+    public init(schema: String, payload: [String : Any]) {
         self._schema = schema
         self._payload = payload
-    }
-    
-    public init(schema: String, payload: [String : String]) {
-        self._schema = schema
-        self._payload = payload as [String : NSObject]
     }
     
     private var _schema: String
@@ -46,8 +41,8 @@ public class SelfDescribing: SelfDescribingAbstract {
         set { _schema = newValue }
     }
     
-    private var _payload: [String: NSObject]
-    override var payload: [String : NSObject] {
+    private var _payload: [String : Any]
+    override var payload: [String : Any] {
         get { return _payload }
         set {
             _payload = newValue
@@ -57,7 +52,7 @@ public class SelfDescribing: SelfDescribingAbstract {
     var eventData: SelfDescribingJson {
         set {
             schema = newValue.schema
-            payload = newValue.data as! [String : NSObject]
+            payload = newValue.data
         }
         get {
             return SelfDescribingJson(schema: schema, andDictionary: payload)

--- a/Sources/Snowplow/Events/Structured.swift
+++ b/Sources/Snowplow/Events/Structured.swift
@@ -59,14 +59,14 @@ public class Structured: PrimitiveAbstract {
         return kSPEventStructured
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPStuctCategory] = category as NSObject
-        payload[kSPStuctAction] = action as NSObject
-        if let label = label { payload[kSPStuctLabel] = label as NSObject }
-        if let property = property { payload[kSPStuctProperty] = property as NSObject }
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPStuctCategory] = category
+        payload[kSPStuctAction] = action
+        if let label = label { payload[kSPStuctLabel] = label }
+        if let property = property { payload[kSPStuctProperty] = property }
         if let value = value {
-            payload[kSPStuctValue] = String(format: "%.17g", value.doubleValue) as NSObject
+            payload[kSPStuctValue] = String(format: "%.17g", value.doubleValue)
         }
         return payload
     }

--- a/Sources/Snowplow/Events/Timing.swift
+++ b/Sources/Snowplow/Events/Timing.swift
@@ -54,12 +54,12 @@ public class Timing: SelfDescribingAbstract {
         return kSPUserTimingsSchema
     }
 
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPUtCategory] = category as NSObject
-        payload[kSPUtVariable] = variable as NSObject
-        payload[kSPUtTiming] = NSNumber(value: timing)
-        if let label = label { payload[kSPUtLabel] = label as NSObject }
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPUtCategory] = category
+        payload[kSPUtVariable] = variable
+        payload[kSPUtTiming] = timing
+        if let label = label { payload[kSPUtLabel] = label }
         return payload
     }
 }

--- a/Sources/Snowplow/Events/TrackerError.swift
+++ b/Sources/Snowplow/Events/TrackerError.swift
@@ -60,19 +60,19 @@ public class TrackerError : SelfDescribingAbstract {
         return kSPDiagnosticErrorSchema
     }
     
-    override var payload: [String : NSObject] {
-        var payload: [String : NSObject] = [:]
-        payload[kSPDiagnosticErrorClassName] = source as NSObject
-        payload[kSPDiagnosticErrorMessage] = truncate(message, maxLength: kMaxMessageLength) as NSObject
+    override var payload: [String : Any] {
+        var payload: [String : Any] = [:]
+        payload[kSPDiagnosticErrorClassName] = source
+        payload[kSPDiagnosticErrorMessage] = truncate(message, maxLength: kMaxMessageLength)
         if let error = error {
-            payload[kSPDiagnosticErrorExceptionName] = error as NSObject
+            payload[kSPDiagnosticErrorExceptionName] = error
         }
         if let exception = exception {
-            payload[kSPDiagnosticErrorExceptionName] = truncate(exception.name.rawValue, maxLength: kMaxExceptionNameLength) as NSObject
+            payload[kSPDiagnosticErrorExceptionName] = truncate(exception.name.rawValue, maxLength: kMaxExceptionNameLength)
             let symbols = (exception).callStackSymbols
             if symbols.count != 0 {
                 let stackTrace = "Stacktrace:\n\(symbols)"
-                payload[kSPDiagnosticErrorStack] = truncate(stackTrace, maxLength: kMaxStackLength) as NSObject
+                payload[kSPDiagnosticErrorStack] = truncate(stackTrace, maxLength: kMaxStackLength)
             }
         }
         return payload

--- a/Sources/Snowplow/Network/Request.swift
+++ b/Sources/Snowplow/Network/Request.swift
@@ -26,7 +26,7 @@ public class Request: NSObject {
     @objc
     public private(set) var payload: Payload?
     @objc
-    public private(set) var emitterEventIds: [NSNumber]?
+    public private(set) var emitterEventIds: [Int64]
     @objc
     public private(set) var oversize = false
     @objc
@@ -37,33 +37,30 @@ public class Request: NSObject {
     }
 
     init(payload: Payload, emitterEventId: Int64, oversize: Bool) {
+        emitterEventIds = [emitterEventId]
         super.init()
         self.payload = payload
-        emitterEventIds = [NSNumber(value: emitterEventId)]
         customUserAgent = userAgent(from: payload)
         self.oversize = oversize
     }
 
-    init(payloads: [Payload], emitterEventIds: [NSNumber]) {
+    init(payloads: [Payload], emitterEventIds: [Int64]) {
+        self.emitterEventIds = emitterEventIds
         super.init()
         var tempUserAgent: String? = nil
-        var payloadData: [[String : NSObject]] = []
+        var payloadData: [[String : Any]] = []
         for payload in payloads {
-            if let data = payload.dictionary {
-                payloadData.append(data)
-            }
+            payloadData.append(payload.dictionary)
             tempUserAgent = userAgent(from: payload)
         }
-        let payloadBundle = SelfDescribingJson(schema: kSPPayloadDataSchema, andData: payloadData as NSObject)
-        if let payloadBundleDict = payloadBundle.dictionary {
-            payload = Payload(dictionary: payloadBundleDict)
-        }
-        self.emitterEventIds = emitterEventIds
+        let payloadBundle = SelfDescribingJson.dictionary(schema: kSPPayloadDataSchema,
+                                                          data: payloadData)
+        payload = Payload(dictionary: payloadBundle)
         customUserAgent = tempUserAgent
         oversize = false
     }
 
     func userAgent(from payload: Payload) -> String? {
-        return (payload.dictionary?[kSPUseragent] as? String)
+        return (payload.dictionary[kSPUseragent] as? String)
     }
 }

--- a/Sources/Snowplow/Network/RequestResult.swift
+++ b/Sources/Snowplow/Network/RequestResult.swift
@@ -30,7 +30,7 @@ public class RequestResult: NSObject {
     public private(set) var isOversize: Bool
     /// Returns the stored index array, needed to remove the events after sending.
     @objc
-    public private(set) var storeIds: [NSNumber]?
+    public private(set) var storeIds: [Int64]?
 
     @objc
     public convenience override init() {
@@ -42,7 +42,7 @@ public class RequestResult: NSObject {
     ///   - statusCode: HTTP status code from collector response
     ///   - storeIds: the event indexes in the database
     @objc
-    public init(statusCode: NSNumber?, oversize isOversize: Bool, storeIds: [NSNumber]?) {
+    public init(statusCode: NSNumber?, oversize isOversize: Bool, storeIds: [Int64]?) {
         self.statusCode = statusCode?.intValue
         self.isOversize = isOversize
         self.storeIds = storeIds

--- a/Sources/Snowplow/Payload/SelfDescribingJson.swift
+++ b/Sources/Snowplow/Payload/SelfDescribingJson.swift
@@ -33,26 +33,20 @@ public class SelfDescribingJson: NSObject {
     
     /// Data of the self-describing JSON.
     @objc
-    public var data: NSObject?
+    public var data: [String : Any]
 
     /// Returns the internal NSDictionary of the self-describing JSON.
     /// - Returns: The self-describing JSON as an NSDictionary.
     @objc
-    public var dictionary: [String : NSObject]? {
-        if let data = data {
-            return [
-                kSPSchema: schema as NSObject,
-                kSPData: data
-            ]
-        }
-        return nil
+    public var dictionary: [String : Any] {
+        return SelfDescribingJson.dictionary(schema: schema, data: data)
     }
 
     /// Returns a string description of the internal dictionary.
     /// - Returns: The description of the dictionary.
     @objc
     override public var description: String {
-        return dictionary?.description ?? ""
+        return dictionary.description
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
@@ -61,10 +55,10 @@ public class SelfDescribingJson: NSObject {
     ///   - data: Data to set for data field of the self-describing JSON, should be an NSDictionary.
     /// - Returns: An SPSelfDescribingJson.
     @objc
-    public init(schema: String, andData data: NSObject?) {
+    public init(schema: String, andData data: [String : Any]) {
         self.schema = schema
+        self.data = data
         super.init()
-        setData(withObject: data)
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
@@ -73,17 +67,8 @@ public class SelfDescribingJson: NSObject {
     ///   - data: Dictionary to set for data field of the self-describing JSON.
     /// - Returns: An SPSelfDescribingJson.
     @objc
-    public convenience init(schema: String, andDictionary data: [String : NSObject]) {
-        self.init(schema: schema, andData: data as NSObject)
-    }
-
-    /// Initializes a newly allocated SPSelfDescribingJson.
-    /// - Parameters:
-    ///   - schema: A valid schema string.
-    ///   - data: Dictionary to set for data field of the self-describing JSON.
-    /// - Returns: An SPSelfDescribingJson.
-    public convenience init(schema: String, andDictionary data: [String : String]) {
-        self.init(schema: schema, andDictionary: data as [String : NSObject])
+    public convenience init(schema: String, andDictionary data: [String : Any]) {
+        self.init(schema: schema, andData: data)
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
@@ -92,8 +77,8 @@ public class SelfDescribingJson: NSObject {
     ///   - data: Payload to set for data field of the self-describing JSON.
     /// - Returns: An SPSelfDescribingJson.
     @objc
-    public convenience init(schema: String, andPayload data: Payload) {
-        self.init(schema: schema, andData: data.dictionary as NSObject?)
+    public convenience init(schema: String, andPayload payload: Payload) {
+        self.init(schema: schema, andData: payload.dictionary)
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
@@ -103,27 +88,27 @@ public class SelfDescribingJson: NSObject {
     /// - Returns: An SPSelfDescribingJson.
     @objc
     public convenience init(schema: String, andSelfDescribingJson data: SelfDescribingJson) {
-        self.init(schema: schema, andData: data.dictionary as NSObject?)
-    }
-
-    /// Sets the data field of the self-describing JSON.
-    /// - Parameter data: An NSObject to be nested into the data.
-    @objc
-    public func setData(withObject data: NSObject?) {
-        self.data = data
+        self.init(schema: schema, andData: data.dictionary)
     }
 
     /// Sets the data field of the self-describing JSON.
     /// - Parameter data: An SPPayload to be nested into the data.
     @objc
     public func setData(withPayload data: Payload) {
-        return setData(withObject: data.dictionary as NSObject?)
+        self.data = data.dictionary
     }
 
     /// Sets the data field of the self-describing JSON.
     /// - Parameter data: A self-describing JSON to be nested into the data.
     @objc
     public func setData(withSelfDescribingJson data: SelfDescribingJson) {
-        return setData(withObject: data.dictionary as NSObject?)
+        self.data = data.dictionary
+    }
+    
+    class func dictionary(schema: String, data: Any) -> [String: Any] {
+        return [
+            kSPSchema: schema,
+            kSPData: data
+        ]
     }
 }

--- a/Sources/Snowplow/Snowplow.swift
+++ b/Sources/Snowplow/Snowplow.swift
@@ -196,7 +196,7 @@ public class Snowplow: NSObject {
     @objc
     public class func createTracker(namespace: String, network networkConfiguration: NetworkConfiguration, configurations: [Configuration]) -> TrackerController? {
         if let serviceProvider = serviceProviderInstances[namespace] {
-            serviceProvider.reset(withConfigurations: configurations + [networkConfiguration])
+            serviceProvider.reset(configurations: configurations + [networkConfiguration])
             return serviceProvider.trackerController
         } else {
             let serviceProvider = ServiceProvider(namespace: namespace, network: networkConfiguration, configurations: configurations)

--- a/Sources/Snowplow/Tracker/InspectableEvent.swift
+++ b/Sources/Snowplow/Tracker/InspectableEvent.swift
@@ -32,7 +32,7 @@ public protocol InspectableEvent {
     var eventName: String? { get }
     /// The payload of the event
     @objc
-    var payload: [String : NSObject] { get }
+    var payload: [String : Any] { get }
     /// The tracker state at the time the event was sent.
     @objc
     var state: TrackerStateSnapshot { get }
@@ -40,5 +40,5 @@ public protocol InspectableEvent {
     /// - Parameter payload: Map of values to add to the event payload.
     /// - Returns: Whether or not the values have been successfully added to the event payload.
     @objc
-    func addPayloadValues(_ payload: [String : NSObject]) -> Bool
+    func addPayloadValues(_ payload: [String : Any]) -> Bool
 }

--- a/Sources/Snowplow/Tracker/SessionState.swift
+++ b/Sources/Snowplow/Tracker/SessionState.swift
@@ -38,20 +38,20 @@ public class SessionState: NSObject, State {
     @objc
     public private(set) var userId: String
 
-    var sessionContext: [String : NSObject] {
+    var sessionContext: [String : Any] {
         return sessionDictionary
     }
-    private var sessionDictionary: [String : NSObject] = [:]
+    private var sessionDictionary: [String : Any] = [:]
 
-    class func buildSessionDictionary(withFirstEventId firstEventId: String?, firstEventTimestamp: String?, currentSessionId: String, previousSessionId: String?, sessionIndex: Int, userId: String, storage: String) -> [String : NSObject] {
-        var dictionary: [String : NSObject] = [:]
-        dictionary[kSPSessionPreviousId] = previousSessionId as NSObject? ?? NSNull()
-        dictionary[kSPSessionId] = currentSessionId as NSObject
-        dictionary[kSPSessionFirstEventId] = firstEventId as NSObject?
-        dictionary[kSPSessionFirstEventTimestamp] = firstEventTimestamp as NSObject?
-        dictionary[kSPSessionIndex] = NSNumber(value: sessionIndex)
-        dictionary[kSPSessionStorage] = storage as NSObject
-        dictionary[kSPSessionUserId] = userId as NSObject
+    class func buildSessionDictionary(withFirstEventId firstEventId: String?, firstEventTimestamp: String?, currentSessionId: String, previousSessionId: String?, sessionIndex: Int, userId: String, storage: String) -> [String : Any] {
+        var dictionary: [String : Any] = [:]
+        dictionary[kSPSessionPreviousId] = previousSessionId ?? NSNull()
+        dictionary[kSPSessionId] = currentSessionId
+        dictionary[kSPSessionFirstEventId] = firstEventId
+        dictionary[kSPSessionFirstEventTimestamp] = firstEventTimestamp
+        dictionary[kSPSessionIndex] = sessionIndex
+        dictionary[kSPSessionStorage] = storage
+        dictionary[kSPSessionUserId] = userId
         return dictionary
     }
 
@@ -74,7 +74,7 @@ public class SessionState: NSObject, State {
             storage: storage)
     }
 
-    init?(storedState: [String : NSObject]) {
+    init?(storedState: [String : Any]) {
         guard let sessionId = storedState[kSPSessionId] as? String,
               let sessionIndex = storedState[kSPSessionIndex] as? Int,
               let userId = storedState[kSPSessionUserId] as? String else {

--- a/Sources/Snowplow/Tracker/StateMachineProtocol.swift
+++ b/Sources/Snowplow/Tracker/StateMachineProtocol.swift
@@ -36,5 +36,5 @@ public protocol StateMachineProtocol {
     @objc
     func entities(from event: InspectableEvent, state: State?) -> [SelfDescribingJson]?
     @objc
-    func payloadValues(from event: InspectableEvent, state: State?) -> [String : NSObject]?
+    func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]?
 }

--- a/Tests/Configurations/TestRemoteConfiguration.swift
+++ b/Tests/Configurations/TestRemoteConfiguration.swift
@@ -44,7 +44,7 @@ class TestRemoteConfiguration: XCTestCase {
         guard let jsonData = config.data(using: .utf8) else {
             return XCTFail()
         }
-        guard let dictionary = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String : NSObject] else {
+        guard let dictionary = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String : Any] else {
             return XCTFail()
         }
         guard let fetchedConfigurationBundle = FetchedConfigurationBundle(dictionary: dictionary) else {

--- a/Tests/Configurations/TestTrackerConfiguration.swift
+++ b/Tests/Configurations/TestTrackerConfiguration.swift
@@ -225,7 +225,7 @@ class TestTrackerConfiguration: XCTestCase {
         let payload = events.first?.payload
 
         // Check v_tracker field
-        let versionTracker = payload?.dictionary?["tv"] as? String
+        let versionTracker = payload?["tv"] as? String
         let expected = "\(kSPVersion) testWithSpace1-2-3"
         XCTAssertEqual(expected, versionTracker)
     }
@@ -262,7 +262,7 @@ class TestTrackerConfiguration: XCTestCase {
         _ = eventStore.removeAllEvents()
         XCTAssertEqual(1, events.count)
         var payload = events.first?.payload
-        var contexts = payload?.dictionary?["co"] as? String
+        var contexts = payload?["co"] as? String
         XCTAssertTrue(contexts?.contains("\"basisForProcessing\":\"contract\"") ?? false)
         XCTAssertTrue(contexts?.contains("\"documentId\":\"id1\"") ?? false)
 
@@ -282,7 +282,7 @@ class TestTrackerConfiguration: XCTestCase {
         _ = eventStore.removeAllEvents()
         XCTAssertEqual(1, events.count)
         payload = events.first?.payload
-        contexts = payload?.dictionary?["co"] as? String
+        contexts = payload?["co"] as? String
         XCTAssertFalse(contexts?.contains("\"basisForProcessing\":\"contract\"") ?? false)
         XCTAssertFalse(contexts?.contains("\"documentId\":\"id1\"") ?? false)
 
@@ -315,7 +315,7 @@ class TestTrackerConfiguration: XCTestCase {
         _ = eventStore.removeAllEvents()
         XCTAssertEqual(1, events.count)
         var payload = events.first?.payload
-        var contexts = payload?.dictionary?["co"] as? String
+        var contexts = payload?["co"] as? String
         XCTAssertFalse(contexts?.contains("\"basisForProcessing\"") ?? true)
 
         // Check gdpr can be enabled again
@@ -334,7 +334,7 @@ class TestTrackerConfiguration: XCTestCase {
         _ = eventStore.removeAllEvents()
         XCTAssertEqual(1, events.count)
         payload = events.first?.payload
-        contexts = payload?.dictionary?["co"] as? String
+        contexts = payload?["co"] as? String
         XCTAssertTrue(contexts?.contains("\"basisForProcessing\":\"contract\"") ?? false)
         XCTAssertTrue(contexts?.contains("\"documentId\":\"id1\"") ?? false)
     }
@@ -363,7 +363,7 @@ class TestTrackerConfiguration: XCTestCase {
         _ = eventStore.removeAllEvents()
         XCTAssertEqual(1, events.count)
         guard let payload = events.first?.payload,
-              let contexts = payload.dictionary?["co"] as? String else { return XCTFail() }
+              let contexts = payload["co"] as? String else { return XCTFail() }
 
         // Check empty userId in session context
         XCTAssertTrue(contexts.contains("\"userId\":\"00000000-0000-0000-0000-000000000000\""))
@@ -394,7 +394,7 @@ class TestTrackerConfiguration: XCTestCase {
         let payload = events.first?.payload
 
         // Check eid field
-        let trackedEventId = payload?.dictionary?["eid"] as? String
+        let trackedEventId = payload?["eid"] as? String
         XCTAssertTrue((eventId?.uuidString == trackedEventId))
     }
 }

--- a/Tests/Global Contexts/TestGlobalContexts.swift
+++ b/Tests/Global Contexts/TestGlobalContexts.swift
@@ -33,7 +33,7 @@ class GlobalContextGenerator: NSObject, ContextGenerator {
     func generator(from event: InspectableEvent) -> [SelfDescribingJson]? {
         return [
             SelfDescribingJson(schema: "schema", andDictionary: [
-                "key": "value" as NSObject
+                "key": "value"
             ])
         ]
     }
@@ -45,14 +45,14 @@ class TestGlobalContexts: XCTestCase {
     func testGlobalContexts() {
         let staticGC = GlobalContext(staticContexts: [
             SelfDescribingJson(schema: "schema", andDictionary: [
-                "key": "value" as NSObject
+                "key": "value"
             ])
         ])
         let generatorGC = GlobalContext(contextGenerator: GlobalContextGenerator())
         let blockGC = GlobalContext(generator: { event in
             return [
                 SelfDescribingJson(schema: "schemaBlock", andDictionary: [
-                    "key": "value" as NSObject
+                    "key": "value"
                 ])
             ]
         })
@@ -98,7 +98,7 @@ class TestGlobalContexts: XCTestCase {
     func testAddRemove() {
         let staticGC = GlobalContext(staticContexts: [
             SelfDescribingJson(schema: "schema", andDictionary: [
-                "key": "value" as NSObject
+                "key": "value"
             ])
         ])
         var generators: [String : GlobalContext] = [:]
@@ -129,7 +129,7 @@ class TestGlobalContexts: XCTestCase {
     func testStaticGenerator() {
         let staticGC = GlobalContext(staticContexts: [
             SelfDescribingJson(schema: "schema", andDictionary: [
-                "key": "value" as NSObject
+                "key": "value"
             ])
         ])
         var globalContexts = [
@@ -151,7 +151,7 @@ class TestGlobalContexts: XCTestCase {
         let filterMatchingGC = GlobalContext(
             staticContexts: [
                 SelfDescribingJson(schema: "schema", andDictionary: [
-                    "key": "value" as NSObject
+                    "key": "value"
                 ])
             ],
             filter: { event in
@@ -186,7 +186,7 @@ class TestGlobalContexts: XCTestCase {
 
         let rulesetGC = GlobalContext(staticContexts: [
             SelfDescribingJson(schema: "schema", andDictionary: [
-                "key": "value" as NSObject
+                "key": "value"
             ])
         ], ruleset: ruleset)
         var globalContexts = [

--- a/Tests/Legacy Tests/LegacyTestSubject.swift
+++ b/Tests/Legacy Tests/LegacyTestSubject.swift
@@ -36,13 +36,13 @@ class LegacyTestSubject: XCTestCase {
 
     func testSubjectInit() {
         let subject = Subject()
-        XCTAssertNotNil(subject.getStandardDict(userAnonymisation: false))
+        XCTAssertNotNil(subject.standardDict(userAnonymisation: false))
     }
 
     func testSubjectInitWithOptions() {
         let subject = Subject(platformContext: true, andGeoContext: false)
-        XCTAssertNotNil(subject.getPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil))
-        XCTAssertNotNil(subject.getStandardDict(userAnonymisation: false))
+        XCTAssertNotNil(subject.platformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil))
+        XCTAssertNotNil(subject.standardDict(userAnonymisation: false))
     }
 
     func testSubjectSetterFunctions() {
@@ -58,20 +58,18 @@ class LegacyTestSubject: XCTestCase {
         subject.networkUserId = "aNuid"
         subject.domainUserId = "aDuid"
 
-        guard var values = subject.getStandardDict(userAnonymisation: false)?.dictionary else {
-            return XCTFail()
-        }
+        let values = subject.standardDict(userAnonymisation: false)
 
-        XCTAssertEqual(values[kSPUid], "aUserId" as NSObject)
-        XCTAssertTrue((values[kSPResolution] == "1920x1080" as NSObject))
-        XCTAssertTrue((values[kSPViewPort] == "1080x1920" as NSObject))
-        XCTAssertTrue((values[kSPColorDepth] == "20" as NSObject))
-        XCTAssertEqual(values[kSPTimezone], "UTC" as NSObject)
-        XCTAssertEqual(values[kSPLanguage], "EN" as NSObject)
-        XCTAssertEqual(values[kSPIpAddress], "127.0.0.1" as NSObject)
-        XCTAssertEqual(values[kSPUseragent], "aUseragent" as NSObject)
-        XCTAssertEqual(values[kSPNetworkUid], "aNuid" as NSObject)
-        XCTAssertEqual(values[kSPDomainUid], "aDuid" as NSObject)
+        XCTAssertEqual(values[kSPUid], "aUserId")
+        XCTAssertTrue((values[kSPResolution] == "1920x1080"))
+        XCTAssertTrue((values[kSPViewPort] == "1080x1920"))
+        XCTAssertTrue((values[kSPColorDepth] == "20"))
+        XCTAssertEqual(values[kSPTimezone], "UTC")
+        XCTAssertEqual(values[kSPLanguage], "EN")
+        XCTAssertEqual(values[kSPIpAddress], "127.0.0.1")
+        XCTAssertEqual(values[kSPUseragent], "aUseragent")
+        XCTAssertEqual(values[kSPNetworkUid], "aNuid")
+        XCTAssertEqual(values[kSPDomainUid], "aDuid")
 
         // Setup GeoLocation
         subject.geoLongitude = NSNumber(value: 5)
@@ -83,26 +81,26 @@ class LegacyTestSubject: XCTestCase {
         subject.geoAltitude = NSNumber(value: 62.3)
         subject.geoAltitudeAccuracy = NSNumber(value: 16.3)
 
-        values = subject.getGeoLocationDict()!
+        let geoValues = subject.geoLocationDict!
 
-        XCTAssertTrue((NSNumber(value: 5) == values[kSPGeoLongitude]))
-        XCTAssertTrue((NSNumber(value: 89.2) == values[kSPGeoLatitude]))
-        XCTAssertTrue((NSNumber(value: 5.5) == values[kSPGeoLatLongAccuracy]))
-        XCTAssertTrue((NSNumber(value: 6.2) == values[kSPGeoSpeed]))
-        XCTAssertTrue((NSNumber(value: 82.3) == values[kSPGeoBearing]))
-        XCTAssertTrue((NSNumber(value: 62.3) == values[kSPGeoAltitude]))
-        XCTAssertTrue((NSNumber(value: 16.3) == values[kSPGeoAltitudeAccuracy]))
-        XCTAssertTrue((NSNumber(value: 5) == values[kSPGeoTimestamp]))
+        XCTAssertTrue((NSNumber(value: 5) == geoValues[kSPGeoLongitude]))
+        XCTAssertTrue((NSNumber(value: 89.2) == geoValues[kSPGeoLatitude]))
+        XCTAssertTrue((NSNumber(value: 5.5) == geoValues[kSPGeoLatLongAccuracy]))
+        XCTAssertTrue((NSNumber(value: 6.2) == geoValues[kSPGeoSpeed]))
+        XCTAssertTrue((NSNumber(value: 82.3) == geoValues[kSPGeoBearing]))
+        XCTAssertTrue((NSNumber(value: 62.3) == geoValues[kSPGeoAltitude]))
+        XCTAssertTrue((NSNumber(value: 16.3) == geoValues[kSPGeoAltitudeAccuracy]))
+        XCTAssertTrue((NSNumber(value: 5) == geoValues[kSPGeoTimestamp]))
     }
 
     func testGeoLocationGetWithoutNeededKeys() {
         let subject = Subject(platformContext: false, andGeoContext: true)
-        XCTAssertNil(subject.getGeoLocationDict())
+        XCTAssertNil(subject.geoLocationDict)
 
         subject.geoLongitude = NSNumber(value: 5)
         subject.geoLatitude = NSNumber(value: 89.2)
 
-        XCTAssertNotNil(subject.getGeoLocationDict())
+        XCTAssertNotNil(subject.geoLocationDict)
     }
 
     func testGeoLocationWithSubjectConfiguration() {
@@ -111,7 +109,7 @@ class LegacyTestSubject: XCTestCase {
         config.geoLongitude = NSNumber(value: 24.24)
         let subject = Subject(platformContext: false, geoLocationContext: true, subjectConfiguration: config)
 
-        let values = subject.getGeoLocationDict()
+        let values = subject.geoLocationDict
 
         XCTAssertEqual(NSNumber(value: 12.12), values?[kSPGeoLatitude])
         XCTAssertEqual(NSNumber(value: 24.24), values?[kSPGeoLongitude])

--- a/Tests/Legacy Tests/LegacyTestTracker.swift
+++ b/Tests/Legacy Tests/LegacyTestTracker.swift
@@ -126,9 +126,9 @@ class LegacyTestTracker: XCTestCase {
         var payload = tracker.payload(with: trackerEvent)
         var payloadDict = payload.dictionary
 
-        XCTAssertEqual(payloadDict?[kSPPlatform] as? String, devicePlatformToString(.general))
-        XCTAssertEqual(payloadDict?[kSPAppId] as? String, "anAppId")
-        XCTAssertEqual(payloadDict?[kSPNamespace] as? String, "aNamespace")
+        XCTAssertEqual(payloadDict[kSPPlatform] as? String, devicePlatformToString(.general))
+        XCTAssertEqual(payloadDict[kSPAppId] as? String, "anAppId")
+        XCTAssertEqual(payloadDict[kSPNamespace] as? String, "aNamespace")
 
         // Test setting variables to new values
 
@@ -139,9 +139,9 @@ class LegacyTestTracker: XCTestCase {
         payload = tracker.payload(with: trackerEvent)
         payloadDict = payload.dictionary
 
-        XCTAssertEqual(payloadDict?[kSPPlatform] as? String, "pc")
-        XCTAssertEqual(payloadDict?[kSPAppId] as? String, "newAppId")
-        XCTAssertEqual(payloadDict?[kSPNamespace] as? String, "newNamespace")
+        XCTAssertEqual(payloadDict[kSPPlatform] as? String, "pc")
+        XCTAssertEqual(payloadDict[kSPAppId] as? String, "newAppId")
+        XCTAssertEqual(payloadDict[kSPNamespace] as? String, "newNamespace")
     }
 
     func testEventIdNotDuplicated() {

--- a/Tests/TestDataPersistence.swift
+++ b/Tests/TestDataPersistence.swift
@@ -36,20 +36,20 @@ class TestDataPersistence: XCTestCase {
     func testDataPersistenceForNamespaceWithDifferentNamespaces() {
         let dp1 = DataPersistence.getFor(namespace: "namespace1")
         let dp2 = DataPersistence.getFor(namespace: "namespace2")
-        XCTAssertNotEqual(dp1, dp2)
+        XCTAssertFalse(dp1 === dp2)
     }
 
     func testDataPersistenceForNamespaceWithSameNamespaces() {
         let dp1 = DataPersistence.getFor(namespace: "namespace")
         let dp2 = DataPersistence.getFor(namespace: "namespace")
-        XCTAssertEqual(dp1, dp2)
+        XCTAssertTrue(dp1 === dp2)
     }
 
     func testRemoveForNamespace() {
         let dp1 = DataPersistence.getFor(namespace: "namespace")
         _ = DataPersistence.remove(withNamespace: "namespace")
         let dp2 = DataPersistence.getFor(namespace: "namespace")
-        XCTAssertNotEqual(dp1, dp2)
+        XCTAssertFalse(dp1 === dp2)
     }
 
     func testDataIsCorrectlyStored() {

--- a/Tests/TestDataPersistence.swift
+++ b/Tests/TestDataPersistence.swift
@@ -63,18 +63,18 @@ class TestDataPersistence: XCTestCase {
     func commonTestDataIsCorrectlyStored(onFile isStoredOnFile: Bool) {
         let dp = DataPersistence.getFor(namespace: "namespace", storedOnFile: isStoredOnFile)
         var session = [
-            "key": "value" as NSObject
+            "key": "value"
         ]
         dp?.session = session
-        XCTAssertEqual(session, dp?.session)
-        XCTAssertEqual(session, dp?.data["session"])
+        XCTAssertEqual(session, dp?.session as! [String : String])
+        XCTAssertEqual(session, dp?.data["session"] as! [String : String])
         // Override session
         session = [
-            "key2": "value2" as NSObject
+            "key2": "value2"
         ]
         dp?.session = session
-        XCTAssertEqual(session, dp?.session)
-        XCTAssertEqual(session, dp?.data["session"])
+        XCTAssertEqual(session, dp?.session as! [String : String])
+        XCTAssertEqual(session, dp?.data["session"] as! [String : String])
     }
 
     func testDataIsStoredWithoutInterference() {
@@ -89,14 +89,14 @@ class TestDataPersistence: XCTestCase {
         let dp1 = DataPersistence.getFor(namespace: "namespace1", storedOnFile: isStoredOnFile)
         let dp2 = DataPersistence.getFor(namespace: "namespace2", storedOnFile: isStoredOnFile)
         let session = [
-            "key": "value" as NSObject
+            "key": "value"
         ]
         dp1?.session = session
         // Check dp1
-        XCTAssertEqual(session, dp1?.session)
-        XCTAssertEqual(session, dp1?.data["session"])
+        XCTAssertEqual(session, dp1?.session as? [String : String])
+        XCTAssertEqual(session, dp1?.data["session"] as? [String : String])
         // Check dp2
-        XCTAssertNotEqual(session, dp2?.session)
-        XCTAssertNotEqual(session, dp2?.data["session"])
+        XCTAssertNotEqual(session, dp2?.session as? [String : String])
+        XCTAssertNotEqual(session, dp2?.data["session"] as? [String : String])
     }
 }

--- a/Tests/TestEvents.swift
+++ b/Tests/TestEvents.swift
@@ -63,7 +63,7 @@ class TestEvents: XCTestCase {
         let payload = events.first?.payload
 
         // Check v_tracker field
-        let deviceTimestamp = payload?.dictionary?["dtm"] as? String
+        let deviceTimestamp = payload?["dtm"] as? String
         let expected = String(format: "%lld", Int64(currentTimestamp.timeIntervalSince1970 * 1000))
         XCTAssertEqual(expected, deviceTimestamp)
     }
@@ -95,8 +95,8 @@ class TestEvents: XCTestCase {
         let payload = events.first?.payload
 
         // Check url and referrer fields
-        let url = payload?.dictionary?[kSPPageUrl] as? String
-        let referrer = payload?.dictionary?[kSPPageRefr] as? String
+        let url = payload?[kSPPageUrl] as? String
+        let referrer = payload?[kSPPageRefr] as? String
         XCTAssertEqual(url, "url")
         XCTAssertEqual(referrer, "referrer")
     }
@@ -132,20 +132,20 @@ class TestEvents: XCTestCase {
 
         var screenViewPayload: Payload? = nil
         for event in events {
-            if (event.payload.dictionary?["eid"] as? String) == screenViewId?.uuidString {
+            if (event.payload.dictionary["eid"] as? String) == screenViewId?.uuidString {
                 screenViewPayload = event.payload
             }
         }
         XCTAssertNotNil(screenViewPayload)
 
         // Check the DeepLink context entity properties
-        let screenViewContext = screenViewPayload?.dictionary?["co"] as? String
+        let screenViewContext = screenViewPayload?["co"] as? String
         XCTAssertTrue(screenViewContext?.contains("\"referrer\":\"the_referrer\"") ?? false)
         XCTAssertTrue(screenViewContext?.contains("\"url\":\"the_url\"") ?? false)
 
         // Check url and referrer fields for atomic table
-        let url = screenViewPayload?.dictionary?[kSPPageUrl] as? String
-        let referrer = screenViewPayload?.dictionary?[kSPPageRefr] as? String
+        let url = screenViewPayload?[kSPPageUrl] as? String
+        let referrer = screenViewPayload?[kSPPageRefr] as? String
         XCTAssertEqual(url, "the_url")
         XCTAssertEqual(referrer, "the_referrer")
     }
@@ -162,15 +162,15 @@ class TestEvents: XCTestCase {
     }
 
     func testUnstructured() {
-        var data: [String : NSObject] = [:]
-        data["level"] = NSNumber(value: 23)
-        data["score"] = NSNumber(value: 56473)
+        var data: [String : Any] = [:]
+        data["level"] = 23
+        data["score"] = 56473
         let sdj = SelfDescribingJson(
             schema: "iglu:com.acme_company/demo_ios_event/jsonschema/1-0-0",
             andDictionary: data)
         let event = SelfDescribing(eventData: sdj)
         XCTAssertEqual("iglu:com.acme_company/demo_ios_event/jsonschema/1-0-0", event.schema)
-        XCTAssertEqual(NSNumber(value: 23), event.payload["level"])
+        XCTAssertEqual(23, event.payload["level"] as? Int)
     }
 
     func testConsentWithdrawn() {
@@ -180,7 +180,7 @@ class TestEvents: XCTestCase {
         event.version = "3"
         event.documentId = "1000"
         event.documentDescription = "description"
-        XCTAssertEqual(NSNumber(value: false), event.payload["all"])
+        XCTAssertEqual(false, event.payload["all"] as? Bool)
         XCTAssertEqual(1, event.allDocuments.count)
     }
 
@@ -239,7 +239,7 @@ class TestEvents: XCTestCase {
         event.subtitle = "subtitle"
         event.sound = "sound"
         event.launchImageName = "image"
-        event.userInfo = userInfo as [String : NSObject]
+        event.userInfo = userInfo
         event.attachments = attachments as [NSObject]
         XCTAssertEqual("sound", event.payload["sound"] as? String)
     }
@@ -271,7 +271,7 @@ class TestEvents: XCTestCase {
         content.subtitle = "subtitle"
         content.sound = "sound"
         content.launchImageName = "image"
-        content.userInfo = userInfo as [String : NSObject]
+        content.userInfo = userInfo
         content.attachments = attachments as [NSObject]
 
         let event = PushNotification(
@@ -313,10 +313,10 @@ class TestEvents: XCTestCase {
         XCTAssertEqual("chime.mp3", payload["sound"] as? String)
         //    XCTAssertEqualObjects(@9, payload["notificationCount"]);
         XCTAssertEqual("category1", payload["category"] as? String)
-        let attachments = (payload["attachments"]) as? [[String : NSObject]]
+        let attachments = (payload["attachments"]) as? [[String : Any]]
         XCTAssertNotNil(attachments)
         XCTAssertEqual(1, (attachments?.count ?? 0))
-        let attachment = attachments?[0] as? [String : NSObject]
+        let attachment = attachments?[0] as? [String : Any]
         XCTAssertEqual("id", attachment?["identifier"] as? String)
         XCTAssertEqual("type", attachment?["type"] as? String)
         XCTAssertEqual("url", attachment?["url"] as? String)
@@ -332,13 +332,13 @@ class TestEvents: XCTestCase {
                     "loc-args": ["loc arg1", "loc arg2"]
                 ],
                 "sound": "chime.aiff",
-                "badge": NSNumber(value: 9),
+                "badge": 9,
                 "category": "category1",
-                "content-available": NSNumber(value: 1)
+                "content-available": 1
             ],
-            "custom-element": NSNumber(value: 1)
+            "custom-element": 1
         ]
-        let event = MessageNotification.messageNotification(userInfo: userInfo as! [String : NSObject], defaultTitle: nil, defaultBody: nil)!
+        let event = MessageNotification.messageNotification(userInfo: userInfo, defaultTitle: nil, defaultBody: nil)!
         let payload = event.payload
         XCTAssertEqual("test-title", payload["title"] as? String)
         XCTAssertEqual("test-body", payload["body"] as? String)
@@ -347,10 +347,10 @@ class TestEvents: XCTestCase {
         XCTAssertEqual(2, (locArgs?.count ?? 0))
         XCTAssertEqual("loc arg1", locArgs?[0] as? String)
         XCTAssertEqual("loc arg2", locArgs?[1] as? String)
-        XCTAssertEqual(NSNumber(value: 9), payload["notificationCount"])
+        XCTAssertEqual(9, payload["notificationCount"] as? Int)
         XCTAssertEqual("chime.aiff", payload["sound"] as? String)
         XCTAssertEqual("category1", payload["category"] as? String)
-        XCTAssertEqual(NSNumber(value: true), payload["contentAvailable"])
+        XCTAssertEqual(true, payload["contentAvailable"] as? Bool)
     }
 
     func testError() {

--- a/Tests/TestLifecycleState.swift
+++ b/Tests/TestLifecycleState.swift
@@ -49,7 +49,7 @@ class TestLifecycleState: XCTestCase {
         }
         var payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        var entities = (payload?.dictionary?["co"]) as? String
+        var entities = (payload?["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains("\"isVisible\":true"))
 
@@ -60,7 +60,7 @@ class TestLifecycleState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains("\"isVisible\":false"))
 
@@ -71,7 +71,7 @@ class TestLifecycleState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?["co"]) as? String
         XCTAssertTrue(entities!.contains("\"isVisible\":false"))
 
         _ = tracker.track(Foreground(index: 1))
@@ -81,7 +81,7 @@ class TestLifecycleState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains("\"isVisible\":true"))
 
@@ -93,7 +93,7 @@ class TestLifecycleState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains("\"isVisible\":true"))
     }

--- a/Tests/TestMemoryEventStore.swift
+++ b/Tests/TestMemoryEventStore.swift
@@ -44,7 +44,8 @@ class TestMemoryEventStore: XCTestCase {
 
         XCTAssertEqual(eventStore.count(), 1)
         let events = eventStore.emittableEvents(withQueryLimit: 1)
-        XCTAssertEqual(events[0].payload.dictionary, payload.dictionary)
+        XCTAssertEqual(events[0].payload.dictionary as! [String : String],
+                       payload.dictionary as! [String : String])
         _ = eventStore.removeEvent(withId: 0)
 
         XCTAssertEqual(eventStore.count(), 0)

--- a/Tests/TestNetworkConnection.swift
+++ b/Tests/TestNetworkConnection.swift
@@ -46,7 +46,7 @@ class TestNetworkConnection: XCTestCase {
         // Check successful result
         let result = results[0]
         XCTAssertTrue(result.isSuccessful)
-        XCTAssertEqual(NSNumber(value: 1), result.storeIds?[0])
+        XCTAssertEqual(1, result.storeIds?[0])
     }
     
     func testGetRequestWithNoSuccess() {
@@ -63,7 +63,7 @@ class TestNetworkConnection: XCTestCase {
         // Check unsuccessful result
         let result = results[0]
         XCTAssertFalse(result.isSuccessful)
-        XCTAssertEqual(NSNumber(value: 1), (result.storeIds)?[0])
+        XCTAssertEqual(1, (result.storeIds)?[0])
     }
     
     func testPostRequestWithSuccess() {
@@ -80,7 +80,7 @@ class TestNetworkConnection: XCTestCase {
         // Check successful result
         let result = results[0]
         XCTAssertTrue(result.isSuccessful)
-        XCTAssertEqual(NSNumber(value: 1), (result.storeIds)?[0])
+        XCTAssertEqual(1, (result.storeIds)?[0])
     }
     
     func testPostRequestWithNoSuccess() {
@@ -97,7 +97,7 @@ class TestNetworkConnection: XCTestCase {
         // Check unsuccessful result
         let result = results[0]
         XCTAssertFalse(result.isSuccessful)
-        XCTAssertEqual(NSNumber(value: 1), (result.storeIds)?[0])
+        XCTAssertEqual(1, (result.storeIds)?[0])
     }
 #endif
     
@@ -143,7 +143,7 @@ class TestNetworkConnection: XCTestCase {
         // Check successful result
         let result = results[0]
         XCTAssertTrue(result.isSuccessful)
-        XCTAssertEqual(NSNumber(value: 1), result.storeIds?[0])
+        XCTAssertEqual(1, result.storeIds?[0])
         wait(for: [requestExpectation], timeout: 2.0)
     }
 
@@ -168,7 +168,7 @@ class TestNetworkConnection: XCTestCase {
         // Check successful result
         let result = results[0]
         XCTAssertTrue(result.isSuccessful)
-        XCTAssertEqual(NSNumber(value: 1), result.storeIds?[0])
+        XCTAssertEqual(1, result.storeIds?[0])
         wait(for: [requestExpectation], timeout: 2.0)
     }
 
@@ -193,7 +193,7 @@ class TestNetworkConnection: XCTestCase {
         // Check successful result
         let result = results[0]
         XCTAssertTrue(result.isSuccessful)
-        XCTAssertEqual(NSNumber(value: 1), result.storeIds?[0])
+        XCTAssertEqual(1, result.storeIds?[0])
         wait(for: [requestExpectation], timeout: 2.0)
     }
 #endif

--- a/Tests/TestPayload.swift
+++ b/Tests/TestPayload.swift
@@ -34,182 +34,158 @@ class TestPayload: XCTestCase {
     func testInit() {
         let sample_payload = Payload()
 
-        XCTAssertEqual(
-            sample_payload.dictionary,
-            [String : NSObject]())
+        XCTAssertTrue(sample_payload.dictionary.isEmpty)
 
     }
 
     func testInitWithNSDictionary() {
-        let sample_dict: [String : NSObject] = [
-            "Key1": "Value1" as NSObject,
-            "Key2": "Value2" as NSObject
+        let sample_dict = [
+            "Key1": "Value1",
+            "Key2": "Value2"
         ]
         let sample_payload = Payload(dictionary: sample_dict)
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dict)
-        XCTAssertTrue(sample_payload.description.contains("\"Key1\": Value1"))
-        XCTAssertTrue(sample_payload.description.contains("\"Key2\": Value2"))
+        XCTAssertTrue(sample_payload.description.contains("\"Key1\": \"Value1\""))
+        XCTAssertTrue(sample_payload.description.contains("\"Key2\": \"Value2\""))
     }
 
     func testInitWithWrongDictionary() {
-        let sample_dict: [String : NSObject] = [
-            "Key1": "Value1" as NSObject,
-            "Key2": "Value2" as NSObject
+        let sample_dict = [
+            "Key1": "Value1",
+            "Key2": "Value2"
         ]
-        let sample_dict2: [String : NSObject] = [
-            "Key2": "Value1" as NSObject,
-            "Key1": "Value2" as NSObject
+        let sample_dict2 = [
+            "Key2": "Value1",
+            "Key1": "Value2"
         ]
         let sample_payload = Payload(dictionary: sample_dict)
 
         XCTAssertNotEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dict2,
             "Payload is not initialized with the correct JSON or NSDictionary")
     }
 
     func testAddValueToPayload() {
-        let sample_dict: [String : NSObject] = [
-            "Key1": "Value1" as NSObject
+        let sample_dict = [
+            "Key1": "Value1"
         ]
         let sample_payload = Payload()
         sample_payload.addValueToPayload("Value1", forKey: "Key1")
 
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dict)
     }
 
     func testAddValueToPayload2() {
-        let sample_dict: [String : NSObject] = [
-            "Key2": "Value2" as NSObject
+        let sample_dict = [
+            "Key2": "Value2"
         ]
         let sample_payload = Payload()
         sample_payload.addValueToPayload("Value1", forKey: "Key1")
 
 
         XCTAssertNotEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dict,
             "Payload should not be the same as sample_dict")
     }
 
     func testAddValueToPayload3() {
-        let sample_dict_init: [String : NSObject] = [
-            "Key1": "Value1" as NSObject
+        let sample_dict_init = [
+            "Key1": "Value1"
         ]
-        let sample_dict_final: [String : NSObject] = [
-            "Key1": "Value1" as NSObject,
-            "Key2": "Value2" as NSObject
+        let sample_dict_final = [
+            "Key1": "Value1",
+            "Key2": "Value2"
         ]
         let sample_payload = Payload(dictionary: sample_dict_init)
         sample_payload.addValueToPayload("Value2", forKey: "Key2")
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dict_final)
     }
 
     func testAddNilValueToPayload() {
         let payload = Payload()
         payload.addValueToPayload(nil, forKey: "foo")
-        XCTAssertEqual(payload.dictionary, [String : NSObject]())
+        XCTAssertTrue(payload.dictionary.isEmpty)
     }
 
     func testAddNilValueToPayloadUnsetsKey() {
         let payload = Payload(dictionary: [
-            "foo": "bar" as NSObject
+            "foo": "bar"
         ])
         payload.addValueToPayload(nil, forKey: "foo")
-        XCTAssertEqual(payload.dictionary, [String : NSObject]())
+        XCTAssertTrue(payload.dictionary.isEmpty)
     }
 
     func testAddNumericValueToPayload() {
         let sample_dict = [
-            "Key1": NSNumber(value: 100)
+            "Key1": 100
         ]
         let sample_payload = Payload()
-        sample_payload.addNumericValueToPayload(NSNumber(value: 100), forKey: "Key1")
+        sample_payload.addValueToPayload(100, forKey: "Key1")
 
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : AnyHashable],
             sample_dict)
-    }
-
-    func testAddNilNumericValueToPayload() {
-        let sample_payload = Payload()
-        sample_payload.addNumericValueToPayload(nil, forKey: "Key1")
-
-
-        XCTAssertEqual(
-            sample_payload.dictionary,
-            [String : NSObject]())
-    }
-
-    func testAddNilNumericValueToPayloadUnsetsKey() {
-        let sample_payload = Payload(dictionary: [
-            "Key1": NSNumber(value: 100)
-        ])
-        sample_payload.addNumericValueToPayload(nil, forKey: "Key1")
-
-
-        XCTAssertEqual(
-            sample_payload.dictionary,
-            [String : NSObject]())
     }
 
     func testAddDictToPayload() {
         let sample_dic = [
-            "Key1": "Value1" as NSObject
+            "Key1": "Value1"
         ]
         let sample_payload = Payload()
         sample_payload.addDictionaryToPayload(sample_dic)
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dic)
     }
 
     func testAddDictToPayload2() {
         let sample_dic = [
-            "Key1": "Value1" as NSObject
+            "Key1": "Value1"
         ]
         let sample_dic2 = [
-            "Key2": "Value2" as NSObject
+            "Key2": "Value2"
         ]
         let sample_dict_final = [
-            "Key1": "Value1" as NSObject,
-            "Key2": "Value2" as NSObject
+            "Key1": "Value1",
+            "Key2": "Value2"
         ]
         let sample_payload = Payload(dictionary: sample_dic)
         sample_payload.addDictionaryToPayload(sample_dic2)
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dict_final)
     }
 
     func testAddDictToPayload3() {
         let sample_dic = [
-            "Key1": "Value1" as NSObject
+            "Key1": "Value1"
         ]
         let sample_dic2 = [
-            "Key2": NSNumber(value: 2)
+            "Key2": 2
         ]
         let sample_dict_final = [
-            "Key1": "Value1" as NSObject
+            "Key1": "Value1"
         ]
 
         let sample_payload = Payload(dictionary: sample_dic)
         sample_payload.addDictionaryToPayload(sample_dic2)
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : AnyHashable],
             sample_dict_final)
     }
 
@@ -220,7 +196,7 @@ class TestPayload: XCTestCase {
             "Key1": "Value1"
         ]
         let sample_enc = [
-            "type_enc": "eyJLZXkxIjoiVmFsdWUxIn0" as NSObject
+            "type_enc": "eyJLZXkxIjoiVmFsdWUxIn0"
         ]
 
         // NSDictionary conversion to JSON string
@@ -234,7 +210,7 @@ class TestPayload: XCTestCase {
             typeWhenNotEncoded: "type_notenc")
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as? [String : String],
             sample_enc)
     }
 
@@ -245,7 +221,7 @@ class TestPayload: XCTestCase {
             "Key1": "Value1"
         ]
         let sample_enc = [
-            "type_notenc": "{\"Key1\":\"Value1\"}" as NSObject
+            "type_notenc": "{\"Key1\":\"Value1\"}"
         ]
 
         // NSDictionary conversion to JSON string
@@ -259,7 +235,7 @@ class TestPayload: XCTestCase {
             typeWhenNotEncoded: "type_notenc")
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_enc)
     }
 
@@ -267,7 +243,7 @@ class TestPayload: XCTestCase {
         // {"Key1":"Value1"} -> eyJLZXkxIjoiVmFsdWUxIn0=
 
         let sample_enc = [
-            "type_notenc": "{\"Key1\":\"Value1\"}" as NSObject
+            "type_notenc": "{\"Key1\":\"Value1\"}"
         ]
         let json_str = "{\"Key1\":\"Value1\"}"
 
@@ -279,7 +255,7 @@ class TestPayload: XCTestCase {
             typeWhenNotEncoded: "type_notenc")
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_enc)
     }
 
@@ -287,7 +263,7 @@ class TestPayload: XCTestCase {
         // {"Key1":"Value1"} -> eyJLZXkxIjoiVmFsdWUxIn0=
 
         let sample_enc = [
-            "type_enc": "eyJLZXkxIjoiVmFsdWUxIn0" as NSObject
+            "type_enc": "eyJLZXkxIjoiVmFsdWUxIn0"
         ]
         let json_str = "{\"Key1\":\"Value1\"}"
 
@@ -299,28 +275,26 @@ class TestPayload: XCTestCase {
             typeWhenNotEncoded: "type_notenc")
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_enc)
     }
 
     func testgetPayloadAsDictionary() {
         let sample_payload = Payload()
 
-        XCTAssertEqual(
-            sample_payload.dictionary,
-            [String : NSObject]())
+        XCTAssertTrue(sample_payload.dictionary.isEmpty)
     }
 
     func testgetPayloadAsDictionary2() {
         let sample_dict = [
-            "Key1": "Value1" as NSObject
+            "Key1": "Value1"
         ]
         let sample_payload = Payload(dictionary: [
-            "Key1": "Value1" as NSObject
+            "Key1": "Value1"
         ])
 
         XCTAssertEqual(
-            sample_payload.dictionary,
+            sample_payload.dictionary as! [String : String],
             sample_dict)
     }
 }

--- a/Tests/TestPlatformContext.swift
+++ b/Tests/TestPlatformContext.swift
@@ -42,20 +42,18 @@ class TestPlatformContext: XCTestCase {
         let deviceInfoMonitor = MockDeviceInfoMonitor()
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
         let idfa = UUID()
-        guard let platformDict = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: { idfa }).dictionary else {
-            return XCTFail()
-        }
-        XCTAssertEqual(idfa.uuidString as NSObject, platformDict[kSPMobileAppleIdfa])
-        XCTAssertEqual("appleIdfv" as NSObject, platformDict[kSPMobileAppleIdfv])
-        XCTAssertEqual("Apple Inc." as NSObject, platformDict[kSPPlatformDeviceManu])
-        XCTAssertEqual("deviceModel" as NSObject, platformDict[kSPPlatformDeviceModel])
-        XCTAssertEqual("13.0.0" as NSObject, platformDict[kSPPlatformOsVersion])
-        XCTAssertEqual("ios" as NSObject, platformDict[kSPPlatformOsType])
-        XCTAssertEqual("att" as NSObject, platformDict[kSPMobileCarrier])
-        XCTAssertEqual("3g" as NSObject, platformDict[kSPMobileNetworkTech])
-        XCTAssertEqual("wifi" as NSObject, platformDict[kSPMobileNetworkType])
-        XCTAssertEqual(NSNumber(value: 20), platformDict[kSPMobileBatteryLevel])
-        XCTAssertEqual("charging" as NSObject, platformDict[kSPMobileBatteryState])
+        let platformDict = context.fetchPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: { idfa })
+        XCTAssertEqual(idfa.uuidString, platformDict[kSPMobileAppleIdfa] as? String)
+        XCTAssertEqual("appleIdfv", platformDict[kSPMobileAppleIdfv] as? String)
+        XCTAssertEqual("Apple Inc.", platformDict[kSPPlatformDeviceManu] as? String)
+        XCTAssertEqual("deviceModel", platformDict[kSPPlatformDeviceModel] as? String)
+        XCTAssertEqual("13.0.0", platformDict[kSPPlatformOsVersion] as? String)
+        XCTAssertEqual("ios", platformDict[kSPPlatformOsType] as? String)
+        XCTAssertEqual("att", platformDict[kSPMobileCarrier] as? String)
+        XCTAssertEqual("3g", platformDict[kSPMobileNetworkTech] as? String)
+        XCTAssertEqual("wifi", platformDict[kSPMobileNetworkType] as? String)
+        XCTAssertEqual(20, platformDict[kSPMobileBatteryLevel] as? Int)
+        XCTAssertEqual("charging", platformDict[kSPMobileBatteryState] as? String)
     }
 
     func testUpdatesMobileInfo() {
@@ -144,22 +142,18 @@ class TestPlatformContext: XCTestCase {
         let deviceInfoMonitor = MockDeviceInfoMonitor()
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
         
-        guard let platformDict1 = context.fetchPlatformDict(
+        let platformDict1 = context.fetchPlatformDict(
             userAnonymisation: false,
             advertisingIdentifierRetriever: { nil }
-        ).dictionary else {
-            return XCTFail()
-        }
+        )
         XCTAssertNil(platformDict1[kSPMobileAppleIdfa])
         
         let idfa = UUID()
-        guard let platformDict2 = context.fetchPlatformDict(
+        let platformDict2 = context.fetchPlatformDict(
             userAnonymisation: false,
             advertisingIdentifierRetriever: { idfa }
-        ).dictionary else {
-            return XCTFail()
-        }
-        XCTAssertEqual(idfa.uuidString as NSObject, platformDict2[kSPMobileAppleIdfa])
+        )
+        XCTAssertEqual(idfa.uuidString, platformDict2[kSPMobileAppleIdfa] as? String)
     }
 
     func testDoesntUpdateIdfaIfAlreadyRetrieved() {
@@ -167,32 +161,26 @@ class TestPlatformContext: XCTestCase {
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
         
         let idfa1 = UUID()
-        guard let platformDict1 = context.fetchPlatformDict(
+        let platformDict1 = context.fetchPlatformDict(
             userAnonymisation: false,
             advertisingIdentifierRetriever: { idfa1 }
-        ).dictionary else {
-            return XCTFail()
-        }
-        XCTAssertEqual(idfa1.uuidString as NSObject, platformDict1[kSPMobileAppleIdfa])
+        )
+        XCTAssertEqual(idfa1.uuidString, platformDict1[kSPMobileAppleIdfa] as? String)
         
-        guard let platformDict2 = context.fetchPlatformDict(
+        let platformDict2 = context.fetchPlatformDict(
             userAnonymisation: false,
             advertisingIdentifierRetriever: { UUID() }
-        ).dictionary else {
-            return XCTFail()
-        }
-        XCTAssertEqual(idfa1.uuidString as NSObject, platformDict2[kSPMobileAppleIdfa])
+        )
+        XCTAssertEqual(idfa1.uuidString, platformDict2[kSPMobileAppleIdfa] as? String)
     }
 
     func testAnonymisesUserIdentifiers() {
         let deviceInfoMonitor = MockDeviceInfoMonitor()
         let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
-        guard let platformDict = context.fetchPlatformDict(
+        let platformDict = context.fetchPlatformDict(
             userAnonymisation: true,
             advertisingIdentifierRetriever: { UUID() }
-        ).dictionary else {
-            return XCTFail()
-        }
+        )
         XCTAssertNil(platformDict[kSPMobileAppleIdfa])
         XCTAssertNil(platformDict[kSPMobileAppleIdfv])
     }

--- a/Tests/TestRequest.swift
+++ b/Tests/TestRequest.swift
@@ -226,7 +226,7 @@ class TestRequest: XCTestCase, RequestCallback {
 
     func customContext() -> [SelfDescribingJson] {
         let data = [
-            "snowplow": "demo-tracker" as NSObject
+            "snowplow": "demo-tracker"
         ]
         let context = SelfDescribingJson(
             schema: "iglu:com.acme_company/demo_ios/jsonschema/1-0-0",

--- a/Tests/TestRequestResult.swift
+++ b/Tests/TestRequestResult.swift
@@ -33,8 +33,8 @@ class TestRequestResult: XCTestCase {
     }
 
     func testSuccessfulRequest() {
-        var emitterEventIds: [NSNumber]? = []
-        emitterEventIds?.append(NSNumber(value: 1))
+        var emitterEventIds: [Int64]? = []
+        emitterEventIds?.append(1)
         let result = RequestResult(statusCode: 200, oversize: false, storeIds: emitterEventIds)
 
         XCTAssertNotNil(result)
@@ -44,8 +44,8 @@ class TestRequestResult: XCTestCase {
     }
 
     func testFailedRequest() {
-        var emitterEventIds: [NSNumber]? = []
-        emitterEventIds?.append(NSNumber(value: 1))
+        var emitterEventIds: [Int64]? = []
+        emitterEventIds?.append(1)
         let result = RequestResult(statusCode: 500, oversize: false, storeIds: emitterEventIds)
         XCTAssertEqual(result.isSuccessful, false)
         XCTAssertEqual(result.shouldRetry([:]), true)

--- a/Tests/TestSQLiteEventStore.swift
+++ b/Tests/TestSQLiteEventStore.swift
@@ -49,7 +49,8 @@ class TestSQLiteEventStore: XCTestCase {
         _ = eventStore.insertEvent(payload)
 
         XCTAssertEqual(eventStore.count(), 1)
-        XCTAssertEqual(eventStore.getEventWithId(1)?.payload.dictionary, payload.dictionary)
+        XCTAssertEqual(eventStore.getEventWithId(1)?.payload.dictionary as! [String : String],
+                       payload.dictionary as! [String : String])
         XCTAssertEqual(eventStore.getLastInsertedRowId(), 1)
         _ = eventStore.removeEvent(withId: 1)
 
@@ -114,7 +115,7 @@ class TestSQLiteEventStore: XCTestCase {
     func testMigrationFromLegacyToNamespacedEventStore() {
         var eventStore = SQLiteEventStore(namespace: "aNamespace")
         eventStore.addEvent(Payload(dictionary: [
-            "key": "value" as NSObject
+            "key": "value"
         ]))
         XCTAssertEqual(1, eventStore.count())
 
@@ -136,20 +137,20 @@ class TestSQLiteEventStore: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: newDbPath))
         XCTAssertEqual(1, eventStore.count())
         for event in eventStore.getAllEvents() ?? [] {
-            XCTAssertEqual("value", event.payload.dictionary?["key"] as? String)
+            XCTAssertEqual("value", event.payload.dictionary["key"] as? String)
         }
     }
 
     func testMultipleAccessToSameSQLiteFile() {
         let eventStore1 = SQLiteEventStore(namespace: "aNamespace")
         eventStore1.addEvent(Payload(dictionary: [
-            "key1": "value1" as NSObject
+            "key1": "value1"
         ]))
         XCTAssertEqual(1, eventStore1.count())
 
         let eventStore2 = SQLiteEventStore(namespace: "aNamespace")
         eventStore2.addEvent(Payload(dictionary: [
-            "key2": "value2" as NSObject
+            "key2": "value2"
         ]))
         XCTAssertEqual(2, eventStore2.count())
     }

--- a/Tests/TestScreenState.swift
+++ b/Tests/TestScreenState.swift
@@ -85,7 +85,7 @@ class TestScreenState: XCTestCase {
         }
         var payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        var entities = (payload?.dictionary?["co"]) as? String
+        var entities = (payload?.dictionary["co"]) as? String
         XCTAssertNil(entities)
 
         let uuid = UUID()
@@ -96,7 +96,7 @@ class TestScreenState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?.dictionary["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains(uuid.uuidString))
 
@@ -107,7 +107,7 @@ class TestScreenState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?.dictionary["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains(uuid.uuidString))
 
@@ -119,10 +119,10 @@ class TestScreenState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?.dictionary["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains(uuid2.uuidString))
-        let eventPayload = (payload?.dictionary?["ue_pr"]) as? String
+        let eventPayload = (payload?.dictionary["ue_pr"]) as? String
         XCTAssertNotNil(eventPayload)
         XCTAssertTrue(eventPayload!.contains(uuid.uuidString))
         XCTAssertTrue(eventPayload!.contains(uuid2.uuidString))
@@ -134,7 +134,7 @@ class TestScreenState: XCTestCase {
         }
         payload = eventStore.db[Int64(eventStore.lastInsertedRow)]
         _ = eventStore.removeAllEvents()
-        entities = (payload?.dictionary?["co"]) as? String
+        entities = (payload?.dictionary["co"]) as? String
         XCTAssertNotNil(entities)
         XCTAssertTrue(entities!.contains(uuid2.uuidString))
     }

--- a/Tests/TestSelfDescribingJson.swift
+++ b/Tests/TestSelfDescribingJson.swift
@@ -32,45 +32,47 @@ class TestSelfDescribingJson: XCTestCase {
     }
 
     func testInitWithObject() {
-        let expected = [
-            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0" as NSObject,
+        let expected: [String : Any] = [
+            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0",
             "data": [
                 "hello": "world"
-            ] as NSObject
+            ]
         ]
         let data = [
-            "hello": "world" as NSObject
+            "hello": "world"
         ]
         let sdj = SelfDescribingJson(
             schema: "iglu:acme.com/test_event/jsonschema/1-0-0",
             andDictionary: data)
-        XCTAssertEqual(expected, sdj.dictionary)
+        XCTAssertEqual(NSDictionary(dictionary: expected),
+                       NSDictionary(dictionary: sdj.dictionary))
     }
 
     func testInitWithSPPayload() {
-        let expected = [
-            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0" as NSObject,
+        let expected: [String : Any] = [
+            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0",
             "data": [
                 "hello": "world"
-            ] as NSObject
+            ]
         ]
         let data = Payload()
         data.addValueToPayload("world", forKey: "hello")
         let sdj = SelfDescribingJson(
             schema: "iglu:acme.com/test_event/jsonschema/1-0-0",
             andPayload: data)
-        XCTAssertEqual(expected, sdj.dictionary)
+        XCTAssertEqual(NSDictionary(dictionary: expected),
+                       NSDictionary(dictionary: sdj.dictionary))
     }
 
     func testInitWithSPSelfDescribingJson() {
-        let expected = [
-            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0" as NSObject,
+        let expected: [String : Any] = [
+            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0",
             "data": [
                 "schema": "iglu:acme.com/nested_event/jsonschema/1-0-0",
                 "data": [
                     "hello": "world"
                 ]
-            ] as NSObject
+            ]
         ]
         let nestedData = [
             "hello": "world"
@@ -81,15 +83,16 @@ class TestSelfDescribingJson: XCTestCase {
         let sdj = SelfDescribingJson(
             schema: "iglu:acme.com/test_event/jsonschema/1-0-0",
             andSelfDescribingJson: data)
-        XCTAssertEqual(expected, sdj.dictionary)
+        XCTAssertEqual(NSDictionary(dictionary: expected),
+                       NSDictionary(dictionary: sdj.dictionary))
     }
 
     func testUpdateSchema() {
-        let expected = [
-            "schema": "iglu:acme.com/test_event_2/jsonschema/1-0-0" as NSObject,
+        let expected: [String : Any] = [
+            "schema": "iglu:acme.com/test_event_2/jsonschema/1-0-0",
             "data": [
                 "hello": "world"
-            ] as NSObject
+            ]
         ]
         let data = [
             "hello": "world"
@@ -98,33 +101,35 @@ class TestSelfDescribingJson: XCTestCase {
             schema: "iglu:acme.com/test_event/jsonschema/1-0-0",
             andDictionary: data)
         sdj.schema = "iglu:acme.com/test_event_2/jsonschema/1-0-0"
-        XCTAssertEqual(expected, sdj.dictionary)
+        XCTAssertEqual(NSDictionary(dictionary: expected),
+                       NSDictionary(dictionary: sdj.dictionary))
     }
-    
+
     func testUpdateDataWithObject() {
-        let expected = [
-            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0" as NSObject,
+        let expected: [String : Any] = [
+            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0",
             "data": [
                 "world": "hello"
-            ] as NSObject
+            ]
         ]
         let sdj = SelfDescribingJson(
             schema: "iglu:acme.com/test_event/jsonschema/1-0-0",
             andDictionary: [
                 "hello": "world"
             ])
-        sdj.setData(withObject: [
+        sdj.data = [
             "world": "hello"
-        ] as NSObject)
-        XCTAssertEqual(expected, sdj.dictionary)
+        ]
+        XCTAssertEqual(NSDictionary(dictionary: expected),
+                       NSDictionary(dictionary: sdj.dictionary))
     }
-    
+
     func testUpdateDataWithSPPayload() {
-        let expected = [
-            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0" as NSObject,
+        let expected: [String : Any] = [
+            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0",
             "data": [
                 "world": "hello"
-            ] as NSObject
+            ]
         ]
         let data = Payload()
         data.addValueToPayload("hello", forKey: "world")
@@ -134,18 +139,19 @@ class TestSelfDescribingJson: XCTestCase {
                 "hello": "world"
             ])
         sdj.setData(withPayload: data)
-        XCTAssertEqual(expected, sdj.dictionary)
+        XCTAssertEqual(NSDictionary(dictionary: expected),
+                       NSDictionary(dictionary: sdj.dictionary))
     }
 
     func testUpdateDataWithSPSelfDescribingJson() {
-        let expected = [
-            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0" as NSObject,
+        let expected: [String : Any] = [
+            "schema": "iglu:acme.com/test_event/jsonschema/1-0-0",
             "data": [
                 "schema": "iglu:acme.com/nested_event/jsonschema/1-0-0",
                 "data": [
                     "hello": "world"
                 ]
-            ] as NSObject
+            ]
         ]
         let nestedData = [
             "hello": "world"
@@ -159,7 +165,8 @@ class TestSelfDescribingJson: XCTestCase {
                 "hello": "world"
             ])
         sdj.setData(withSelfDescribingJson: data)
-        XCTAssertEqual(expected, sdj.dictionary)
+        XCTAssertEqual(NSDictionary(dictionary: expected),
+                       NSDictionary(dictionary: sdj.dictionary))
     }
 }
 

--- a/Tests/TestServiceProvider.swift
+++ b/Tests/TestServiceProvider.swift
@@ -51,7 +51,7 @@ class TestServiceProvider: XCTestCase {
         serviceProvider.emitterController.pause()
 
         // refresh configuration
-        serviceProvider.reset(withConfigurations: [EmitterConfigurationUpdate()])
+        serviceProvider.reset(configurations: [EmitterConfigurationUpdate()])
 
         // track event and check that emitter is paused
         _ = serviceProvider.trackerController.track(Structured(category: "cat", action: "act"))

--- a/Tests/TestSession.swift
+++ b/Tests/TestSession.swift
@@ -72,9 +72,9 @@ class TestSession: XCTestCase {
         let sessionContext = session.getDictWithEventId("event_1", eventTimestamp: 1654496481346, userAnonymisation: false)
         let sessionIndex = session.state!.sessionIndex
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual("event_1" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.346Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.346Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
     }
 
     func testForegroundEventsOnSameSession() {
@@ -82,41 +82,41 @@ class TestSession: XCTestCase {
 
         var sessionContext = session.getDictWithEventId("event_1", eventTimestamp: 1654496481346, userAnonymisation: false)
         var sessionIndex = session.state?.sessionIndex
-        let sessionId = sessionContext?[kSPSessionId]
+        let sessionId = sessionContext?[kSPSessionId] as? String
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual("event_1" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.346Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.346Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
 
         Thread.sleep(forTimeInterval: 1)
 
         sessionContext = session.getDictWithEventId("event_2", eventTimestamp: 1654496481347, userAnonymisation: false)
         sessionIndex = session.state?.sessionIndex
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual("event_1" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.346Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
-        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.346Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
+        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId] as? String)
 
         Thread.sleep(forTimeInterval: 1)
 
         sessionContext = session.getDictWithEventId("event_3", eventTimestamp: 1654496481348, userAnonymisation: false)
         sessionIndex = session.state?.sessionIndex
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual("event_1" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.346Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
-        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.346Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
+        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId] as? String)
 
         Thread.sleep(forTimeInterval: 3.1)
 
         sessionContext = session.getDictWithEventId("event_4", eventTimestamp: 1654496481349, userAnonymisation: false)
         sessionIndex = session.state?.sessionIndex
         XCTAssertEqual(2, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual("event_4" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.349Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
-        XCTAssertNotEqual(sessionId, sessionContext?[kSPSessionId])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_4", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.349Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
+        XCTAssertNotEqual(sessionId, sessionContext?[kSPSessionId] as? String)
     }
 
     func testBackgroundEventsOnWhenLifecycleEventsDisabled() {
@@ -136,9 +136,9 @@ class TestSession: XCTestCase {
         let sessionContext = session?.getDictWithEventId("event_1", eventTimestamp: 1654496481346, userAnonymisation: false)
         let sessionIndex = session?.state?.sessionIndex ?? 0
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue ?? 0)
-        XCTAssertEqual("event_1" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.346Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.346Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
         XCTAssertFalse(session!.inBackground)
         XCTAssertEqual(0, session?.backgroundIndex)
     }
@@ -158,13 +158,13 @@ class TestSession: XCTestCase {
 
         session?.updateInBackground() // It sends a background event
 
-        let sessionId = session?.state?.sessionId as? NSString
+        let sessionId = session?.state?.sessionId
 
         var sessionContext = session?.getDictWithEventId("event_1", eventTimestamp: 1654496481346, userAnonymisation: false)
         var sessionIndex = session?.state?.sessionIndex ?? 0
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue ?? 0)
-        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId] as? String)
         XCTAssertTrue(session!.inBackground)
         XCTAssertEqual(1, session?.backgroundIndex)
 
@@ -173,8 +173,8 @@ class TestSession: XCTestCase {
         sessionContext = session?.getDictWithEventId("event_2", eventTimestamp: 1654496481347, userAnonymisation: false)
         sessionIndex = session?.state?.sessionIndex ?? 0
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue ?? 0)
-        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId] as? String)
         XCTAssertTrue(session!.inBackground)
         XCTAssertEqual(1, session?.backgroundIndex)
 
@@ -183,8 +183,8 @@ class TestSession: XCTestCase {
         sessionContext = session?.getDictWithEventId("event_3", eventTimestamp: 1654496481348, userAnonymisation: false)
         sessionIndex = session?.state?.sessionIndex ?? 0
         XCTAssertEqual(1, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue ?? 0)
-        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual(sessionId, sessionContext?[kSPSessionId] as? String)
         XCTAssertTrue(session!.inBackground)
         XCTAssertEqual(1, session?.backgroundIndex)
 
@@ -193,10 +193,10 @@ class TestSession: XCTestCase {
         sessionContext = session?.getDictWithEventId("event_4", eventTimestamp: 1654496481349, userAnonymisation: false)
         sessionIndex = session?.state?.sessionIndex ?? 0
         XCTAssertEqual(2, sessionIndex)
-        XCTAssertEqual(sessionIndex, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue ?? 0)
-        XCTAssertEqual("event_4" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.349Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
-        XCTAssertNotEqual(sessionId, sessionContext?[kSPSessionId])
+        XCTAssertEqual(sessionIndex, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_4", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.349Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
+        XCTAssertNotEqual(sessionId, sessionContext?[kSPSessionId] as? String)
         XCTAssertTrue(session!.inBackground)
         XCTAssertEqual(1, session?.backgroundIndex)
     }
@@ -214,44 +214,44 @@ class TestSession: XCTestCase {
         let session = tracker.session
 
         var sessionContext = session?.getDictWithEventId("event_1", eventTimestamp: 1654496481351, userAnonymisation: false)
-        XCTAssertEqual("event_1" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.351Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.351Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
         XCTAssertFalse(session!.inBackground)
         XCTAssertEqual(0, session?.backgroundIndex)
         XCTAssertEqual(0, session?.foregroundIndex)
-        var oldSessionId = sessionContext?[kSPSessionId]
+        var oldSessionId = sessionContext?[kSPSessionId] as? String
 
         session?.updateInBackground()
         Thread.sleep(forTimeInterval: 1.1)
 
         sessionContext = session?.getDictWithEventId("event_2", eventTimestamp: 1654496481352, userAnonymisation: false)
-        XCTAssertEqual(oldSessionId, sessionContext?[kSPSessionPreviousId])
-        XCTAssertEqual("event_2" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.352Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual(oldSessionId, sessionContext?[kSPSessionPreviousId] as? String)
+        XCTAssertEqual("event_2", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.352Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
         XCTAssertTrue(session!.inBackground)
         XCTAssertEqual(1, session?.backgroundIndex)
         XCTAssertEqual(0, session?.foregroundIndex)
-        oldSessionId = sessionContext?[kSPSessionId]
+        oldSessionId = sessionContext?[kSPSessionId] as? String
 
         session?.updateInForeground()
         Thread.sleep(forTimeInterval: 1.1)
 
         sessionContext = session?.getDictWithEventId("event_3", eventTimestamp: 1654496481353, userAnonymisation: false)
-        XCTAssertEqual(oldSessionId, sessionContext?[kSPSessionPreviousId])
-        XCTAssertEqual("event_3" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.353Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual(oldSessionId, sessionContext?[kSPSessionPreviousId] as? String)
+        XCTAssertEqual("event_3", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.353Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
         XCTAssertFalse(session!.inBackground)
         XCTAssertEqual(1, session?.backgroundIndex)
         XCTAssertEqual(1, session?.foregroundIndex)
-        oldSessionId = sessionContext?[kSPSessionId]
+        oldSessionId = sessionContext?[kSPSessionId] as? String
 
         session?.updateInBackground()
         Thread.sleep(forTimeInterval: 1.1)
 
         sessionContext = session?.getDictWithEventId("event_4", eventTimestamp: 1654496481354, userAnonymisation: false)
-        XCTAssertEqual(oldSessionId, sessionContext?[kSPSessionPreviousId])
-        XCTAssertEqual("event_4" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.354Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual(oldSessionId, sessionContext?[kSPSessionPreviousId] as? String)
+        XCTAssertEqual("event_4", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.354Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
         XCTAssertTrue(session!.inBackground)
         XCTAssertEqual(2, session?.backgroundIndex)
         XCTAssertEqual(1, session?.foregroundIndex)
@@ -261,27 +261,27 @@ class TestSession: XCTestCase {
         let session = Session(foregroundTimeout: 1, andBackgroundTimeout: 1, andTracker: nil)
 
         var sessionContext = session.getDictWithEventId("event_1", eventTimestamp: 1654496481355, userAnonymisation: false)
-        var prevSessionId = sessionContext?[kSPSessionId]
-        XCTAssertEqual("event_1" as NSString, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.355Z" as NSString, sessionContext?[kSPSessionFirstEventTimestamp])
+        var prevSessionId = sessionContext?[kSPSessionId] as? String
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.355Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
 
         session.stopChecker()
         Thread.sleep(forTimeInterval: 2)
 
         sessionContext = session.getDictWithEventId("event_2", eventTimestamp: 1654496481356, userAnonymisation: false)
-        XCTAssertEqual(1, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual(prevSessionId, sessionContext?[kSPSessionId])
-        XCTAssertEqual("event_1" as NSObject, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.355Z" as NSObject, sessionContext?[kSPSessionFirstEventTimestamp])
-        prevSessionId = sessionContext?[kSPSessionId]
+        XCTAssertEqual(1, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual(prevSessionId, sessionContext?[kSPSessionId] as? String)
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.355Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
+        prevSessionId = sessionContext?[kSPSessionId] as? String
 
         session.startChecker()
 
         sessionContext = session.getDictWithEventId("event_3", eventTimestamp: 1654496481357, userAnonymisation: false)
-        XCTAssertEqual(2, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual(prevSessionId, sessionContext?[kSPSessionPreviousId])
-        XCTAssertEqual("event_3" as NSObject, sessionContext?[kSPSessionFirstEventId])
-        XCTAssertEqual("2022-06-06T06:21:21.357Z" as NSObject, sessionContext?[kSPSessionFirstEventTimestamp])
+        XCTAssertEqual(2, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual(prevSessionId, sessionContext?[kSPSessionPreviousId] as? String)
+        XCTAssertEqual("event_3", sessionContext?[kSPSessionFirstEventId] as? String)
+        XCTAssertEqual("2022-06-06T06:21:21.357Z", sessionContext?[kSPSessionFirstEventTimestamp] as? String)
     }
 
     func testBackgroundTimeBiggerThanBackgroundTimeoutCausesNewSession() {
@@ -297,7 +297,7 @@ class TestSession: XCTestCase {
         let session = tracker.session
 
         let sessionContext = session?.getDictWithEventId("event_1", eventTimestamp: 1654496481361, userAnonymisation: false)
-        XCTAssertEqual("event_1" as NSObject, sessionContext?[kSPSessionFirstEventId])
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
         XCTAssertFalse(session!.inBackground)
         XCTAssertEqual(0, session?.backgroundIndex)
         XCTAssertEqual(0, session?.foregroundIndex)
@@ -328,7 +328,7 @@ class TestSession: XCTestCase {
         let session = tracker.session
 
         let sessionContext = session?.getDictWithEventId("event_1", eventTimestamp: 1654496481358, userAnonymisation: false)
-        XCTAssertEqual("event_1" as NSObject, sessionContext?[kSPSessionFirstEventId])
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
         XCTAssertFalse(session!.inBackground)
         XCTAssertEqual(0, session?.backgroundIndex)
         XCTAssertEqual(0, session?.foregroundIndex)
@@ -350,13 +350,13 @@ class TestSession: XCTestCase {
         let session = Session(foregroundTimeout: 1, andBackgroundTimeout: 1, andTracker: nil)
 
         var sessionContext = session.getDictWithEventId("event_1", eventTimestamp: 1654496481359, userAnonymisation: false)
-        XCTAssertEqual("event_1" as NSObject, sessionContext?[kSPSessionFirstEventId])
+        XCTAssertEqual("event_1", sessionContext?[kSPSessionFirstEventId] as? String)
 
         Thread.sleep(forTimeInterval: 4)
 
         sessionContext = session.getDictWithEventId("event_2", eventTimestamp: 1654496481360, userAnonymisation: false)
-        XCTAssertEqual(2, (sessionContext?[kSPSessionIndex] as? NSNumber)?.intValue)
-        XCTAssertEqual("event_2" as NSObject, sessionContext?[kSPSessionFirstEventId])
+        XCTAssertEqual(2, sessionContext?[kSPSessionIndex] as? Int)
+        XCTAssertEqual("event_2", sessionContext?[kSPSessionFirstEventId] as? String)
     }
 
     func testMultipleTrackersUpdateDifferentSessions() {
@@ -434,22 +434,22 @@ class TestSession: XCTestCase {
         let session = Session(foregroundTimeout: 3, andBackgroundTimeout: 3, andTracker: nil)
 
         var sessionContext = session.getDictWithEventId("event_1", eventTimestamp: 1654496481346, userAnonymisation: false)
-        XCTAssertEqual(NSNumber(value: 1), sessionContext?[kSPSessionEventIndex])
+        XCTAssertEqual(1, sessionContext?[kSPSessionEventIndex] as? Int)
 
         Thread.sleep(forTimeInterval: 1)
 
         sessionContext = session.getDictWithEventId("event_2", eventTimestamp: 1654496481347, userAnonymisation: false)
-        XCTAssertEqual(NSNumber(value: 2), sessionContext?[kSPSessionEventIndex])
+        XCTAssertEqual(2, sessionContext?[kSPSessionEventIndex] as? Int)
 
         Thread.sleep(forTimeInterval: 1)
 
         sessionContext = session.getDictWithEventId("event_3", eventTimestamp: 1654496481348, userAnonymisation: false)
-        XCTAssertEqual(NSNumber(value: 3), sessionContext?[kSPSessionEventIndex])
+        XCTAssertEqual(3, sessionContext?[kSPSessionEventIndex] as? Int)
 
         Thread.sleep(forTimeInterval: 3.1)
 
         sessionContext = session.getDictWithEventId("event_4", eventTimestamp: 1654496481349, userAnonymisation: false)
-        XCTAssertEqual(NSNumber(value: 1), sessionContext?[kSPSessionEventIndex])
+        XCTAssertEqual(1, sessionContext?[kSPSessionEventIndex] as? Int)
     }
 
     func testAnonymisesUserIdentifiers() {
@@ -458,11 +458,11 @@ class TestSession: XCTestCase {
         session.startNewSession() // create previous session ID reference
 
         let withoutAnonymisation = session.getDictWithEventId("event_2", eventTimestamp: 1654496481346, userAnonymisation: false)
-        XCTAssertNotEqual("00000000-0000-0000-0000-000000000000" as NSObject, withoutAnonymisation?[kSPSessionUserId])
+        XCTAssertNotEqual("00000000-0000-0000-0000-000000000000", withoutAnonymisation?[kSPSessionUserId] as? String)
         XCTAssertNotNil(withoutAnonymisation?[kSPSessionPreviousId])
 
         let withAnonymisation = session.getDictWithEventId("event_3", eventTimestamp: 1654496481347, userAnonymisation: true)
-        XCTAssertEqual("00000000-0000-0000-0000-000000000000" as NSObject, withAnonymisation?[kSPSessionUserId])
+        XCTAssertEqual("00000000-0000-0000-0000-000000000000", withAnonymisation?[kSPSessionUserId] as? String)
         XCTAssertNil(withAnonymisation?[kSPSessionPreviousId])
     }
 
@@ -476,10 +476,10 @@ class TestSession: XCTestCase {
 
     func storeAsV3_0(withNamespace namespace: String, eventId: String?, sessionId: String?, sessionIndex: Int, userId: String?) {
         let dataPersistence = DataPersistence.getFor(namespace: namespace)
-        var newSessionDict: [String : NSObject] = [:]
-        newSessionDict[kSPSessionFirstEventId] = eventId as? NSObject
-        newSessionDict[kSPSessionId] = sessionId as? NSObject
-        newSessionDict[kSPSessionIndex] = NSNumber(value: sessionIndex)
+        var newSessionDict: [String : Any] = [:]
+        newSessionDict[kSPSessionFirstEventId] = eventId
+        newSessionDict[kSPSessionId] = sessionId
+        newSessionDict[kSPSessionIndex] = sessionIndex
         dataPersistence?.session = newSessionDict
 
         //Store userId

--- a/Tests/TestStateManager.swift
+++ b/Tests/TestStateManager.swift
@@ -66,7 +66,7 @@ class MockStateMachine: StateMachineProtocol {
     func entities(from event: InspectableEvent, state: State?) -> [SelfDescribingJson]? {
         let mockState = state as? MockState
         let sdj = SelfDescribingJson(schema: "entity", andDictionary: [
-            "value": NSNumber(value: mockState?.value ?? 0)
+            "value": mockState?.value ?? 0
         ])
         return [sdj]
     }
@@ -75,9 +75,9 @@ class MockStateMachine: StateMachineProtocol {
         return ["event"]
     }
 
-    func payloadValues(from event: InspectableEvent, state: State?) -> [String : NSObject]? {
+    func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]? {
         return [
-            "newParam": "value" as NSObject
+            "newParam": "value"
         ]
     }
 }
@@ -103,13 +103,13 @@ class TestStateManager: XCTestCase {
         stateManager.addOrReplaceStateMachine(MockStateMachine())
 
         let eventInc = SelfDescribing(schema: "inc", payload: [
-            "value": NSNumber(value: 1)
+            "value": 1
         ])
         let eventDec = SelfDescribing(schema: "dec", payload: [
-            "value": NSNumber(value: 2)
+            "value": 2
         ])
         let event = SelfDescribing(schema: "event", payload: [
-            "value": NSNumber(value: 3)
+            "value": 3
         ])
 
         var trackerState = stateManager.trackerState(forProcessedEvent: eventInc)
@@ -117,7 +117,7 @@ class TestStateManager: XCTestCase {
         XCTAssertEqual(1, mockState?.value)
         var e = TrackerEvent(event: eventInc, state: trackerState)
         var entities = stateManager.entities(forProcessedEvent: e)
-        XCTAssertEqual(NSNumber(value: 1), ((entities[0].data) as? [String : NSNumber])?["value"])
+        XCTAssertEqual(1, ((entities[0].data) as? [String : Int])?["value"])
         XCTAssertTrue(stateManager.addPayloadValues(to: e))
         XCTAssertNil((e.payload)["newParam"])
 
@@ -125,7 +125,7 @@ class TestStateManager: XCTestCase {
         XCTAssertEqual(2, (trackerState?.state(withStateMachine: stateMachine) as? MockState)?.value)
         e = TrackerEvent(event: eventInc, state: trackerState)
         entities = stateManager.entities(forProcessedEvent: e)
-        XCTAssertEqual(NSNumber(value: 2), ((entities[0].data) as? [String : NSNumber])?["value"])
+        XCTAssertEqual(2, ((entities[0].data) as? [String : Int])?["value"])
         XCTAssertTrue(stateManager.addPayloadValues(to: e))
         XCTAssertNil((e.payload)["newParam"])
 
@@ -133,7 +133,7 @@ class TestStateManager: XCTestCase {
         XCTAssertEqual(1, (trackerState?.state(withStateMachine: stateMachine) as? MockState)?.value)
         e = TrackerEvent(event: eventDec, state: trackerState)
         entities = stateManager.entities(forProcessedEvent: e)
-        XCTAssertEqual(NSNumber(value: 1), ((entities[0].data) as? [String : NSNumber])?["value"])
+        XCTAssertEqual(1, ((entities[0].data) as? [String : Int])?["value"])
         XCTAssertTrue(stateManager.addPayloadValues(to: e))
         XCTAssertNil((e.payload)["newParam"])
 
@@ -141,9 +141,9 @@ class TestStateManager: XCTestCase {
         XCTAssertEqual(1, (trackerState?.state(withStateMachine: stateMachine) as? MockState)?.value)
         e = TrackerEvent(event: event, state: trackerState)
         entities = stateManager.entities(forProcessedEvent: e)
-        XCTAssertEqual(NSNumber(value: 1), ((entities[0].data) as? [String : NSNumber])?["value"])
+        XCTAssertEqual(1, ((entities[0].data) as? [String : Int])?["value"])
         XCTAssertTrue(stateManager.addPayloadValues(to: e))
-        XCTAssertEqual("value" as NSObject, (e.payload)["newParam"])
+        XCTAssertEqual("value", (e.payload)["newParam"] as? String)
     }
 
     func testAddRemoveStateMachine() {
@@ -153,7 +153,7 @@ class TestStateManager: XCTestCase {
         _ = stateManager.removeStateMachine("identifier")
 
         let eventInc = SelfDescribing(schema: "inc", payload: [
-            "value": NSNumber(value: 1)
+            "value": 1
         ])
 
         let trackerState = stateManager.trackerState(forProcessedEvent: eventInc)
@@ -170,7 +170,7 @@ class TestStateManager: XCTestCase {
         stateManager.addOrReplaceStateMachine(MockStateMachine2())
 
         let eventInc = SelfDescribing(schema: "inc", payload: [
-            "value": NSNumber(value: 1)
+            "value": 1
         ])
 
         let trackerState = stateManager.trackerState(forProcessedEvent: eventInc)
@@ -185,7 +185,7 @@ class TestStateManager: XCTestCase {
         stateManager.addOrReplaceStateMachine(MockStateMachine())
 
         let eventInc = SelfDescribing(schema: "inc", payload: [
-            "value": NSNumber(value: 1)
+            "value": 1
         ])
 
         let trackerState = stateManager.trackerState(forProcessedEvent: eventInc)
@@ -198,7 +198,7 @@ class TestStateManager: XCTestCase {
         let stateManager = StateManager()
         stateManager.addOrReplaceStateMachine(MockStateMachine("identifier"))
         let trackerState1 = stateManager.trackerState(forProcessedEvent: SelfDescribing(schema: "inc", payload: [
-            "value": NSNumber(value: 1)
+            "value": 1
         ]))
         XCTAssertEqual(1, (trackerState1?.state(withIdentifier: "identifier") as? MockState)?.value)
 
@@ -211,7 +211,7 @@ class TestStateManager: XCTestCase {
         let stateManager = StateManager()
         stateManager.addOrReplaceStateMachine(MockStateMachine1("identifier"))
         let trackerState1 = stateManager.trackerState(forProcessedEvent: SelfDescribing(schema: "inc", payload: [
-            "value": NSNumber(value: 1)
+            "value": 1
         ]))
         XCTAssertEqual(1, (trackerState1?.state(withIdentifier: "identifier") as? MockState)?.value)
 

--- a/Tests/TestSubject.swift
+++ b/Tests/TestSubject.swift
@@ -25,14 +25,14 @@ import XCTest
 class TestSubject: XCTestCase {
     func testReturnsPlatformContextIfEnabled() {
         let subject = Subject(platformContext: true, andGeoContext: false)
-        let platformDict = subject.getPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
+        let platformDict = subject.platformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertNotNil(platformDict)
-        XCTAssertNotNil(platformDict?.dictionary?[kSPPlatformOsType])
+        XCTAssertNotNil(platformDict?.dictionary[kSPPlatformOsType])
     }
 
     func testDoesntReturnPlatformContextIfDisabled() {
         let subject = Subject(platformContext: false, andGeoContext: false)
-        let platformDict = subject.getPlatformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
+        let platformDict = subject.platformDict(userAnonymisation: false, advertisingIdentifierRetriever: nil)
         XCTAssertNil(platformDict)
     }
 
@@ -40,7 +40,7 @@ class TestSubject: XCTestCase {
         let subject = Subject(platformContext: false, andGeoContext: true)
         subject.geoLatitude = NSNumber(value: 10.0)
         subject.geoLongitude = NSNumber(value: 10.0)
-        let geoLocationDict = subject.getGeoLocationDict()
+        let geoLocationDict = subject.geoLocationDict
         XCTAssertNotNil(geoLocationDict)
         XCTAssertNotNil(geoLocationDict)
     }
@@ -49,7 +49,7 @@ class TestSubject: XCTestCase {
         let subject = Subject(platformContext: false, andGeoContext: false)
         subject.geoLatitude = NSNumber(value: 10.0)
         subject.geoLongitude = NSNumber(value: 10.0)
-        let geoLocationDict = subject.getGeoLocationDict()
+        let geoLocationDict = subject.geoLocationDict
         XCTAssertNil(geoLocationDict)
     }
 
@@ -61,13 +61,11 @@ class TestSubject: XCTestCase {
         subject.domainUserId = "aDuid"
         subject.language = "EN"
 
-        guard let values = subject.getStandardDict(userAnonymisation: true)?.dictionary else {
-            return XCTFail()
-        }
+        let values = subject.standardDict(userAnonymisation: true)
         XCTAssertNil(values[kSPUid])
         XCTAssertNil(values[kSPIpAddress])
         XCTAssertNil(values[kSPNetworkUid])
         XCTAssertNil(values[kSPDomainUid])
-        XCTAssertEqual(values[kSPLanguage], "EN" as NSObject)
+        XCTAssertEqual(values[kSPLanguage], "EN")
     }
 }

--- a/Tests/TestWebViewMessageHandler.swift
+++ b/Tests/TestWebViewMessageHandler.swift
@@ -66,7 +66,7 @@ class TestWebViewMessageHandler: XCTestCase {
         XCTAssertEqual(1, networkConnection?.sendingCount)
         XCTAssertEqual(1, (networkConnection?.previousRequests)?[0].count)
         let request = (networkConnection?.previousRequests)?[0][0]
-        let payload = (request?.payload?.dictionary?["data"] as? [[String: Any]])?[0]
+        let payload = (request?.payload?["data"] as? [[String: Any]])?[0]
         XCTAssert((payload?["se_ca"] as? String == "cat"))
         XCTAssert((payload?["se_ac"] as? String == "act"))
         XCTAssert((payload?["se_pr"] as? String == "prop"))
@@ -129,7 +129,7 @@ class TestWebViewMessageHandler: XCTestCase {
         XCTAssertEqual(1, networkConnection?.sendingCount)
         XCTAssertEqual(1, (networkConnection?.previousRequests)?[0].count)
         let request = (networkConnection?.previousRequests)?[0][0]
-        let payload = (request?.payload?.dictionary?["data"] as? [[String : Any]])?[0]
+        let payload = (request?.payload?["data"] as? [[String : Any]])?[0]
 
         let context = payload?["co"] as? String
         XCTAssert(context?.contains("{\"a\":\"b\"}") ?? false)

--- a/Tests/Utils/MockEventStore.swift
+++ b/Tests/Utils/MockEventStore.swift
@@ -48,10 +48,10 @@ class MockEventStore: NSObject, EventStore {
         return db.removeValue(forKey: storeId) != nil
     }
 
-    func removeEvents(withIds storeIds: [NSNumber]) -> Bool {
+    func removeEvents(withIds storeIds: [Int64]) -> Bool {
         let result = true
         for storeId in storeIds {
-            db.removeValue(forKey: storeId.int64Value)
+            db.removeValue(forKey: storeId)
         }
         return result
     }
@@ -76,7 +76,7 @@ class MockEventStore: NSObject, EventStore {
         var eventIds: [Int64] = []
         var events: [EmitterEvent] = []
         for (key, obj) in db {
-            let payloadCopy = Payload(dictionary: obj.dictionary ?? [:])
+            let payloadCopy = Payload(dictionary: obj.dictionary)
             let event = EmitterEvent(payload: payloadCopy, storeId: key)
             events.append(event)
             eventIds.append(event.storeId)


### PR DESCRIPTION
Issue #748 

Refactors the code and public APIs to make them feel more native in Swift. The main change is getting rid of using the `NSObject` type for values in dictionaries. Instead, we now accept `Any` which doesn't require typecasting each value to `NSObject`. For instance, instead of doing this:

```swift
let sdj = SelfDescribingJson(
            schema: "iglu:acme.com/test_event/jsonschema/1-0-0",
            andDictionary: [
                "hello": "world" as NSObject,
                "count": NSNumber(value: 1)
            ])
```

It would be possible to create the data payload like this:

```swift
let sdj = SelfDescribingJson(
            schema: "iglu:acme.com/test_event/jsonschema/1-0-0",
            andDictionary: [
                "hello": "world",
                "count": 1
            ])
```

There are some small refactorings here and there, such as making it possible to get and set values in `Payload` directly using `payload["key"]`.