### PR TITLE
Add ability to provide custom tracker plugins to inspect and enrich tracked events (close #750)

### DIFF
--- a/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
+++ b/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
@@ -1,0 +1,51 @@
+//
+//  GlobalContextPluginConfiguration.swift
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  License: Apache License Version 2.0
+//
+
+import Foundation
+
+class GlobalContextPluginConfiguration: Configuration, PluginConfigurationProtocol {
+    private(set) var identifier: String
+    private(set) var globalContext: GlobalContext
+    private(set) var afterTrackConfiguration: PluginAfterTrackConfiguration? = nil
+    private(set) var entitiesConfiguration: PluginEntitiesConfiguration?
+
+    init(identifier: String, globalContext: GlobalContext) {
+        self.identifier = identifier
+        self.globalContext = globalContext
+        self.entitiesConfiguration = PluginEntitiesConfiguration(closure: globalContext.contexts)
+    }
+
+    // MARK: - NSCopying
+
+    override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = GlobalContextPluginConfiguration(
+            identifier: identifier,
+            globalContext: globalContext
+        )
+        return copy
+    }
+
+    // MARK: - NSCoding (No coding possible as we can't encode and decode the contextGenerators)
+
+    required convenience public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
@@ -37,6 +37,10 @@ class ScreenStateMachine: StateMachineProtocol {
         return [kSPScreenViewSchema]
     }
 
+    var subscribedEventSchemasForAfterTrackCallback: [String] {
+        return []
+    }
+
     func transition(from event: Event, state currentState: State?) -> State? {
         if let screenView = event as? ScreenView {
             let newState: ScreenState = screenState(from: screenView)
@@ -83,5 +87,8 @@ class ScreenStateMachine: StateMachineProtocol {
             return SelfDescribingJson(schema: kSPScreenContextSchema, andPayload: contextPayload)
         }
         return nil
+    }
+    
+    func afterTrack(event: InspectableEvent) {
     }
 }

--- a/Sources/Core/StateMachine/DeepLinkStateMachine.swift
+++ b/Sources/Core/StateMachine/DeepLinkStateMachine.swift
@@ -49,6 +49,10 @@ class DeepLinkStateMachine: StateMachineProtocol {
         return []
     }
 
+    var subscribedEventSchemasForAfterTrackCallback: [String] {
+        return []
+    }
+
     func transition(from event: Event, state: State?) -> State? {
         if let dlEvent = event as? DeepLinkReceived {
             return DeepLinkState(url: dlEvent.url, referrer: dlEvent.referrer)
@@ -79,5 +83,8 @@ class DeepLinkStateMachine: StateMachineProtocol {
 
     func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]? {
         return nil
+    }
+    
+    func afterTrack(event: InspectableEvent) {
     }
 }

--- a/Sources/Core/StateMachine/LifecycleStateMachine.swift
+++ b/Sources/Core/StateMachine/LifecycleStateMachine.swift
@@ -63,4 +63,11 @@ class LifecycleStateMachine: StateMachineProtocol {
     func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]? {
         return nil
     }
+
+    var subscribedEventSchemasForAfterTrackCallback: [String] {
+        return []
+    }
+
+    func afterTrack(event: InspectableEvent) {
+    }
 }

--- a/Sources/Core/StateMachine/PluginStateMachine.swift
+++ b/Sources/Core/StateMachine/PluginStateMachine.swift
@@ -1,0 +1,91 @@
+//
+//  PluginStateMachine.swift
+//  Snowplow
+//
+// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License
+// Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+// http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the Apache License Version 2.0 for the specific
+// language governing permissions and limitations there under.
+//
+// License: Apache License Version 2.0
+//
+
+import Foundation
+
+typealias EntitiesConfiguration = (schemas: [String]?, closure: (InspectableEvent) -> ([SelfDescribingJson]))
+typealias AfterTrackConfiguration = (schemas: [String]?, closure: (InspectableEvent) -> ())
+
+class PluginStateMachine: StateMachineProtocol {
+    var identifier: String
+    private var entitiesConfiguration: EntitiesConfiguration?
+    private var afterTrackConfiguration: AfterTrackConfiguration?
+
+    init(
+        identifier: String,
+        entitiesConfiguration: EntitiesConfiguration?,
+        afterTrackConfiguration: AfterTrackConfiguration?
+    ) {
+        self.identifier = identifier
+        self.entitiesConfiguration = entitiesConfiguration
+        self.afterTrackConfiguration = afterTrackConfiguration
+    }
+
+    var subscribedEventSchemasForTransitions: [String] {
+        return []
+    }
+
+    func transition(from event: Event, state currentState: State?) -> State? {
+        return nil
+    }
+
+    var subscribedEventSchemasForEntitiesGeneration: [String] {
+        if let entitiesConfiguration = entitiesConfiguration {
+            if let schemas = entitiesConfiguration.schemas {
+                return schemas
+            } else {
+                return ["*"]
+            }
+        }
+        return []
+    }
+
+    func entities(from event: InspectableEvent, state: State?) -> [SelfDescribingJson]? {
+        if let entitiesConfiguration = entitiesConfiguration {
+            return entitiesConfiguration.closure(event)
+        }
+        return nil
+    }
+
+    var subscribedEventSchemasForPayloadUpdating: [String] {
+        return []
+    }
+
+    func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]? {
+        return nil
+    }
+
+    var subscribedEventSchemasForAfterTrackCallback: [String] {
+        if let afterTrackConfiguration = afterTrackConfiguration {
+            if let schemas = afterTrackConfiguration.schemas {
+                return schemas
+            } else {
+                return ["*"]
+            }
+        }
+        return []
+    }
+
+    func afterTrack(event: InspectableEvent) {
+        if let afterTrackConfiguration = afterTrackConfiguration {
+            afterTrackConfiguration.closure(event)
+        }
+    }
+}

