### PR TITLE
Update year in copyright headers and remove authors from headers in source files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Snowplow Analytics Ltd.
+   Copyright 2023 Snowplow Analytics Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Some examples of demo apps instrumented with our iOS Tracker can be found in the
 
 ## Copyright and license
 
-The Snowplow iOS/macOS/tvOS/watchOS Tracker is copyright 2013-2022 Snowplow Analytics Ltd.
+The Snowplow iOS/macOS/tvOS/watchOS Tracker is copyright 2013-2023 Snowplow Analytics Ltd.
 
 Licensed under the **[Apache License, Version 2.0][license]** (the "License");
 you may not use this software except in compliance with the License.

--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -1,8 +1,4 @@
-//
-//  Emitter.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Emitter/EmitterConfigurationUpdate.swift
+++ b/Sources/Core/Emitter/EmitterConfigurationUpdate.swift
@@ -1,8 +1,4 @@
-//
-//  SPEmitterConfigurationUpdate.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Emitter/EmitterControllerImpl.swift
+++ b/Sources/Core/Emitter/EmitterControllerImpl.swift
@@ -1,8 +1,4 @@
-//
-//  SPEmitterControllerImpl.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Emitter/EmitterEventProcessing.swift
+++ b/Sources/Core/Emitter/EmitterEventProcessing.swift
@@ -1,8 +1,4 @@
-//
-//  SPEmitterEventProcessing.h
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/GDPR/GDPRConfigurationUpdate.swift
+++ b/Sources/Core/GDPR/GDPRConfigurationUpdate.swift
@@ -1,8 +1,4 @@
-//
-//  SPGDPRConfigurationUpdate.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/GDPR/GDPRContext.swift
+++ b/Sources/Core/GDPR/GDPRContext.swift
@@ -1,8 +1,4 @@
-//
-//  SPGdprContext.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/GDPR/GDPRControllerImpl.swift
+++ b/Sources/Core/GDPR/GDPRControllerImpl.swift
@@ -1,7 +1,4 @@
-//  SPGDPRControllerImpl.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -13,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
+++ b/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  GlobalContextPluginConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/GlobalContexts/GlobalContextsControllerImpl.swift
+++ b/Sources/Core/GlobalContexts/GlobalContextsControllerImpl.swift
@@ -1,8 +1,4 @@
-//
-//  SPGlobalContextsControllerImpl.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/GlobalContexts/SchemaRule.swift
+++ b/Sources/Core/GlobalContexts/SchemaRule.swift
@@ -1,8 +1,4 @@
-//
-//  SchemaRule.swift
-//  Snowplow-iOS
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Logger/Logger.swift
+++ b/Sources/Core/Logger/Logger.swift
@@ -1,8 +1,4 @@
-//
-//  Logger.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/NetworkConnection/NetworkConfigurationUpdate.swift
+++ b/Sources/Core/NetworkConnection/NetworkConfigurationUpdate.swift
@@ -1,8 +1,4 @@
-//
-//  SPNetworkConfigurationUpdate.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/NetworkConnection/NetworkControllerImpl.swift
+++ b/Sources/Core/NetworkConnection/NetworkControllerImpl.swift
@@ -1,8 +1,4 @@
-//
-//  SPNetworkControllerImpl.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/RemoteConfiguration/ConfigurationCache.swift
+++ b/Sources/Core/RemoteConfiguration/ConfigurationCache.swift
@@ -1,8 +1,4 @@
-//
-//  SPConfigurationCache.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/RemoteConfiguration/ConfigurationFetcher.swift
+++ b/Sources/Core/RemoteConfiguration/ConfigurationFetcher.swift
@@ -1,8 +1,4 @@
-//
-//  SPConfigurationFetcher.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/RemoteConfiguration/ConfigurationProvider.swift
+++ b/Sources/Core/RemoteConfiguration/ConfigurationProvider.swift
@@ -1,8 +1,4 @@
-//
-//  ConfigurationProvider.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/RemoteConfiguration/FetchedConfigurationBundle.swift
+++ b/Sources/Core/RemoteConfiguration/FetchedConfigurationBundle.swift
@@ -1,8 +1,4 @@
-//
-//  SPFetchedConfigurationBundle.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/ScreenViewTracking/ScreenState.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenState.swift
@@ -1,8 +1,4 @@
-//
-//  ScreenState.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
@@ -1,8 +1,4 @@
-//
-//  SPScreenStateMachine.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/ScreenViewTracking/ScreenViewModifier.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenViewModifier.swift
@@ -1,8 +1,4 @@
-//
-// ScreenViewModifier.swift
-// Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 #if canImport(SwiftUI)
 

