### PR TITLE
Remove requirement for all configurations to be serializable (close #752)

### DIFF
--- a/Sources/Core/GDPR/GDPRConfigurationUpdate.swift
+++ b/Sources/Core/GDPR/GDPRConfigurationUpdate.swift
@@ -90,8 +90,4 @@ class GDPRConfigurationUpdate: GDPRConfiguration {
     public init() {
         super.init(basis: .consent, documentId: nil, documentVersion: nil, documentDescription: nil)
     }
-    
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
 }

--- a/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
+++ b/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 
-class GlobalContextPluginConfiguration: Configuration, PluginConfigurationProtocol {
+class GlobalContextPluginConfiguration: NSObject, ConfigurationProtocol, PluginConfigurationProtocol {
     private(set) var identifier: String
     private(set) var globalContext: GlobalContext
     private(set) var afterTrackConfiguration: PluginAfterTrackConfiguration? = nil
@@ -31,21 +31,5 @@ class GlobalContextPluginConfiguration: Configuration, PluginConfigurationProtoc
         self.identifier = identifier
         self.globalContext = globalContext
         self.entitiesConfiguration = PluginEntitiesConfiguration(closure: globalContext.contexts)
-    }
-
-    // MARK: - NSCopying
-
-    override func copy(with zone: NSZone? = nil) -> Any {
-        let copy = GlobalContextPluginConfiguration(
-            identifier: identifier,
-            globalContext: globalContext
-        )
-        return copy
-    }
-
-    // MARK: - NSCoding (No coding possible as we can't encode and decode the contextGenerators)
-
-    required convenience public init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/Sources/Core/RemoteConfiguration/FetchedConfigurationBundle.swift
+++ b/Sources/Core/RemoteConfiguration/FetchedConfigurationBundle.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 
-class FetchedConfigurationBundle: Configuration {
+class FetchedConfigurationBundle: SerializableConfiguration {
     var schema: String
     var configurationVersion: Int
     var configurationBundle: [ConfigurationBundle] = []

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -122,7 +122,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
     
     // MARK: - Init
 
-    init(namespace: String, network networkConfiguration: NetworkConfiguration, configurations: [Configuration]) {
+    init(namespace: String, network networkConfiguration: NetworkConfiguration, configurations: [ConfigurationProtocol]) {
         self.namespace = namespace
         super.init()
         
@@ -134,7 +134,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
         let _ = tracker // Build tracker to initialize NotificationCenter receivers
     }
 
-    func reset(configurations: [Configuration]) {
+    func reset(configurations: [ConfigurationProtocol]) {
         stopServices()
         resetConfigurationUpdates()
         processConfigurations(configurations)
@@ -152,7 +152,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
 
     // MARK: - Private methods
 
-    func processConfigurations(_ configurations: [Configuration]) {
+    func processConfigurations(_ configurations: [ConfigurationProtocol]) {
         for configuration in configurations {
             if let configuration = configuration as? NetworkConfiguration {
                 networkConfigurationUpdate.sourceConfig = configuration

--- a/Sources/Snowplow/Configurations/ConfigurationBundle.swift
+++ b/Sources/Snowplow/Configurations/ConfigurationBundle.swift
@@ -1,4 +1,5 @@
-//  SPConfigurationBundle.swift
+//
+//  ConfigurationBundle.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -22,7 +23,7 @@ import Foundation
 
 /// This class represents the default configuration applied in place of the remote configuration.
 @objc(SPConfigurationBundle)
-public class ConfigurationBundle: Configuration {
+public class ConfigurationBundle: SerializableConfiguration {
     @objc
     private(set) public var namespace: String
     @objc
@@ -35,8 +36,8 @@ public class ConfigurationBundle: Configuration {
     public var sessionConfiguration: SessionConfiguration?
 
     @objc
-    public var configurations: [Configuration] {
-        var array: [Configuration] = []
+    public var configurations: [ConfigurationProtocol] {
+        var array: [ConfigurationProtocol] = []
         if let networkConfiguration = networkConfiguration {
             array.append(networkConfiguration)
         }

--- a/Sources/Snowplow/Configurations/ConfigurationProtocol.swift
+++ b/Sources/Snowplow/Configurations/ConfigurationProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  ConfigurationState.h
+//  Configuration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -15,19 +15,13 @@
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
 //
-//  Authors: Matus Tomlein
+//  Authors: Alex Benini
 //  License: Apache License Version 2.0
 //
 
 import Foundation
 
-/// State of retrieved remote configuration that states where the configuration was retrieved from.
-@objc(SPConfigurationState)
-public enum ConfigurationState: Int {
-    /// The default configuration was used.
-    case `default`
-    /// The configuration was retrieved from local cache.
-    case cached
-    /// The configuration was retrieved from the remote configuration endpoint.
-    case fetched
+/// Common parent protocol for configuration classes.
+@objc(SPConfigurationProtocol)
+public protocol ConfigurationProtocol {
 }

--- a/Sources/Snowplow/Configurations/EmitterConfiguration.swift
+++ b/Sources/Snowplow/Configurations/EmitterConfiguration.swift
@@ -1,4 +1,5 @@
-//  SPEmitterConfiguration.swift
+//
+//  EmitterConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -54,7 +55,7 @@ public protocol EmitterConfigurationProtocol: AnyObject {
 /// The EmitterConfiguration can be used to setup details about how the tracker should treat the events
 /// to emit to the collector.
 @objc(SPEmitterConfiguration)
-public class EmitterConfiguration: Configuration, EmitterConfigurationProtocol {
+public class EmitterConfiguration: NSObject, EmitterConfigurationProtocol, ConfigurationProtocol {
     /// Sets whether the buffer should send events instantly or after the buffer
     /// has reached it's limit. By default, this is set to BufferOption Default.
     @objc
@@ -105,51 +106,5 @@ public class EmitterConfiguration: Configuration, EmitterConfigurationProtocol {
     @objc
     public override init() {
         super.init()
-    }
-
-    // MARK: - NSCopying
-
-    @objc
-    public override func copy(with zone: NSZone? = nil) -> Any {
-        let copy = EmitterConfiguration()
-        copy.bufferOption = bufferOption
-        copy.emitRange = emitRange
-        copy.threadPoolSize = threadPoolSize
-        copy.byteLimitGet = byteLimitGet
-        copy.byteLimitPost = byteLimitPost
-        copy.requestCallback = requestCallback
-        copy.eventStore = eventStore
-        copy.customRetryForStatusCodes = customRetryForStatusCodes
-        copy.serverAnonymisation = serverAnonymisation
-        return copy
-    }
-
-    // MARK: - NSSecureCoding
-    
-    @objc
-    public override class var supportsSecureCoding: Bool { return true }
-
-    @objc
-    public override func encode(with coder: NSCoder) {
-        coder.encode(bufferOption, forKey: "bufferOption")
-        coder.encode(emitRange, forKey: "emitRange")
-        coder.encode(threadPoolSize, forKey: "threadPoolSize")
-        coder.encode(byteLimitGet, forKey: "byteLimitGet")
-        coder.encode(byteLimitPost, forKey: "byteLimitPost")
-        coder.encode(customRetryForStatusCodes, forKey: "customRetryForStatusCodes")
-        coder.encode(serverAnonymisation, forKey: "serverAnonymisation")
-    }
-
-    required init?(coder: NSCoder) {
-        super.init()
-        if let bufferOption = BufferOption(rawValue: coder.decodeInteger(forKey: "bufferOption")) {
-            self.bufferOption = bufferOption
-        }
-        emitRange = coder.decodeInteger(forKey: "emitRange")
-        threadPoolSize = coder.decodeInteger(forKey: "threadPoolSize")
-        byteLimitGet = coder.decodeInteger(forKey: "byteLimitGet")
-        byteLimitPost = coder.decodeInteger(forKey: "byteLimitPost")
-        customRetryForStatusCodes = coder.decodeObject(forKey: "customRetryForStatusCodes") as? [Int : Bool]
-        serverAnonymisation = coder.decodeBool(forKey: "serverAnonymisation")
     }
 }

--- a/Sources/Snowplow/Configurations/FocalMeterConfiguration.swift
+++ b/Sources/Snowplow/Configurations/FocalMeterConfiguration.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Matus Tomlein on 30/12/2022.
+//
+
+import Foundation

--- a/Sources/Snowplow/Configurations/GDPRConfiguration.swift
+++ b/Sources/Snowplow/Configurations/GDPRConfiguration.swift
@@ -1,4 +1,5 @@
-//  SPGDPRConfiguration.swift
+//
+//  GDPRConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -38,7 +39,7 @@ public protocol GDPRConfigurationProtocol: AnyObject {
 
 /// This class allows the GDPR configuration of the tracker.
 @objc(SPGDPRConfiguration)
-public class GDPRConfiguration: Configuration, GDPRConfigurationProtocol {
+public class GDPRConfiguration: NSObject, GDPRConfigurationProtocol, ConfigurationProtocol {
     /// Basis for processing.
     @objc
     public var basisForProcessing: GDPRProcessingBasis
@@ -70,41 +71,5 @@ public class GDPRConfiguration: Configuration, GDPRConfigurationProtocol {
         self.documentVersion = documentVersion ?? ""
         self.documentDescription = documentDescription ?? ""
         super.init()
-    }
-
-    // MARK: - NSCopying
-
-    @objc
-    public override func copy(with zone: NSZone? = nil) -> Any {
-        let copy = GDPRConfiguration(basis: basisForProcessing,
-                                     documentId: documentId,
-                                     documentVersion: documentVersion,
-                                     documentDescription: documentDescription)
-        return copy
-    }
-
-    // MARK: - NSSecureCodin
-    
-    @objc
-    public override class var supportsSecureCoding: Bool { return true }
-
-    @objc
-    public override func encode(with coder: NSCoder) {
-        coder.encode(basisForProcessing.rawValue, forKey: "basisForProcessing")
-        coder.encode(documentId, forKey: "documentId")
-        coder.encode(documentVersion, forKey: "documentVersion")
-        coder.encode(documentDescription, forKey: "documentDescription")
-    }
-
-    required init?(coder: NSCoder) {
-        if let basisForProcessing = GDPRProcessingBasis(rawValue: coder.decodeInteger(forKey: "basisForProcessing")) {
-            self.basisForProcessing = basisForProcessing
-            self.documentId = coder.decodeObject(forKey: "documentId") as? String ?? ""
-            self.documentVersion = coder.decodeObject(forKey: "documentVersion") as? String ?? ""
-            self.documentDescription = coder.decodeObject(forKey: "documentDescription") as? String ?? ""
-            super.init()
-        } else {
-            return nil
-        }
     }
 }

--- a/Sources/Snowplow/Configurations/GlobalContextsConfiguration.swift
+++ b/Sources/Snowplow/Configurations/GlobalContextsConfiguration.swift
@@ -1,4 +1,5 @@
-//  SPGlobalContextsConfiguration.swift
+//
+//  GlobalContextsConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -40,7 +41,7 @@ public protocol GlobalContextsConfigurationProtocol: AnyObject {
 
 /// This class allows the setup of Global Contexts which are attached to selected events.
 @objc(SPGlobalContextsConfiguration)
-public class GlobalContextsConfiguration: Configuration, GlobalContextsConfigurationProtocol {
+public class GlobalContextsConfiguration: NSObject, GlobalContextsConfigurationProtocol, ConfigurationProtocol {
     @objc
     public var contextGenerators: [String : GlobalContext] = [:]
 
@@ -61,17 +62,6 @@ public class GlobalContextsConfiguration: Configuration, GlobalContextsConfigura
         }
         return toDelete
     }
-
-    // MARK: - NSCopying
-
-    @objc
-    public override func copy(with zone: NSZone? = nil) -> Any {
-        let copy = GlobalContextsConfiguration()
-        copy.contextGenerators = contextGenerators
-        return copy
-    }
-
-    // MARK: - NSCoding (No coding possible as we can't encode and decode the contextGenerators)
     
     // MARK: - Internal functions
     

--- a/Sources/Snowplow/Configurations/NetworkConfiguration.swift
+++ b/Sources/Snowplow/Configurations/NetworkConfiguration.swift
@@ -1,4 +1,5 @@
-//  SPNetworkConfiguration.swift
+//
+//  NetworkConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -22,7 +23,7 @@ import Foundation
 
 /// Represents the network communication configuration allowing the tracker to be able to send events to the Snowplow collector.
 @objc(SPNetworkConfiguration)
-public class NetworkConfiguration: Configuration {
+public class NetworkConfiguration: SerializableConfiguration, ConfigurationProtocol {
     /// URL (without schema/protocol) used to send events to the collector.
     @objc
     private(set) public var endpoint: String?

--- a/Sources/Snowplow/Configurations/PluginConfiguration.swift
+++ b/Sources/Snowplow/Configurations/PluginConfiguration.swift
@@ -91,7 +91,7 @@ extension PluginConfigurationProtocol {
 /// Configuration for a custom tracker plugin.
 /// Enables you to add closures to be called when and after events are tracked in the tracker.
 @objc(SPPluginConfiguration)
-public class PluginConfiguration: Configuration, PluginConfigurationProtocol {
+public class PluginConfiguration: NSObject, PluginConfigurationProtocol, ConfigurationProtocol {
     /// Unique identifier of the plugin within the tracker.
     public private(set) var identifier: String
     /// Closure configuration that is called after events are tracked.
@@ -130,34 +130,4 @@ public class PluginConfiguration: Configuration, PluginConfigurationProtocol {
             closure: closure
         )
     }
-
-    // MARK: - NSCopying
-
-    @objc
-    public override func copy(with zone: NSZone? = nil) -> Any {
-        let copy = PluginConfiguration(identifier: identifier)
-        if let afterTrack = afterTrackConfiguration {
-            copy.afterTrack(schemas: afterTrack.schemas, closure: afterTrack.closure)
-        }
-        if let entities = entitiesConfiguration {
-            copy.entities(schemas: entities.schemas, closure: entities.closure)
-        }
-        return copy
-    }
-
-    // MARK: - NSSecureCoding
-    
-    @objc
-    public override class var supportsSecureCoding: Bool { return true }
-    
-    @objc
-    public override func encode(with coder: NSCoder) {
-        coder.encode(identifier, forKey: "identifier")
-    }
-
-    required init?(coder: NSCoder) {
-        identifier = coder.decodeObject(forKey: "identifier") as? String ?? ""
-        super.init()
-    }
-
 }

--- a/Sources/Snowplow/Configurations/RemoteConfiguration.swift
+++ b/Sources/Snowplow/Configurations/RemoteConfiguration.swift
@@ -1,4 +1,5 @@
-//  SPRemoteConfiguration.swift
+//
+//  RemoteConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -23,7 +24,7 @@ import Foundation
 /// Represents the configuration for fetching configurations from a remote source.
 /// For details on the correct format of a remote configuration see the official documentation.
 @objc(SPRemoteConfiguration)
-public class RemoteConfiguration: Configuration {
+public class RemoteConfiguration: NSObject {
     /// URL of the remote configuration.
     @objc
     private(set) public var endpoint: String
@@ -55,34 +56,5 @@ public class RemoteConfiguration: Configuration {
     public convenience init(endpoint: String, method: HttpMethodOptions) {
         self.init(endpoint: endpoint)
         self.method = method
-    }
-
-    // MARK: - NSCopying
-
-    @objc
-    override public func copy(with zone: NSZone? = nil) -> Any {
-        let copy = RemoteConfiguration(endpoint: endpoint)
-        copy.method = method
-        return copy
-    }
-
-    // MARK: - NSSecureCoding
-
-    @objc
-    override public func encode(with coder: NSCoder) {
-        coder.encode(endpoint, forKey: "endpoint")
-        coder.encode(method?.rawValue, forKey: "method")
-    }
-    
-    @objc
-    public override class var supportsSecureCoding: Bool { return true }
-    
-    required init?(coder: NSCoder) {
-        if let endpoint = coder.decodeObject(forKey: "endpoint") as? String {
-            self.endpoint = endpoint
-            method = HttpMethodOptions(rawValue: coder.decodeInteger(forKey: "method"))
-        } else {
-            return nil
-        }
     }
 }

--- a/Sources/Snowplow/Configurations/SerializableConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SerializableConfiguration.swift
@@ -1,4 +1,5 @@
-//  Configuration.swift
+//
+//  SerializableConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -21,8 +22,8 @@
 import Foundation
 
 /// Common parent class for configuration classes.
-@objc(SPConfiguration)
-public class Configuration: NSObject, NSCopying, NSSecureCoding {
+@objc(SPSerializableConfiguration)
+public class SerializableConfiguration: NSObject, NSCopying, NSSecureCoding {
     @objc
     public convenience init?(dictionary: [String : Any]) {
         self.init()
@@ -30,7 +31,7 @@ public class Configuration: NSObject, NSCopying, NSSecureCoding {
 
     @objc
     public func copy(with zone: NSZone? = nil) -> Any {
-        return Configuration()
+        return SerializableConfiguration()
     }
 
     @objc

--- a/Sources/Snowplow/Configurations/SessionConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SessionConfiguration.swift
@@ -1,4 +1,5 @@
-//  SPSessionConfiguration.swift
+//
+//  SessionConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -59,7 +60,7 @@ public protocol SessionConfigurationProtocol: AnyObject {
 /// Session data is maintained for the life of the application being installed on a device.
 /// A new session will be created if the session information is not accessed within a configurable timeout.
 @objc(SPSessionConfiguration)
-public class SessionConfiguration: Configuration, SessionConfigurationProtocol {
+public class SessionConfiguration: SerializableConfiguration, SessionConfigurationProtocol, ConfigurationProtocol {
     @objc
     public var backgroundTimeoutInSeconds: Int
     @objc

--- a/Sources/Snowplow/Configurations/SubjectConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SubjectConfiguration.swift
@@ -1,4 +1,4 @@
-//  SPSubjectConfiguration.swift
+//  SubjectConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -94,7 +94,7 @@ public protocol SubjectConfigurationProtocol: AnyObject {
 /// user and the app which will be attached on all the events as contexts.
 /// The contexts to track can be enabled in the `TrackerConfiguration` class.
 @objc(SPSubjectConfiguration)
-public class SubjectConfiguration: Configuration, SubjectConfigurationProtocol {
+public class SubjectConfiguration: SerializableConfiguration, SubjectConfigurationProtocol, ConfigurationProtocol {
     convenience init(dictionary: [String : Any]) {
         self.init()
         if let userId = dictionary["userId"] as? String { self.userId = userId }

--- a/Sources/Snowplow/Configurations/TrackerConfiguration.swift
+++ b/Sources/Snowplow/Configurations/TrackerConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  SPTrackerConfiguration.swift
+//  TrackerConfiguration.swift
 //  Snowplow
 //
 //  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
@@ -90,7 +90,7 @@ public protocol TrackerConfigurationProtocol: AnyObject {
 /// The TrackerConfiguration can be used to setup the tracker behaviour indicating what should be
 /// tracked in term of automatic tracking and contexts/entities to track with the events.
 @objc(SPTrackerConfiguration)
-public class TrackerConfiguration: Configuration, TrackerConfigurationProtocol {
+public class TrackerConfiguration: SerializableConfiguration, TrackerConfigurationProtocol, ConfigurationProtocol {
     /// Identifer of the app.
     @objc
     public var appId = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? ""
@@ -254,9 +254,9 @@ public class TrackerConfiguration: Configuration, TrackerConfigurationProtocol {
     @objc
     public override func encode(with coder: NSCoder) {
         coder.encode(appId, forKey: "appId")
-        coder.encode(devicePlatform, forKey: "devicePlatform")
+        coder.encode(devicePlatform.rawValue, forKey: "devicePlatform")
         coder.encode(base64Encoding, forKey: "base64Encoding")
-        coder.encode(logLevel, forKey: "logLevel")
+        coder.encode(logLevel.rawValue, forKey: "logLevel")
         coder.encode(loggerDelegate, forKey: "loggerDelegate")
         coder.encode(sessionContext, forKey: "sessionContext")
         coder.encode(applicationContext, forKey: "applicationContext")

--- a/Sources/Snowplow/Snowplow.swift
+++ b/Sources/Snowplow/Snowplow.swift
@@ -194,7 +194,7 @@ public class Snowplow: NSObject {
     ///                       the tracker.
     /// - Returns: The tracker instance created.
     @objc
-    public class func createTracker(namespace: String, network networkConfiguration: NetworkConfiguration, configurations: [Configuration]) -> TrackerController? {
+    public class func createTracker(namespace: String, network networkConfiguration: NetworkConfiguration, configurations: [ConfigurationProtocol]) -> TrackerController? {
         if let serviceProvider = serviceProviderInstances[namespace] {
             serviceProvider.reset(configurations: configurations + [networkConfiguration])
             return serviceProvider.trackerController

--- a/Tests/TestPlugins.swift
+++ b/Tests/TestPlugins.swift
@@ -176,7 +176,7 @@ class TestPlugins: XCTestCase {
         XCTAssertFalse(pluginCalled)
     }
 
-    private func createTracker(_ configurations: [Configuration]) -> TrackerController {
+    private func createTracker(_ configurations: [ConfigurationProtocol]) -> TrackerController {
         let networkConfig = NetworkConfiguration(networkConnection: MockNetworkConnection(requestOption: .post, statusCode: 200))
         let trackerConfig = TrackerConfiguration()
         trackerConfig.installAutotracking = false


### PR DESCRIPTION
Issue #752 

Currently the `Configuration` class implements `NSCopying` and `NSSecureCoding` which makes it possible to serialize configuration objects which is useful for remote configuration.

However, not all configurations are used in remote configuration and some are not event possible to implement that way (e.g., global contexts, plugins). It is unnecessary to require all configurations to implement the serialization and makes it more difficult to create new plugins.

This PR removes the `NSCopying` and `NSSecureCoding` implementation from `Configuration` and moves it to `SerializableConfiguration` which is implemented only where relevant. Also the `Configuration` class can now be a protocol, so I renamed it to `ConfigurationProtocol`.