--- a/Sources/Core/StateMachine/StateMachineProtocol.swift
+++ b/Sources/Core/StateMachine/StateMachineProtocol.swift
@@ -26,6 +26,7 @@ protocol StateMachineProtocol {
     var subscribedEventSchemasForTransitions: [String] { get }
     var subscribedEventSchemasForEntitiesGeneration: [String] { get }
     var subscribedEventSchemasForPayloadUpdating: [String] { get }
+    var subscribedEventSchemasForAfterTrackCallback: [String] { get }
     
     /// Only available for self-describing events (inheriting from SelfDescribingAbstract)
     func transition(from event: Event, state: State?) -> State?
@@ -35,4 +36,7 @@ protocol StateMachineProtocol {
     
     /// Only available for self-describing events (inheriting from SelfDescribingAbstract)
     func payloadValues(from event: InspectableEvent, state: State?) -> [String : Any]?
+    
+    /// Available for both self-describing and primitive events (when using `*` as the schema)
+    func afterTrack(event: InspectableEvent)
 }

--- a/Sources/Core/Tracker/PluginsControllerImpl.swift
+++ b/Sources/Core/Tracker/PluginsControllerImpl.swift
@@ -1,0 +1,36 @@
+//
+//  PluginsControllerImpl.swift
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  License: Apache License Version 2.0
+//
+
+import Foundation
+
+class PluginsControllerImpl: Controller, PluginsController {
+    var identifiers: [String] {
+        return serviceProvider.pluginConfigurations.map { $0.identifier }
+    }
+    
+    func add(plugin: PluginConfigurationProtocol) {
+        serviceProvider.addPlugin(plugin: plugin)
+    }
+
+    func remove(identifier: String) {
+        serviceProvider.removePlugin(identifier: identifier)
+    }
+}

--- a/Sources/Core/Tracker/ServiceProviderProtocol.swift
+++ b/Sources/Core/Tracker/ServiceProviderProtocol.swift
@@ -34,10 +34,14 @@ protocol ServiceProviderProtocol: AnyObject {
     var globalContextsController: GlobalContextsControllerImpl { get }
     var subjectController: SubjectControllerImpl { get }
     var sessionController: SessionControllerImpl { get }
+    var pluginsController: PluginsControllerImpl { get }
     var networkConfigurationUpdate: NetworkConfigurationUpdate { get }
     var trackerConfigurationUpdate: TrackerConfigurationUpdate { get }
     var emitterConfigurationUpdate: EmitterConfigurationUpdate { get }
     var subjectConfigurationUpdate: SubjectConfigurationUpdate { get }
     var sessionConfigurationUpdate: SessionConfigurationUpdate { get }
     var gdprConfigurationUpdate: GDPRConfigurationUpdate { get }
+    var pluginConfigurations: [PluginConfigurationProtocol] { get }
+    func addPlugin(plugin: PluginConfigurationProtocol)
+    func removePlugin(identifier: String)
 }

--- a/Sources/Core/Tracker/TrackerControllerImpl.swift
+++ b/Sources/Core/Tracker/TrackerControllerImpl.swift
@@ -54,6 +54,10 @@ class TrackerControllerImpl: Controller, TrackerController {
         return sessionController.isEnabled ? sessionController : nil
     }
 
+    var plugins: PluginsController {
+        return serviceProvider.pluginsController
+    }
+
     // MARK: - Control methods
 
     func pause() {

--- a/Sources/Snowplow/Configurations/GlobalContextsConfiguration.swift
+++ b/Sources/Snowplow/Configurations/GlobalContextsConfiguration.swift
@@ -72,4 +72,13 @@ public class GlobalContextsConfiguration: Configuration, GlobalContextsConfigura
     }
 
     // MARK: - NSCoding (No coding possible as we can't encode and decode the contextGenerators)
+    
+    // MARK: - Internal functions
+    
+    func toPluginConfigurations() -> [GlobalContextPluginConfiguration] {
+        return contextGenerators.map { (identifier, globalContext) in
+            return GlobalContextPluginConfiguration(identifier: identifier,
+                                                    globalContext: globalContext)
+        }
+    }
 }