--- a/Sources/Core/ScreenViewTracking/UIKitScreenViewTracking.swift
+++ b/Sources/Core/ScreenViewTracking/UIKitScreenViewTracking.swift
@@ -1,8 +1,4 @@
-//
-//  UIKitScreenViewTracking.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 class UIKitScreenViewTracking {
     private static var initialized = false

--- a/Sources/Core/Session/Session.swift
+++ b/Sources/Core/Session/Session.swift
@@ -1,8 +1,4 @@
-//
-//  Session.swift
-//  Snowplow
-//
-//  Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 #if os(iOS) || os(tvOS)

--- a/Sources/Core/Session/SessionConfigurationUpdate.swift
+++ b/Sources/Core/Session/SessionConfigurationUpdate.swift
@@ -1,8 +1,4 @@
-//
-//  SPSessionConfigurationUpdate.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Session/SessionControllerImpl.swift
+++ b/Sources/Core/Session/SessionControllerImpl.swift
@@ -1,8 +1,4 @@
-//
-//  SPSessionControllerImpl.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/DeepLinkState.swift
+++ b/Sources/Core/StateMachine/DeepLinkState.swift
@@ -1,8 +1,4 @@
-//
-//  SPDeepLinkState.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/DeepLinkStateMachine.swift
+++ b/Sources/Core/StateMachine/DeepLinkStateMachine.swift
@@ -1,8 +1,4 @@
-//
-//  DeepLinkStateMachine.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/LifecycleState.swift
+++ b/Sources/Core/StateMachine/LifecycleState.swift
@@ -1,8 +1,4 @@
-//
-//  SPLifecycleState.swift
-//  Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/LifecycleStateMachine.swift
+++ b/Sources/Core/StateMachine/LifecycleStateMachine.swift
@@ -1,8 +1,4 @@
-//
-//  SPLifecycleStateMachine.swift
-//  Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/PluginStateMachine.swift
+++ b/Sources/Core/StateMachine/PluginStateMachine.swift
@@ -1,8 +1,4 @@
-//
-//  PluginStateMachine.swift
-//  Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/State.swift
+++ b/Sources/Core/StateMachine/State.swift
@@ -1,8 +1,4 @@
-//
-//  State.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/StateFuture.swift
+++ b/Sources/Core/StateMachine/StateFuture.swift
@@ -1,8 +1,4 @@
-//
-//  StateFuture.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/StateMachineEvent.swift
+++ b/Sources/Core/StateMachine/StateMachineEvent.swift
@@ -1,8 +1,4 @@
-//
-//  StateMachineEvent.swift
-//  Snowplow
-//
-//  Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/StateMachineProtocol.swift
+++ b/Sources/Core/StateMachine/StateMachineProtocol.swift
@@ -1,8 +1,4 @@
-//
-//  SPStateMachineProtocol.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/StateManager.swift
+++ b/Sources/Core/StateMachine/StateManager.swift
@@ -1,8 +1,4 @@
-//
-//  StateManager.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/TrackerState.swift
+++ b/Sources/Core/StateMachine/TrackerState.swift
@@ -1,8 +1,4 @@
-//
-//  TrackerState.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/StateMachine/TrackerStateSnapshot.swift
+++ b/Sources/Core/StateMachine/TrackerStateSnapshot.swift
@@ -1,8 +1,4 @@
-//
-//  TrackerStateSnapshot.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Storage/MemoryEventStore.swift
+++ b/Sources/Core/Storage/MemoryEventStore.swift
@@ -1,8 +1,4 @@
-//
-//  SPMemoryEventStore.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Storage/SQLiteEventStore.swift
+++ b/Sources/Core/Storage/SQLiteEventStore.swift
@@ -1,8 +1,4 @@
-//
-//  SQLiteEventStore.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 #if os(iOS) || os(macOS)
 

--- a/Sources/Core/Subject/PlatformContext.swift
+++ b/Sources/Core/Subject/PlatformContext.swift
@@ -1,8 +1,4 @@
-//
-//  PlatformContext.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 #if os(iOS)

