### PR TITLE
Strip empty strings from optional media player entity fields

### DIFF
--- a/Sources/Snowplow/Media/Entities/MediaPlayerEntity.swift
+++ b/Sources/Snowplow/Media/Entities/MediaPlayerEntity.swift
@@ -98,15 +98,15 @@ public class MediaPlayerEntity: NSObject {
         ]
         if let fullscreen = fullscreen { data["fullscreen"] = fullscreen }
         if let livestream = livestream { data["livestream"] = livestream }
-        if let label = label { data["label"] = label }
+        if let label = label, !label.isEmpty { data["label"] = label }
         if let duration = duration { data["duration"] = duration }
         if let mediaType = mediaType { data["mediaType"] = mediaType.value }
         if let loop = loop { data["loop"] = loop }
         if let muted = muted { data["muted"] = muted }
         if let pictureInPicture = pictureInPicture { data["pictureInPicture"] = pictureInPicture }
-        if let playerType = playerType { data["playerType"] = playerType }
+        if let playerType = playerType, !playerType.isEmpty { data["playerType"] = playerType }
         if let playbackRate = playbackRate { data["playbackRate"] = playbackRate }
-        if let quality = quality { data["quality"] = quality }
+        if let quality = quality, !quality.isEmpty { data["quality"] = quality }
         if let volume = volume { data["volume"] = volume }
         
         return SelfDescribingJson(schema: MediaSchemata.playerSchema, andData: data)

--- a/Tests/Media/TestMediaEventAndEntitySerialization.swift
+++ b/Tests/Media/TestMediaEventAndEntitySerialization.swift
@@ -73,6 +73,19 @@ class TestMediaEventAndEntitySerialization: XCTestCase {
         XCTAssertEqual("1080p", entity.data["quality"] as? String)
     }
     
+    func testStripsEmptyStringValuesFromMediaPlayer() {
+        let entity = MediaPlayerEntity(
+            label: "",
+            playerType: "",
+            quality: ""
+        ).entity
+
+        XCTAssertEqual(mediaPlayerSchema, entity.schema)
+        XCTAssertFalse(entity.data.keys.contains("label"))
+        XCTAssertFalse(entity.data.keys.contains("playerType"))
+        XCTAssertFalse(entity.data.keys.contains("quality"))
+    }
+
     func testBuildsMediaSessionEntity() {
         let date = Date()
         let timeTraveler = TimeTraveler()


### PR DESCRIPTION
The media_player entity (iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0) can produce inconsistent values for optional string fields (label, playerType, quality). The existing if let guards in MediaPlayerEntity.entity handle nil correctly but pass through empty strings. When callers supply "" where nil is intended, the field is present but empty rather than absent, resulting in "" in the warehouse instead of NULL.

The dbt media player package treats "" and NULL as distinct values. When the same media content generates events with both representations, it produces different surrogate keys for media_identifier, causing merge conflicts and duplicate rows in aggregated models.

### Fix
Added !.isEmpty checks to the three optional string field guards in the entity computed property of MediaPlayerEntity:
```
if let label = label → if let label = label, !label.isEmpty
if let playerType = playerType → if let playerType = playerType, !playerType.isEmpty
if let quality = quality → if let quality = quality, !quality.isEmpty
```
Empty strings are now treated as absent, matching the nil behaviour.