--- a/Sources/Snowplow/Configurations/PluginConfiguration.swift
+++ b/Sources/Snowplow/Configurations/PluginConfiguration.swift
@@ -1,0 +1,163 @@
+//
+//  PluginConfiguration.swift
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  License: Apache License Version 2.0
+//
+
+import Foundation
+
+/// Closure used in after track plugin callbacks.
+public typealias PluginAfterTrackClosure = (InspectableEvent) -> Void
+/// Closure used in plugin callbacks to generate entities.
+public typealias PluginEntitiesClosure = (InspectableEvent) -> [SelfDescribingJson]
+
+/// Provides a block closure to be called after events are tracked.
+/// Optionally, you can specify the event schemas for which the block should be called.
+@objc(SPPluginAfterTrackConfiguration)
+public class PluginAfterTrackConfiguration: NSObject {
+    var schemas: [String]?
+    var closure: PluginAfterTrackClosure
+
+    /// Create the after track closure configuration
+    /// - Parameters:
+    ///    - schemas: Optional list of event schemas to call the block for. If null, the block is called for all events.
+    ///    - closure: Block to call after events are tracked.
+    public init(schemas: [String]? = nil, closure: @escaping PluginAfterTrackClosure) {
+        self.schemas = schemas
+        self.closure = closure
+    }
+
+    func toTuple() -> (schemas: [String]?, closure: PluginAfterTrackClosure)? {
+        return (schemas: schemas, closure: closure)
+    }
+}
+
+/// Provides a block closure that returns a list of context entities and is called when events are tracked.
+/// Optionally, you can specify the event schemas for which the block should be called.
+@objc(SPPluginEntitiesConfiguration)
+public class PluginEntitiesConfiguration: NSObject {
+    var schemas: [String]?
+    var closure: PluginEntitiesClosure
+
+    /// Create the entities closure configuration
+    /// - Parameters:
+    ///    - schemas: Optional list of event schemas to call the block for. If null, the block is called for all events.
+    ///    - closure: Block that produces entities, called when events are tracked.
+    public init(schemas: [String]? = nil, closure: @escaping PluginEntitiesClosure) {
+        self.schemas = schemas
+        self.closure = closure
+    }
+
+    func toTuple() -> (schemas: [String]?, closure: PluginEntitiesClosure)? {
+        return (schemas: schemas, closure: closure)
+    }
+}
+
+/// Protocol for tracker plugin definition.
+/// Specifies configurations for the closures called when and after events are tracked.
+@objc(SPPluginConfigurationProtocol)
+public protocol PluginConfigurationProtocol {
+    /// Unique identifier of the plugin within the tracker.
+    var identifier: String { get }
+    /// Closure configuration that is called after events are tracked.
+    var afterTrackConfiguration: PluginAfterTrackConfiguration? { get }
+    /// Closure configuration that is called when events are tracked to generate context entities to enrich the events.
+    var entitiesConfiguration: PluginEntitiesConfiguration? { get }
+}
+
+extension PluginConfigurationProtocol {
+    func toStateMachine() -> StateMachineProtocol {
+        return PluginStateMachine(
+            identifier: identifier,
+            entitiesConfiguration: entitiesConfiguration?.toTuple(),
+            afterTrackConfiguration: afterTrackConfiguration?.toTuple())
+    }
+}
+
+/// Configuration for a custom tracker plugin.
+/// Enables you to add closures to be called when and after events are tracked in the tracker.
+@objc(SPPluginConfiguration)
+public class PluginConfiguration: Configuration, PluginConfigurationProtocol {
+    /// Unique identifier of the plugin within the tracker.
+    public private(set) var identifier: String
+    /// Closure configuration that is called after events are tracked.
+    /// Read-only, use `afterTrack(schemas:closure:)` to initialize.
+    public private(set) var afterTrackConfiguration: PluginAfterTrackConfiguration?
+    /// Closure configuration that is called when events are tracked to generate context entities to enrich the events.
+    /// Read-only, use `entities(schemas:closure:)` to initialize.
+    public private(set) var entitiesConfiguration: PluginEntitiesConfiguration?
+
+    /// Create a plugin configuration.
+    /// - Parameters:
+    ///    - identifier: Unique identifier of the plugin within the tracker.
+    public init(identifier: String) {
+        self.identifier = identifier
+    }
+
+    /// Add a closure that generates entities for a given tracked event.
+    /// - Parameters:
+    ///   - schemas: Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+    ///   - closure: Closure that produces entities, called when events are tracked.
+    public func entities(schemas: [String]? = nil, closure: @escaping PluginEntitiesClosure) {
+        self.entitiesConfiguration = PluginEntitiesConfiguration(
+            schemas: schemas,
+            closure: closure
+        )
+    }
+
+    /// Add a closure that is called after the events are tracked.
+    /// The closure is called after the events are added to event queue in Emitter, not necessarily after they are sent to the Collector.
+    /// - Parameters:
+    ///   - schemas: Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+    ///   - closure: Closure block to call after events are tracked.
+    public func afterTrack(schemas: [String]? = nil, closure: @escaping PluginAfterTrackClosure) {
+        self.afterTrackConfiguration = PluginAfterTrackConfiguration(
+            schemas: schemas,
+            closure: closure
+        )
+    }
+
+    // MARK: - NSCopying
+
+    @objc
+    public override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = PluginConfiguration(identifier: identifier)
+        if let afterTrack = afterTrackConfiguration {
+            copy.afterTrack(schemas: afterTrack.schemas, closure: afterTrack.closure)
+        }
+        if let entities = entitiesConfiguration {
+            copy.entities(schemas: entities.schemas, closure: entities.closure)
+        }
+        return copy
+    }
+
+    // MARK: - NSSecureCoding
+    
+    @objc
+    public override class var supportsSecureCoding: Bool { return true }
+    
+    @objc
+    public override func encode(with coder: NSCoder) {
+        coder.encode(identifier, forKey: "identifier")
+    }
+
+    required init?(coder: NSCoder) {
+        identifier = coder.decodeObject(forKey: "identifier") as? String ?? ""
+        super.init()
+    }
+
+}