--- a/Sources/Core/Subject/Subject.swift
+++ b/Sources/Core/Subject/Subject.swift
@@ -1,8 +1,4 @@
-//
-//  Subject.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Subject/SubjectConfigurationUpdate.swift
+++ b/Sources/Core/Subject/SubjectConfigurationUpdate.swift
@@ -1,7 +1,4 @@
-//  SPSubjectConfigurationUpdate.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -13,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Subject/SubjectControllerImpl.swift
+++ b/Sources/Core/Subject/SubjectControllerImpl.swift
@@ -1,8 +1,4 @@
-//
-//  SubjectControllerImpl.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/InstallTracker.swift
+++ b/Sources/Core/Tracker/InstallTracker.swift
@@ -1,8 +1,4 @@
-//
-//  InstallTracker.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/PluginsControllerImpl.swift
+++ b/Sources/Core/Tracker/PluginsControllerImpl.swift
@@ -1,8 +1,4 @@
-//
-//  PluginsControllerImpl.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -1,8 +1,4 @@
-//
-//  SPServiceProvider.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/ServiceProviderProtocol.swift
+++ b/Sources/Core/Tracker/ServiceProviderProtocol.swift
@@ -1,8 +1,4 @@
-//
-//  SPServiceProviderProtocol.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -1,8 +1,4 @@
-//
-//  Tracker.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/TrackerConfigurationUpdate.swift
+++ b/Sources/Core/Tracker/TrackerConfigurationUpdate.swift
@@ -1,8 +1,4 @@
-//
-//  SPTrackerConfigurationUpdate.h
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/TrackerControllerImpl.swift
+++ b/Sources/Core/Tracker/TrackerControllerImpl.swift
@@ -1,8 +1,4 @@
-//
-//  TrackerController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/TrackerDefaults.swift
+++ b/Sources/Core/Tracker/TrackerDefaults.swift
@@ -1,8 +1,4 @@
-//
-//  TrackerDefaults.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/TrackerEvent.swift
+++ b/Sources/Core/Tracker/TrackerEvent.swift
@@ -1,8 +1,4 @@
-//
-//  SPTrackerEvent.h
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Tracker/WebViewMessageHandler.swift
+++ b/Sources/Core/Tracker/WebViewMessageHandler.swift
@@ -1,8 +1,4 @@
-//
-//  WebViewMessageHandler.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -1,8 +1,4 @@
-//
-//  TrackerConstants.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Utils/DataPersistence.swift
+++ b/Sources/Core/Utils/DataPersistence.swift
@@ -1,8 +1,4 @@
-//
-//  SPDataPersistence.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Core/Utils/DeviceInfoMonitor.swift
+++ b/Sources/Core/Utils/DeviceInfoMonitor.swift
@@ -1,8 +1,4 @@
-//
-//  SPDeviceInfoMonitor.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 import os

--- a/Sources/Core/Utils/SNOWReachability.swift
+++ b/Sources/Core/Utils/SNOWReachability.swift
@@ -1,8 +1,4 @@
-//
-//  SNOWReachability.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 #if os(iOS)
 import Foundation

--- a/Sources/Core/Utils/Utilities.swift
+++ b/Sources/Core/Utils/Utilities.swift
@@ -1,8 +1,4 @@
-//
-//  Utilities.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 #if os(iOS)
 import UIKit

--- a/Sources/Snowplow/Configurations/ConfigurationBuilder.swift
+++ b/Sources/Snowplow/Configurations/ConfigurationBuilder.swift
@@ -1,8 +1,4 @@
-//
-//  ConfigurationBuilder.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/ConfigurationBundle.swift
+++ b/Sources/Snowplow/Configurations/ConfigurationBundle.swift
@@ -1,8 +1,4 @@
-//
-//  ConfigurationBundle.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/ConfigurationProtocol.swift
+++ b/Sources/Snowplow/Configurations/ConfigurationProtocol.swift
@@ -1,8 +1,4 @@
-//
-//  ConfigurationProtocol.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/ConfigurationState.swift
+++ b/Sources/Snowplow/Configurations/ConfigurationState.swift
@@ -1,8 +1,4 @@
-//
-//  ConfigurationState.h
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/EmitterConfiguration.swift
+++ b/Sources/Snowplow/Configurations/EmitterConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  EmitterConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/FocalMeterConfiguration.swift
+++ b/Sources/Snowplow/Configurations/FocalMeterConfiguration.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by Matus Tomlein on 30/12/2022.
-//
-
-import Foundation

