### PR TITLE
ci(implement): add label_trigger + allowed_bots so dispatcher-created issues actually run

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The `implement` label on this issue IS the trigger. Without
+          # this the action looks for `@claude` in the body, finds
+          # nothing, and exits silently.
+          label_trigger: implement
+          # The dispatching issue is authored by the snowplow-claude-review
+          # GitHub App. Without this opt-in the action filters bot-authored
+          # events to prevent recursion.
+          allowed_bots: '*'
           additional_permissions: |
             actions: read
           claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(swift:*),Bash(xcodebuild:*),Bash(xcrun:*)"'


### PR DESCRIPTION
Same fix as [snowplow/snowplow-android-tracker#730](https://github.com/snowplow/snowplow-android-tracker/pull/730). The Claude Code action defaults to triggering on `@claude` in the issue body and filtering bot-authored events; both bit our dispatcher-driven flow where the trigger is the `implement` label and the issue author is the `snowplow-claude-review` App. See [run 26395866251 on android-tracker](https://github.com/snowplow/snowplow-android-tracker/actions/runs/26395866251) for the original symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)