--- a/Sources/Snowplow/Controllers/PluginsController.swift
+++ b/Sources/Snowplow/Controllers/PluginsController.swift
@@ -1,0 +1,32 @@
+//
+//  PluginsController.swift
+//  Snowplow
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Alex Benini
+//  License: Apache License Version 2.0
+//
+
+import Foundation
+
+@objc(SPPluginsController)
+public protocol PluginsController {
+    @objc
+    var identifiers: [String] { get }
+    @objc
+    func add(plugin: PluginConfigurationProtocol)
+    @objc
+    func remove(identifier: String)
+}

--- a/Sources/Snowplow/Controllers/TrackerController.swift
+++ b/Sources/Snowplow/Controllers/TrackerController.swift
@@ -58,6 +58,9 @@ public protocol TrackerController: TrackerConfigurationProtocol {
     /// @apiNote Don't retain the reference. It may change on tracker reconfiguration.
     @objc
     var globalContexts: GlobalContextsController? { get }
+    /// 
+    @objc
+    var plugins: PluginsController { get }
     /// Track the event.
     /// The tracker will take care to process and send the event assigning `event_id` and `device_timestamp`.
     /// - Parameter event: The event to track.

--- a/Tests/Global Contexts/TestGlobalContexts.swift
+++ b/Tests/Global Contexts/TestGlobalContexts.swift
@@ -56,41 +56,42 @@ class TestGlobalContexts: XCTestCase {
                 ])
             ]
         })
-        
+
         var generators = [
             "static": staticGC,
             "generator": generatorGC,
             "block": blockGC
         ]
-        let tracker = getTrackerWithGlobalContextGenerators(&generators)
+        let serviceProvider = getServiceProviderWithGlobalContextGenerators(&generators)
+        let controller = serviceProvider.globalContextsController
 
-        var result = Set<String>(tracker.globalContextTags)
+        var result = Set<String>(controller.tags)
         var expected = Set<String>(["static", "generator", "block"])
         XCTAssertEqual(result, expected)
 
         // Can't remove a not existing tag
-        var removedGC = tracker.removeGlobalContext("notExistingTag")
+        var removedGC = controller.remove(tag: "notExistingTag")
         XCTAssertNil(removedGC)
-        result = Set<String>(tracker.globalContextTags)
+        result = Set<String>(controller.tags)
         expected = Set<String>(["static", "generator", "block"])
         XCTAssertTrue(result == expected)
 
         // Remove an existing tag
-        removedGC = tracker.removeGlobalContext("static")
+        removedGC = controller.remove(tag: "static")
         XCTAssertNotNil(removedGC)
-        result = Set<String>(tracker.globalContextTags)
+        result = Set<String>(controller.tags)
         expected = Set<String>(["generator", "block"])
         XCTAssertTrue(result == expected)
 
         // Add a not existing tag
-        XCTAssertTrue(tracker.add(staticGC, tag: "static"))
-        result = Set<String>(tracker.globalContextTags)
+        XCTAssertTrue(controller.add(tag: "static", contextGenerator: staticGC))
+        result = Set<String>(controller.tags)
         expected = Set<String>(["generator", "block", "static"])
         XCTAssertTrue(result == expected)
 
         // Can't add an existing tag
-        XCTAssertFalse(tracker.add(staticGC, tag: "static"))
-        result = Set<String>(tracker.globalContextTags)
+        XCTAssertFalse(controller.add(tag: "static", contextGenerator: staticGC))
+        result = Set<String>(controller.tags)
         expected = Set<String>(["generator", "block", "static"])
         XCTAssertTrue(result == expected)
     }