--- a/Sources/Snowplow/Configurations/GDPRConfiguration.swift
+++ b/Sources/Snowplow/Configurations/GDPRConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  GDPRConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/GlobalContextsConfiguration.swift
+++ b/Sources/Snowplow/Configurations/GlobalContextsConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  GlobalContextsConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/NetworkConfiguration.swift
+++ b/Sources/Snowplow/Configurations/NetworkConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  NetworkConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/PluginConfiguration.swift
+++ b/Sources/Snowplow/Configurations/PluginConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  PluginConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/RemoteConfiguration.swift
+++ b/Sources/Snowplow/Configurations/RemoteConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  RemoteConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/SerializableConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SerializableConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  SerializableConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/SessionConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SessionConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  SessionConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Configurations/SubjectConfiguration.swift
+++ b/Sources/Snowplow/Configurations/SubjectConfiguration.swift
@@ -1,7 +1,4 @@
-//  SubjectConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -13,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import CoreGraphics
 import Foundation

--- a/Sources/Snowplow/Configurations/TrackerConfiguration.swift
+++ b/Sources/Snowplow/Configurations/TrackerConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  TrackerConfiguration.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/Controller.swift
+++ b/Sources/Snowplow/Controllers/Controller.swift
@@ -1,7 +1,4 @@
-//  SPController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -13,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/EmitterController.swift
+++ b/Sources/Snowplow/Controllers/EmitterController.swift
@@ -1,8 +1,4 @@
-//
-//  SPEmitterController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/GDPRController.swift
+++ b/Sources/Snowplow/Controllers/GDPRController.swift
@@ -1,8 +1,4 @@
-//
-//  GDPRController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/GlobalContextsController.swift
+++ b/Sources/Snowplow/Controllers/GlobalContextsController.swift
@@ -1,8 +1,4 @@
-//
-//  SPGlobalContextsController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/NetworkController.swift
+++ b/Sources/Snowplow/Controllers/NetworkController.swift
@@ -1,8 +1,4 @@
-//
-//  SPNetworkController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/PluginsController.swift
+++ b/Sources/Snowplow/Controllers/PluginsController.swift
@@ -1,8 +1,4 @@
-//
-//  PluginsController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/SessionController.swift
+++ b/Sources/Snowplow/Controllers/SessionController.swift
@@ -1,8 +1,4 @@
-//
-//  SPSessionController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/SubjectController.swift
+++ b/Sources/Snowplow/Controllers/SubjectController.swift
@@ -1,8 +1,4 @@
-//
-//  SPSubjectController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Controllers/TrackerController.swift
+++ b/Sources/Snowplow/Controllers/TrackerController.swift
@@ -1,8 +1,4 @@
-//
-//  SPTrackerController.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Emitter/BufferOption.swift
+++ b/Sources/Snowplow/Emitter/BufferOption.swift
@@ -1,7 +1,4 @@
-//  BufferOption.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -13,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Emitter/EmitterDefaults.swift
+++ b/Sources/Snowplow/Emitter/EmitterDefaults.swift
@@ -1,8 +1,4 @@
-//
-//  EmitterDefaults.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Emitter/EmitterEvent.swift
+++ b/Sources/Snowplow/Emitter/EmitterEvent.swift
@@ -1,8 +1,4 @@
-//
-//  SPEmitterEvent.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Emitter/EventStore.swift
+++ b/Sources/Snowplow/Emitter/EventStore.swift
@@ -1,8 +1,4 @@
-//
-//  SPEventStore.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Entities/DeepLinkEntity.swift
+++ b/Sources/Snowplow/Entities/DeepLinkEntity.swift
@@ -1,8 +1,4 @@
-//
-// SPDeepLinkEntity.swift
-// Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Entities/LifecycleEntity.swift
+++ b/Sources/Snowplow/Entities/LifecycleEntity.swift
@@ -1,8 +1,4 @@
-//
-// SPLifecycleEntity.swift
-// Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/Background.swift
+++ b/Sources/Snowplow/Events/Background.swift
@@ -1,8 +1,4 @@
-//
-//  Background.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/ConsentDocument.swift
+++ b/Sources/Snowplow/Events/ConsentDocument.swift
@@ -1,8 +1,4 @@
-//
-//  ConsentDocument.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/ConsentGranted.swift
+++ b/Sources/Snowplow/Events/ConsentGranted.swift
@@ -1,8 +1,4 @@
-//
-//  ConsentGranted.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/ConsentWithdrawn.swift
+++ b/Sources/Snowplow/Events/ConsentWithdrawn.swift
@@ -1,8 +1,4 @@
-//
-//  ConsentWithdrawn.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/DeepLinkReceived.swift
+++ b/Sources/Snowplow/Events/DeepLinkReceived.swift
@@ -1,8 +1,4 @@
-//
-// DeepLinkReceived.swift
-// Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/Ecommerce.swift
+++ b/Sources/Snowplow/Events/Ecommerce.swift
@@ -1,8 +1,4 @@
-//
-//  Ecommerce.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/EcommerceItem.swift
+++ b/Sources/Snowplow/Events/EcommerceItem.swift
@@ -1,8 +1,4 @@
-//
-//  EcommerceItem.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/EventBase.swift
+++ b/Sources/Snowplow/Events/EventBase.swift
@@ -1,8 +1,4 @@
-//
-//  EventBase.swift
-//  Snowplow
-//
-//  Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/Foreground.swift
+++ b/Sources/Snowplow/Events/Foreground.swift
@@ -1,8 +1,4 @@
-//
-//  Foreground.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/MessageNotification.swift
+++ b/Sources/Snowplow/Events/MessageNotification.swift
@@ -1,8 +1,4 @@
-//
-// MessageNotification.m
-// Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/MessageNotificationAttachment.swift
+++ b/Sources/Snowplow/Events/MessageNotificationAttachment.swift
@@ -1,8 +1,4 @@
-//
-// MessageNotificationAttachment.swift
-// Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/PageView.swift
+++ b/Sources/Snowplow/Events/PageView.swift
@@ -1,8 +1,4 @@
-//
-//  PageView.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/PushNotification.swift
+++ b/Sources/Snowplow/Events/PushNotification.swift
@@ -1,7 +1,4 @@
-//  PushNotification.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -13,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 #if os(iOS)