@@ -102,26 +103,27 @@ class TestGlobalContexts: XCTestCase {
             ])
         ])
         var generators: [String : GlobalContext] = [:]
-        let tracker = getTrackerWithGlobalContextGenerators(&generators)
+        let serviceProvider = getServiceProviderWithGlobalContextGenerators(&generators)
+        let controller = serviceProvider.globalContextsController
 
-        var result = Set<String>(tracker.globalContextTags)
+        var result = Set<String>(controller.tags)
         var expected = Set<String>([])
         XCTAssertTrue(result == expected)
 
         // Can't remove a not existing tag
-        var removedGC = tracker.removeGlobalContext("notExistingTag")
+        var removedGC = controller.remove(tag: "notExistingTag")
         XCTAssertNil(removedGC)
 
         // Add a not existing tag
-        XCTAssertTrue(tracker.add(staticGC, tag: "static"))
-        result = Set<String>(tracker.globalContextTags)
+        XCTAssertTrue(controller.add(tag: "static", contextGenerator: staticGC))
+        result = Set<String>(controller.tags)
         expected = Set<String>(["static"])
         XCTAssertTrue(result == expected)
 
         // Remove an existing tag
-        removedGC = tracker.removeGlobalContext("static")
+        removedGC = controller.remove(tag: "static")
         XCTAssertNotNil(removedGC)
-        result = Set<String>(tracker.globalContextTags)
+        result = Set<String>(controller.tags)
         expected = Set<String>([])
         XCTAssertTrue(result == expected)
     }
@@ -135,15 +137,14 @@ class TestGlobalContexts: XCTestCase {
         var globalContexts = [
             "static": staticGC
         ]
-        let tracker = getTrackerWithGlobalContextGenerators(&globalContexts)
+        let serviceProvider = getServiceProviderWithGlobalContextGenerators(&globalContexts)
 
         let event = Structured(category: "Category", action: "Action")
         let trackerEvent = TrackerEvent(event: event, state: nil)
 
-        var contexts: [SelfDescribingJson] = []
-        tracker.addGlobalContexts(toContexts: &contexts, event: trackerEvent)
-        XCTAssertTrue(contexts.count == 1)
-        XCTAssertEqual(contexts[0].schema, "schema")
+        serviceProvider.tracker.addStateMachineEntities(event: trackerEvent)
+        XCTAssertTrue(trackerEvent.entities.count == 1)
+        XCTAssertEqual(trackerEvent.entities[0].schema, "schema")
     }
 
     func testStaticGeneratortWithFilter() {
@@ -168,15 +169,14 @@ class TestGlobalContexts: XCTestCase {
             "matching": filterMatchingGC,
             "notMatching": filterNotMatchingGC
         ]
-        let tracker = getTrackerWithGlobalContextGenerators(&globalContexts)
+        let serviceProvider = getServiceProviderWithGlobalContextGenerators(&globalContexts)
 
         let event = Structured(category: stringToMatch, action: "Action")
         let trackerEvent = TrackerEvent(event: event, state: nil)
 
-        var contexts: [SelfDescribingJson] = []
-        tracker.addGlobalContexts(toContexts: &contexts, event: trackerEvent)
-        XCTAssertTrue(contexts.count == 1)
-        XCTAssertEqual(contexts[0].schema, "schema")
+        serviceProvider.tracker.addStateMachineEntities(event: trackerEvent)
+        XCTAssertTrue(trackerEvent.entities.count == 1)
+        XCTAssertEqual(trackerEvent.entities[0].schema, "schema")
     }
 
     func testStaticGeneratorWithRuleset() {
@@ -192,30 +192,28 @@ class TestGlobalContexts: XCTestCase {
         var globalContexts = [
             "ruleset": rulesetGC
         ]
-        let tracker = getTrackerWithGlobalContextGenerators(&globalContexts)
-
-        var contexts: [SelfDescribingJson] = []
+        let serviceProvider = getServiceProviderWithGlobalContextGenerators(&globalContexts)
 
         // Not matching primitive event
         let primitiveEvent = Structured(category: "Category", action: "Action")
         var trackerEvent = TrackerEvent(event: primitiveEvent, state: nil)
-        tracker.addGlobalContexts(toContexts: &contexts, event: trackerEvent)
-        XCTAssertTrue(contexts.count == 0)
+        serviceProvider.tracker.addStateMachineEntities(event: trackerEvent)
+        XCTAssertTrue(trackerEvent.entities.count == 0)
 
         // Not matching self-describing event with mobile schema
         let screenView = ScreenView(name: "Name", screenId: nil)
         screenView.type = "Type"
         trackerEvent = TrackerEvent(event: screenView, state: nil)
-        tracker.addGlobalContexts(toContexts: &contexts, event: trackerEvent)
-        XCTAssertTrue(contexts.count == 0)
+        serviceProvider.tracker.addStateMachineEntities(event: trackerEvent)
+        XCTAssertTrue(trackerEvent.entities.count == 0)
 
         // Matching self-describing event with general schema
         let timing = Timing(category: "Category", variable: "Variable", timing: 123)
         timing.label = "Label"
         trackerEvent = TrackerEvent(event: timing, state: nil)
-        tracker.addGlobalContexts(toContexts: &contexts, event: trackerEvent)
-        XCTAssertTrue(contexts.count == 1)
-        XCTAssertEqual(contexts[0].schema, "schema")
+        serviceProvider.tracker.addStateMachineEntities(event: trackerEvent)
+        XCTAssertTrue(trackerEvent.entities.count == 1)
+        XCTAssertEqual(trackerEvent.entities[0].schema, "schema")
     }
 
     func testBlockGenerator() {
@@ -228,15 +226,14 @@ class TestGlobalContexts: XCTestCase {
                 ]
             })
         ]
-        let tracker = getTrackerWithGlobalContextGenerators(&generators)
+        let serviceProvider = getServiceProviderWithGlobalContextGenerators(&generators)
 
         let event = Structured(category: "Category", action: "Action")
         let trackerEvent = TrackerEvent(event: event, state: nil)
 
-        var contexts: [SelfDescribingJson] = []
-        tracker.addGlobalContexts(toContexts: &contexts, event: trackerEvent)
-        XCTAssertTrue(contexts.count == 1)
-        XCTAssertEqual(contexts[0].schema, "schema")
+        serviceProvider.tracker.addStateMachineEntities(event: trackerEvent)
+        XCTAssertTrue(trackerEvent.entities.count == 1)
+        XCTAssertEqual(trackerEvent.entities[0].schema, "schema")
     }
 
     func testContextGenerator() {
@@ -244,21 +241,20 @@ class TestGlobalContexts: XCTestCase {
         var generators = [
             "contextGenerator": contextGeneratorGC
         ]
-        let tracker = getTrackerWithGlobalContextGenerators(&generators)
+        let serviceProvider = getServiceProviderWithGlobalContextGenerators(&generators)
 
         let event = Structured(category: "StringToMatch", action: "Action")
         let trackerEvent = TrackerEvent(event: event, state: nil)
 
-        var contexts: [SelfDescribingJson] = []
-        tracker.addGlobalContexts(toContexts: &contexts, event: trackerEvent)
-        XCTAssertTrue(contexts.count == 1)
-        XCTAssertEqual(contexts[0].schema, "schema")
+        serviceProvider.tracker.addStateMachineEntities(event: trackerEvent)
+        XCTAssertTrue(trackerEvent.entities.count == 1)
+        XCTAssertEqual(trackerEvent.entities[0].schema, "schema")
     }
 
     // MARK: - Utility function
 
 
-    func getTrackerWithGlobalContextGenerators(_ generators: inout [String : GlobalContext]) -> Tracker {
+    func getServiceProviderWithGlobalContextGenerators(_ generators: inout [String : GlobalContext]) -> ServiceProvider {
         let networkConfig = NetworkConfiguration(
             endpoint: "https://com.acme.fake",
             method: .post)
@@ -274,6 +270,6 @@ class TestGlobalContexts: XCTestCase {
             namespace: "aNamespace",
             network: networkConfig,
             configurations: [gcConfig])
-        return serviceProvider.tracker
+        return serviceProvider
     }
 }

--- a/Tests/Integration/TestTrackEventsToMicro.swift
+++ b/Tests/Integration/TestTrackEventsToMicro.swift
@@ -27,9 +27,10 @@ class TestTrackEventsToMicro: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        
-        tracker = Snowplow.createTracker(namespace: "ns", network: NetworkConfiguration(endpoint: Micro.endpoint))!
-        
+
+        tracker = Snowplow.createTracker(namespace: "testMicro",
+                                         network: NetworkConfiguration(endpoint: Micro.endpoint))!
+
         Micro.setUpMockerIgnores()
         wait(for: [Micro.reset()], timeout: Micro.timeout)
     }