--- a/Sources/Snowplow/Events/SNOWError.swift
+++ b/Sources/Snowplow/Events/SNOWError.swift
@@ -1,8 +1,4 @@
-//
-//  SNOWError.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/ScreenView.swift
+++ b/Sources/Snowplow/Events/ScreenView.swift
@@ -1,8 +1,4 @@
-//
-//  ScreenView.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/SelfDescribing.swift
+++ b/Sources/Snowplow/Events/SelfDescribing.swift
@@ -1,8 +1,4 @@
-//
-//  SelfDescribing.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/Structured.swift
+++ b/Sources/Snowplow/Events/Structured.swift
@@ -1,8 +1,4 @@
-//
-//  Structured.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/Timing.swift
+++ b/Sources/Snowplow/Events/Timing.swift
@@ -1,8 +1,4 @@
-//
-//  Timing.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Events/TrackerError.swift
+++ b/Sources/Snowplow/Events/TrackerError.swift
@@ -1,8 +1,4 @@
-//
-//  TrackerError.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 let kMaxMessageLength = 2048
 let kMaxStackLength = 8192

--- a/Sources/Snowplow/GlobalContexts/ContextGenerator.swift
+++ b/Sources/Snowplow/GlobalContexts/ContextGenerator.swift
@@ -1,8 +1,4 @@
-//
-//  ContextGenerator.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/GlobalContexts/GlobalContext.swift
+++ b/Sources/Snowplow/GlobalContexts/GlobalContext.swift
@@ -1,8 +1,4 @@
-//
-//  GlobalContext.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/GlobalContexts/SchemaRuleset.swift
+++ b/Sources/Snowplow/GlobalContexts/SchemaRuleset.swift
@@ -1,8 +1,4 @@
-//
-//  SchemaRuleset.swift
-//  Snowplow-iOS
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Network/DefaultNetworkConnection.swift
+++ b/Sources/Snowplow/Network/DefaultNetworkConnection.swift
@@ -1,8 +1,4 @@
-//
-//  SPDefaultNetworkConnection.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Network/HttpMethodOptions.swift
+++ b/Sources/Snowplow/Network/HttpMethodOptions.swift
@@ -1,8 +1,4 @@
-//
-//  HttpMethodOptions.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Network/NetworkConnection.swift
+++ b/Sources/Snowplow/Network/NetworkConnection.swift
@@ -1,8 +1,4 @@
-//
-//  SPNetworkConnection.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Network/ProtocolOptions.swift
+++ b/Sources/Snowplow/Network/ProtocolOptions.swift
@@ -1,8 +1,4 @@
-//
-//  ProtocolOptions.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Network/Request.swift
+++ b/Sources/Snowplow/Network/Request.swift
@@ -1,8 +1,4 @@
-//
-//  SPRequest.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Network/RequestCallback.swift
+++ b/Sources/Snowplow/Network/RequestCallback.swift
@@ -1,8 +1,4 @@
-//
-//  SPRequestCallback.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Network/RequestResult.swift
+++ b/Sources/Snowplow/Network/RequestResult.swift
@@ -1,8 +1,4 @@
-//
-//  SPRequestResult.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Payload/Payload.swift
+++ b/Sources/Snowplow/Payload/Payload.swift
@@ -1,8 +1,4 @@
-//
-//  SPPayload.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Payload/SelfDescribingJson.swift
+++ b/Sources/Snowplow/Payload/SelfDescribingJson.swift
@@ -1,8 +1,4 @@
-//
-//  SPSelfDescribingJson.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Snowplow.swift
+++ b/Sources/Snowplow/Snowplow.swift
@@ -1,8 +1,4 @@
-//
-//  SPSnowplow.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 #if os(iOS) || os(macOS)