--- a/Tests/TestPlugins.swift
+++ b/Tests/TestPlugins.swift
@@ -1,0 +1,197 @@
+//
+//  TestPlugins.swift
+//  Snowplow-iOSTests
+//
+//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+//
+//  Authors: Matus Tomlein
+//  License: Apache License Version 2.0
+//
+
+import XCTest
+@testable import SnowplowTracker
+
+class TestPlugins: XCTestCase {
+    override func tearDown() {
+        Snowplow.removeAllTrackers()
+        super.tearDown()
+    }
+
+    func testAddsEntitiesToEvent() {
+        let plugin = PluginConfiguration(identifier: "plugin")
+        plugin.entities { [SelfDescribingJson(schema: "schema", andData: ["val": $0.payload["se_ca"]!])] }
+        
+        let testPlugin = PluginConfiguration(identifier: "test")
+        let expect = expectation(description: "Has context entity on event")
+        testPlugin.afterTrack { event in
+            XCTAssertTrue(
+                event.entities.filter({ entity in
+                    entity.schema == "schema" && entity.data["val"] as? String == "cat"
+                }).count == 1
+            )
+            expect.fulfill()
+        }
+        
+        let tracker = createTracker([plugin, testPlugin])
+        _ = tracker.track(Structured(category: "cat", action: "act"))
+        
+        wait(for: [expect], timeout: 10)
+    }
+
+    func testAddsEntitiesFromMultiplePlugins() {
+        let plugin1 = PluginConfiguration(identifier: "plugin1")
+        plugin1.entities { _ in [SelfDescribingJson(schema: "schema1", andData: [:])] }
+        
+        let plugin2 = PluginConfiguration(identifier: "plugin2")
+        plugin2.entities { _ in [SelfDescribingJson(schema: "schema2", andData: [:])] }
+        
+        let testPlugin = PluginConfiguration(identifier: "test")
+        let expect = expectation(description: "Has both context entities on event")
+        testPlugin.afterTrack { event in
+            XCTAssertTrue(
+                event.entities.filter({ $0.schema == "schema1" }).count == 1
+            )
+            XCTAssertTrue(
+                event.entities.filter({ $0.schema == "schema2" }).count == 1
+            )
+            expect.fulfill()
+        }
+        
+        let tracker = createTracker([plugin1, plugin2, testPlugin])
+        _ = tracker.track(ScreenView(name: "sv"))
+
+        wait(for: [expect], timeout: 1)
+    }
+
+    func testAddsEntitiesOnlyForEventsMatchingSchema() {
+        let plugin = PluginConfiguration(identifier: "plugin")
+        plugin.entities(schemas: ["schema1"]) { _ in [SelfDescribingJson(schema: "xx", andData: [:])] }
+        
+        var event1HasEntity: Bool? = nil
+        var event2HasEntity: Bool? = nil
+        
+        let testPlugin = PluginConfiguration(identifier: "test")
+        testPlugin.afterTrack { event in
+            if event.schema == "schema1" {
+                event1HasEntity = event.entities.contains(where: { $0.schema == "xx" })
+            }
+            if event.schema == "schema2" {
+                event2HasEntity = event.entities.contains(where: { $0.schema == "xx" })
+            }
+        }
+        
+        let tracker = createTracker([plugin, testPlugin])
+        _ = tracker.track(SelfDescribing(schema: "schema1", payload: [:]))
+        _ = tracker.track(SelfDescribing(schema: "schema2", payload: [:]))
+
+        waitForEventsToBeTracked()
+
+        XCTAssertTrue(event1HasEntity!)
+        XCTAssertFalse(event2HasEntity!)
+    }
+
+    func testCallsAfterTrackOnlyForEventsMatchingSchema() {
+        var event1Called: Bool = false
+        var event2Called: Bool = false
+        var event3Called: Bool = false
+
+        let plugin = PluginConfiguration(identifier: "plugin")
+        plugin.afterTrack(schemas: ["schema1"]) { event in
+            if event.schema == "schema1" { event1Called = true }
+            if event.schema == "schema2" { event2Called = true }
+            if event.schema == nil { event3Called = true }
+        }
+
+        let tracker = createTracker([plugin])
+        _ = tracker.track(SelfDescribing(schema: "schema1", payload: [:]))
+        _ = tracker.track(SelfDescribing(schema: "schema2", payload: [:]))
+        _ = tracker.track(Structured(category: "cat", action: "act"))
+
+        waitForEventsToBeTracked()
+
+        XCTAssertTrue(event1Called)
+        XCTAssertFalse(event2Called)
+        XCTAssertFalse(event3Called)
+    }
+
+    func testCallsAfterTrackOnlyForStructuredEvent() {
+        var selfDescribingCalled: Bool = false
+        var structuredCalled: Bool = false
+
+        let plugin = PluginConfiguration(identifier: "plugin")
+        plugin.afterTrack(schemas: ["se"]) { event in
+            if event.schema == "schema1" { selfDescribingCalled = true }
+            if event.schema == nil { structuredCalled = true }
+        }
+
+        let tracker = createTracker([plugin])
+        _ = tracker.track(SelfDescribing(schema: "schema1", payload: [:]))
+        _ = tracker.track(Structured(category: "cat", action: "act"))
+
+        waitForEventsToBeTracked()
+
+        XCTAssertTrue(structuredCalled)
+        XCTAssertFalse(selfDescribingCalled)
+    }
+    
+    func testAddsPluginToTracker() {
+        let tracker = createTracker([])
+        
+        let plugin = PluginConfiguration(identifier: "plugin")
+        let expect = expectation(description: "Plugin called")
+        plugin.afterTrack { _ -> Void in expect.fulfill() }
+        tracker.plugins.add(plugin: plugin)
+        
+        _ = tracker.track(ScreenView(name: "sv"))
+        
+        wait(for: [expect], timeout: 1)
+    }
+    
+    func testRemovesPluginFromTracker() {
+        var pluginCalled = false
+        let plugin = PluginConfiguration(identifier: "plugin")
+        plugin.afterTrack { _ in pluginCalled = true }
+
+        let tracker = createTracker([plugin])
+        XCTAssertEqual(["plugin"], tracker.plugins.identifiers)
+        tracker.plugins.remove(identifier: "plugin")
+
+        _ = tracker.track(ScreenView(name: "sv"))
+
+        let expect = expectation(description: "Wait for events to be tracked")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { () -> Void in expect.fulfill() }
+        wait(for: [expect], timeout: 1)
+
+        XCTAssertFalse(pluginCalled)
+    }
+
+    private func createTracker(_ configurations: [Configuration]) -> TrackerController {
+        let networkConfig = NetworkConfiguration(networkConnection: MockNetworkConnection(requestOption: .post, statusCode: 200))
+        let trackerConfig = TrackerConfiguration()
+        trackerConfig.installAutotracking = false
+        trackerConfig.lifecycleAutotracking = false
+        let namespace = "testPlugins" + String(describing: Int.random(in: 0..<100))
+        return Snowplow.createTracker(namespace: namespace,
+                                      network: networkConfig,
+                                      configurations: configurations + [trackerConfig])!
+    }
+    
+    private func waitForEventsToBeTracked() {
+        let expect = expectation(description: "Wait for events to be tracked")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { () -> Void in
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 1)
+    }
+}