--- a/Sources/Snowplow/Tracker/DevicePlatform.swift
+++ b/Sources/Snowplow/Tracker/DevicePlatform.swift
@@ -1,8 +1,4 @@
-//
-//  SPDevicePlatform.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Tracker/InspectableEvent.swift
+++ b/Sources/Snowplow/Tracker/InspectableEvent.swift
@@ -1,8 +1,4 @@
-//
-//  InspectableEvent.swift
-//  Snowplow
-//
-//  Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Tracker/LogLevel.swift
+++ b/Sources/Snowplow/Tracker/LogLevel.swift
@@ -1,8 +1,4 @@
-//
-//  LogLevel.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Tracker/LoggerDelegate.swift
+++ b/Sources/Snowplow/Tracker/LoggerDelegate.swift
@@ -1,8 +1,4 @@
-//
-//  LoggerDelegate.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Tracker/SessionState.swift
+++ b/Sources/Snowplow/Tracker/SessionState.swift
@@ -1,8 +1,4 @@
-//
-//  SPSessionState.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Tracker/View.swift
+++ b/Sources/Snowplow/Tracker/View.swift
@@ -1,8 +1,4 @@
-//
-// View.swift
-// Snowplow
-//
-// Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+// Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 // This program is licensed to you under the Apache License Version 2.0,
 // and you may not use this file except in compliance with the Apache License
@@ -14,9 +10,6 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the Apache License Version 2.0 for the specific
 // language governing permissions and limitations there under.
-//
-// License: Apache License Version 2.0
-//
 
 #if canImport(SwiftUI)
 import SwiftUI

--- a/Sources/Snowplow/Utils/GDPRProcessingBasis.swift
+++ b/Sources/Snowplow/Utils/GDPRProcessingBasis.swift
@@ -1,8 +1,4 @@
-//
-//  GDPRProcessingBasis.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Sources/Snowplow/Utils/SPSize.swift
+++ b/Sources/Snowplow/Utils/SPSize.swift
@@ -1,8 +1,4 @@
-//
-//  SPSubjectConfiguration.h
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 

--- a/Tests/Configurations/TestConfigurationBuilder.swift
+++ b/Tests/Configurations/TestConfigurationBuilder.swift
@@ -1,8 +1,4 @@
-//
-//  TestConfigurationBuilder.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Configurations/TestEmitterConfiguration.swift
+++ b/Tests/Configurations/TestEmitterConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  TestEmitterConfiguration.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini, Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Configurations/TestMultipleInstances.swift
+++ b/Tests/Configurations/TestMultipleInstances.swift
@@ -1,8 +1,4 @@
-//
-//  TestMultipleInstances.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Configurations/TestRemoteConfiguration.swift
+++ b/Tests/Configurations/TestRemoteConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  TestRemoteConfiguration.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 import Mocker

--- a/Tests/Configurations/TestTrackerConfiguration.swift
+++ b/Tests/Configurations/TestTrackerConfiguration.swift
@@ -1,8 +1,4 @@
-//
-//  TestTrackerConfiguration.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Configurations/TestTrackerController.swift
+++ b/Tests/Configurations/TestTrackerController.swift
@@ -1,8 +1,4 @@
-//
-//  TestTrackerController.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Global Contexts/TestGlobalContexts.swift
+++ b/Tests/Global Contexts/TestGlobalContexts.swift
@@ -1,8 +1,4 @@
-//
-//  TestGlobalContexts.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,11 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  Copyright: Copyright © 2020 Snowplow Analytics.
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Global Contexts/TestSchemaRuleset.swift
+++ b/Tests/Global Contexts/TestSchemaRuleset.swift
@@ -1,8 +1,4 @@
-//
-//  TestSchemaRuleset.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,11 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  Copyright: Copyright © 2020 Snowplow Analytics.
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Integration/TestTrackEventsToMicro.swift
+++ b/Tests/Integration/TestTrackEventsToMicro.swift
@@ -1,8 +1,4 @@
-//
-//  TestWithMicro.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 import SnowplowTracker

--- a/Tests/Legacy Tests/LegacyTestEmitter.swift
+++ b/Tests/Legacy Tests/LegacyTestEmitter.swift
@@ -1,8 +1,4 @@
-//
-//  LegacyTestEmitter.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,11 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  Copyright: Copyright (c) 2020 Snowplow Analytics Ltd
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Legacy Tests/LegacyTestSubject.swift
+++ b/Tests/Legacy Tests/LegacyTestSubject.swift
@@ -1,8 +1,4 @@
-//
-//  TestLifecycleState.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/Legacy Tests/LegacyTestTracker.swift
+++ b/Tests/Legacy Tests/LegacyTestTracker.swift
@@ -1,8 +1,4 @@
-//
-//  LegacyTestTracker.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 //#pragma clang diagnostic push
 //#pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/Tests/TestDataPersistence.swift
+++ b/Tests/TestDataPersistence.swift
@@ -1,8 +1,4 @@
-//
-//  TestLifecycleState.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestEvents.swift
+++ b/Tests/TestEvents.swift
@@ -1,9 +1,4 @@
-
-//
-//  TestEvents.swift
-//  SnowplowTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -15,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestLifecycleState.swift
+++ b/Tests/TestLifecycleState.swift
@@ -1,8 +1,4 @@
-//
-//  TestLifecycleState.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestLogger.swift
+++ b/Tests/TestLogger.swift
@@ -1,8 +1,4 @@
-//
-//  TestLogger.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestMemoryEventStore.swift
+++ b/Tests/TestMemoryEventStore.swift
@@ -1,8 +1,4 @@
-//
-//  TestMemoryEventStore.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestNetworkConnection.swift
+++ b/Tests/TestNetworkConnection.swift
@@ -1,8 +1,4 @@
-//
-//  TestNetworkConnection.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Mocker
 import XCTest

--- a/Tests/TestPayload.swift
+++ b/Tests/TestPayload.swift
@@ -1,8 +1,4 @@
-//
-//  TestPayload.swift
-//  SnowplowTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestPlatformContext.swift
+++ b/Tests/TestPlatformContext.swift
@@ -1,8 +1,4 @@
-//
-//  TestPlatformContext.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestPlugins.swift
+++ b/Tests/TestPlugins.swift
@@ -1,8 +1,4 @@
-//
-//  TestPlugins.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestRequest.swift
+++ b/Tests/TestRequest.swift
@@ -1,8 +1,4 @@
-//
-//  TestRequest.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida, Joshua Beemster
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestRequestResult.swift
+++ b/Tests/TestRequestResult.swift
@@ -1,8 +1,4 @@
-//
-//  TestRequestResult.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,11 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  Copyright: Copyright (c) 2020 Snowplow Analytics Ltd
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestSQLiteEventStore.swift
+++ b/Tests/TestSQLiteEventStore.swift
@@ -1,8 +1,4 @@
-//
-//  TestSQLiteEventStore.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida
-//  License: Apache License Version 2.0
-//
 
 #if os(iOS) || os(macOS)
 