--- a/Tests/TestServiceProvider.swift
+++ b/Tests/TestServiceProvider.swift
@@ -44,7 +44,9 @@ class TestServiceProvider: XCTestCase {
         trackerConfig.installAutotracking = false
         trackerConfig.screenViewAutotracking = false
         trackerConfig.lifecycleAutotracking = false
-        let serviceProvider = ServiceProvider(namespace: "ns", network: networkConfig, configurations: [emitterConfig, trackerConfig])
+        let serviceProvider = ServiceProvider(namespace: "serviceProviderTest",
+                                              network: networkConfig,
+                                              configurations: [emitterConfig, trackerConfig])
         XCTAssertNotNil(serviceProvider)
 
         // pause emitter

--- a/Tests/TestStateManager.swift
+++ b/Tests/TestStateManager.swift
@@ -80,6 +80,13 @@ class MockStateMachine: StateMachineProtocol {
             "newParam": "value"
         ]
     }
+
+    var subscribedEventSchemasForAfterTrackCallback: [String] {
+        return []
+    }
+
+    func afterTrack(event: SnowplowTracker.InspectableEvent) {
+    }
 }
 
 class MockStateMachine1: MockStateMachine {


### PR DESCRIPTION
Issue #750 

Implements the ability to provide custom plugins that can intercept tracked events. Plugins provide callbacks that can enrich events with additional entities and inspect tracked events.

**Code snippet**

The API is explained in this snippet:

```swift
// identifier needs uniquely identify the plugin
let plugin = PluginConfiguration(identifier: "myPlugin")

// entities closure can return context entities to enrich events
// the list of schemas to call the closure for is optional (it will be called for all events if null)
plugin.entities(schemas: ["iglu:..."]) { event in
    return [
        SelfDescribingJson(schema: "iglu:xx", andData: ["yy": true])
    ]
}

// after track callback called on a background thread to inspect final tracked events
// one can also supply a list of schemas to call the closure only for specific events
plugin.afterTrack { event in
    print("Tracked event with \(event.entities.count) entities")
}

// the plugin is supplied to the tracker as a configuration
let tracker = Snowplow.createTracker(namespace: "ns",
                                     network: networkConfig,
                                     configurations: [plugin])

// one can inspect the enabled plugins and get the list of their identifiers
let pluginIdentifiers = tracker?.plugins.identifiers

// add additional plugins (using PluginConfiguration as above)
tracker?.plugins.add(plugin: otherPlugin)

// remove registered plugins by their identifiers
tracker?.plugins.remove(identifier: "myPlugin")
```

**Implemented using state machines**

On the background, plugins are implemented using `PluginStateMachine` state machine. Each plugin has a separate state machine with the same identifier. The state machine calls the plugin closures in the `entities()` and `afterTrack()` functions.

**After track callback**

In order to implement the `afterTrack()` callback (which will be useful in plugins such as the one for FocalMeter, see other PR), I had to add this API to the state machines. It is called on a background thread to enable the plugins to make API requests without blocking the tracking code.

**Global context**

I changed the internal implementation of global contexts so that it is now built using plugins. This simplifies the code since we don't have deal with global contexts as a special case in `Tracker`, it is just another plugin/state machine.

The implementation was straightforward, since global context just adds entities based on some conditions which can be done in the `entities` closure in plugins.

There were no public API changes required to global context (from outside, it looks the same).

**Other refactoring in `Tracker`**

Finally, I tried to tidy up the code in the `Tracker.transformEvent()` and `Tracker.payload()` functions to make it more clear what is the sequence of the processing steps when events are tracked.