--- a/Tests/TestScreenState.swift
+++ b/Tests/TestScreenState.swift
@@ -1,8 +1,4 @@
-//
-//  TestScreenState.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestScreenViewModifier.swift
+++ b/Tests/TestScreenViewModifier.swift
@@ -1,8 +1,4 @@
-//
-//  TestScreenViewModifier.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 import XCTest

--- a/Tests/TestSelfDescribingJson.swift
+++ b/Tests/TestSelfDescribingJson.swift
@@ -1,8 +1,4 @@
-//
-//  TestSelfDescribingJson.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestServiceProvider.swift
+++ b/Tests/TestServiceProvider.swift
@@ -1,8 +1,4 @@
-//
-//  TestServiceProvider.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestSession.swift
+++ b/Tests/TestSession.swift
@@ -1,8 +1,4 @@
-//
-//  TestSession.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,11 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Joshua Beemster
-//  Copyright: Copyright (c) 2020 Snowplow Analytics Ltd
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestStateManager.swift
+++ b/Tests/TestStateManager.swift
@@ -1,8 +1,4 @@
-//
-//  TestStateManager.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 
 import XCTest

--- a/Tests/TestSubject.swift
+++ b/Tests/TestSubject.swift
@@ -1,8 +1,4 @@
-//
-//  TestSubject.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -1,8 +1,4 @@
-//
-//  TestUtils.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Jonathan Almeida
-//  License: Apache License Version 2.0
-//
 
 import XCTest
 @testable import SnowplowTracker

--- a/Tests/TestWebViewMessageHandler.swift
+++ b/Tests/TestWebViewMessageHandler.swift
@@ -1,8 +1,4 @@
-//
-//  TestWebViewMessageHandler.h
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 #if os(iOS) || os(macOS)
 import XCTest

--- a/Tests/Utils/Micro.swift
+++ b/Tests/Utils/Micro.swift
@@ -1,8 +1,4 @@
-//
-//  Micro.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Michael Hadam
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 import XCTest

--- a/Tests/Utils/MockDeviceInfoMonitor.swift
+++ b/Tests/Utils/MockDeviceInfoMonitor.swift
@@ -1,8 +1,4 @@
-//
-//  MockDeviceInfoMonitor.swift
-//  Snowplow-iOSTests
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 @testable import SnowplowTracker

--- a/Tests/Utils/MockEventStore.swift
+++ b/Tests/Utils/MockEventStore.swift
@@ -1,8 +1,4 @@
-//
-//  MockEventStore.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 @testable import SnowplowTracker

--- a/Tests/Utils/MockLoggerDelegate.swift
+++ b/Tests/Utils/MockLoggerDelegate.swift
@@ -1,8 +1,4 @@
-//
-//  SPMockLoggerDelegate.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini, Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 @testable import SnowplowTracker

--- a/Tests/Utils/MockNetworkConnection.swift
+++ b/Tests/Utils/MockNetworkConnection.swift
@@ -1,8 +1,4 @@
-//
-//  SPMockNetworkConnection.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Alex Benini, Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 import Foundation
 @testable import SnowplowTracker

--- a/Tests/Utils/MockWKScriptMessage.swift
+++ b/Tests/Utils/MockWKScriptMessage.swift
@@ -1,8 +1,4 @@
-//
-//  SPMockWKScriptMessage.swift
-//  Snowplow
-//
-//  Copyright (c) 2013-2022 Snowplow Analytics Ltd. All rights reserved.
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 //
 //  This program is licensed to you under the Apache License Version 2.0,
 //  and you may not use this file except in compliance with the Apache License
@@ -14,10 +10,6 @@
 //  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 //  express or implied. See the Apache License Version 2.0 for the specific
 //  language governing permissions and limitations there under.
-//
-//  Authors: Matus Tomlein
-//  License: Apache License Version 2.0
-//
 
 #if os(iOS) || os(macOS)
 import WebKit


### PR DESCRIPTION
Updates the years in copyrights.

Also removes authors (they were not kept up to date and not useful since there is more info in git) and repeated information from copyright headers to match the Android tracker headers.